### PR TITLE
Make version of CCM / CSI configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .terraform*
 *.tfstate*
 crash.log
+hetzner/ccm/kustomization.yaml
+hetzner/csi/kustomization.yaml
 kubeconfig.yaml
+kubeconfig.yaml-e
 terraform.tfvars
 templates/rendered/traefik_config.yaml

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,15 @@
+data "github_release" "hetzner_ccm" {
+  repository  = "hcloud-cloud-controller-manager"
+  owner       = "hetznercloud"
+  retrieve_by = "latest"
+}
+
+data "github_release" "hetzner_csi" {
+  repository  = "csi-driver"
+  owner       = "hetznercloud"
+  retrieve_by = "latest"
+}
+
+data "hcloud_image" "linux" {
+  name = local.hcloud_image_name
+}

--- a/hetzner/ccm/kustomization.yaml
+++ b/hetzner/ccm/kustomization.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm-networks.yaml
-
-patchesStrategicMerge:
-- patch.yaml

--- a/hetzner/csi/kustomization.yaml
+++ b/hetzner/csi/kustomization.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi.yml
-
-patchesStrategicMerge:
-- patch.yaml

--- a/main.tf
+++ b/main.tf
@@ -144,8 +144,22 @@ resource "hcloud_firewall" "k3s" {
 
 }
 
-data "hcloud_image" "linux" {
-  name = local.hcloud_image_name
+resource "local_file" "hetzner_ccm_config" {
+  content = templatefile("${path.module}/templates/hetzner_ccm.yaml.tpl", {
+    ccm_version = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
+  })
+  filename             = "${path.module}/hetzner/ccm/kustomization.yaml"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}
+
+resource "local_file" "hetzner_csi_config" {
+  content = templatefile("${path.module}/templates/hetzner_csi.yaml.tpl", {
+    csi_version = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag
+  })
+  filename             = "${path.module}/hetzner/csi/kustomization.yaml"
+  file_permission      = "0644"
+  directory_permission = "0755"
 }
 
 resource "local_file" "traefik_config" {
@@ -153,5 +167,7 @@ resource "local_file" "traefik_config" {
     lb_server_type = var.lb_server_type
     location       = var.location
   })
-  filename = "${path.module}/templates/rendered/traefik_config.yaml"
+  filename             = "${path.module}/templates/rendered/traefik_config.yaml"
+  file_permission      = "0644"
+  directory_permission = "0755"
 }

--- a/master.tf
+++ b/master.tf
@@ -52,9 +52,9 @@ resource "hcloud_server" "first_control_plane" {
   provisioner "local-exec" {
     command = <<-EOT
       kubectl -n kube-system create secret generic hcloud --from-literal=token=${var.hcloud_token} --from-literal=network=${hcloud_network.k3s.name} --kubeconfig ${path.module}/kubeconfig.yaml
-      kubectl apply -k ${path.module}/hetzner/ccm --kubeconfig ${path.module}/kubeconfig.yaml
+      kubectl apply -k ${dirname(local_file.hetzner_ccm_config.filename)} --kubeconfig ${path.module}/kubeconfig.yaml
       kubectl -n kube-system create secret generic hcloud-csi --from-literal=token=${var.hcloud_token} --kubeconfig ${path.module}/kubeconfig.yaml
-      kubectl apply -k  ${path.module}/hetzner/csi --kubeconfig ${path.module}/kubeconfig.yaml
+      kubectl apply -k ${dirname(local_file.hetzner_csi_config.filename)} --kubeconfig ${path.module}/kubeconfig.yaml
     EOT
   }
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,5 @@
+provider "github" {}
+
 provider "hcloud" {
   token = var.hcloud_token
 }

--- a/templates/hetzner_ccm.yaml.tpl
+++ b/templates/hetzner_ccm.yaml.tpl
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${ccm_version}/ccm-networks.yaml"
+
+patchesStrategicMerge:
+- patch.yaml

--- a/templates/hetzner_csi.yaml.tpl
+++ b/templates/hetzner_csi.yaml.tpl
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- "https://raw.githubusercontent.com/hetznercloud/csi-driver/${csi_version}/deploy/kubernetes/hcloud-csi.yml"
+
+patchesStrategicMerge:
+- patch.yaml

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,15 @@ variable "agents_num" {
   description = "Number of agent nodes."
   type        = number
 }
+
+variable "hetzner_ccm_version" {
+  type        = string
+  default     = null
+  description = "Version of Kubernetes Cloud Controller Manager for Hetzner Cloud"
+}
+
+variable "hetzner_csi_version" {
+  type        = string
+  default     = null
+  description = "Version of Container Storage Interface driver for Hetzner Cloud"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 4.0.0, < 5.0.0"
+    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = ">= 1.0.0, < 2.0.0"


### PR DESCRIPTION
Users should be able to use a specific version of CCM / CSI. If no value has been provided, the latest available version will be fetched from the GitHub repository.