### PR TITLE
Improve stability of traefik load balancer IP

### DIFF
--- a/templates/traefik_config.yaml.tpl
+++ b/templates/traefik_config.yaml.tpl
@@ -4,7 +4,7 @@ metadata:
   name: traefik
   namespace: kube-system
 spec:
-  failurePolicy: stop
+  failurePolicy: abort
   valuesContent: |-
     service:
       enabled: true

--- a/templates/traefik_config.yaml.tpl
+++ b/templates/traefik_config.yaml.tpl
@@ -4,6 +4,7 @@ metadata:
   name: traefik
   namespace: kube-system
 spec:
+  failurePolicy: stop
   valuesContent: |-
     service:
       enabled: true


### PR DESCRIPTION
By default, if the helm chart installation or upgrade fails for any
reason, the whole helm chart is deleted and recreated from scratch,
with a new load balancer bound to a new IP.

By setting the traefik helm chart failure policy to `stop`, we prevent
the load balancer service from being recreated in case of chart
upgrade failure, at the cost of requiring manual user intervention to
restore automatic upgrades.