### PR TITLE
fix ssh-rsa not in PubkeyAcceptedAlgorithms error / Terraform IO Timeout

### DIFF
--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -15,6 +15,7 @@ write_files:
     MaxAuthTries 2
     AllowTcpForwarding no
     AllowAgentForwarding no
+    PubkeyAcceptedKeyTypes=+ssh-rsa
     AuthorizedKeysFile .ssh/authorized_keys
   path: /etc/ssh/sshd_config.d/kube-hetzner.conf
 


### PR DESCRIPTION
Hello,

terraform v1.1.9 on Ubuntu 20.04 is using ssh-rsa as key type.
This ends in the following Error:

```
May 16 15:08:38 static sshd[1693]: userauth_pubkey: key type ssh-rsa not in PubkeyAcceptedAlgorithms [preauth]
May 16 15:08:38 static sshd[1693]: Connection closed by authenticating user root <MYIP> port 55484 [preauth]

```
After some loops of the remote-exec provisioner, my IP got blocked:
`
May 16 15:08:39 static tallow[692]: Blocked <MYIP>
`

I seem to run into the following problem: https://github.com/hashicorp/terraform/issues/29082
Adding the keytype ssh-rsa to sshd-config in cloudinit fixed this behaviour.

Regards,
Erik
