### PR TITLE
system-upgrade on the storage node

### DIFF
--- a/templates/plans.yaml.tpl
+++ b/templates/plans.yaml.tpl
@@ -16,6 +16,11 @@ spec:
       - {key: k3s_upgrade, operator: NotIn, values: ["disabled", "false"]}
       - {key: node-role.kubernetes.io/master, operator: NotIn, values: ["true"]}
   serviceAccountName: system-upgrade
+  tolerations:
+  - effect: NoSchedule
+    key: server-usage
+    operator: Equal
+    value: storage
   prepare:
     image: rancher/k3s-upgrade
     args: ["prepare", "k3s-server"]


### PR DESCRIPTION
Adds `tolerations` so that the system-upgrade job can run on the storage node.

fixes #181 