### PR TITLE
+ use cluster_name as prefix for local kubeconfig.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .terraform*
 *.tfstate*
 crash.log
-kubeconfig.yaml
-kubeconfig.yaml-e
+*_kubeconfig.yaml
+*_kubeconfig.yaml-e
 terraform.tfvars
 plans-custom.yaml
 traefik-custom.yaml

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ It will take around 5 minutes to complete, and then you should see a green outpu
 
 When your brand new cluster is up and running, the sky is your limit! 🎉
 
-You can immediately kubectl into it (using the `kubeconfig.yaml` saved to the project's directory after the installation). By doing `kubectl --kubeconfig kubeconfig.yaml`, but for more convenience, either create a symlink from `~/.kube/config` to `kubeconfig.yaml` or add an export statement to your `~/.bashrc` or `~/.zshrc` file, as follows (you can get the path of `kubeconfig.yaml` by running `pwd`):
+You can immediately kubectl into it (using the `${cluster_name}_kubeconfig.yaml` saved to the project's directory after the installation). By doing `kubectl --kubeconfig ${cluster_name}_kubeconfig.yaml`, but for more convenience, either create a symlink from `~/.kube/config` to `${cluster_name}_kubeconfig.yaml` or add an export statement to your `~/.bashrc` or `~/.zshrc` file, as follows (you can get the path of `${cluster_name}_kubeconfig.yaml` by running `pwd`):
 
 ```sh
-export KUBECONFIG=/<path-to>/kubeconfig.yaml
+export KUBECONFIG=/<path-to>/${cluster_name}_kubeconfig.yaml
 ```
 
 _Once you start with Terraform, it's best not to change the state manually in Hetzner; otherwise, you'll get an error when you try to scale up or down or even destroy the cluster._
@@ -146,7 +146,7 @@ kubectl delete plan k3s-server -n system-upgrade
 
 ### Individual Components Upgrade
 
-Rarely needed, but can be handy in the long run. During the installation, we automatically download a backup of the kustomization to a `kustomization_backup.yaml` file. You will find it next to your `kubeconfig.yaml` at the root of your project.
+Rarely needed, but can be handy in the long run. During the installation, we automatically download a backup of the kustomization to a `kustomization_backup.yaml` file. You will find it next to your `${cluster_name}_kubeconfig.yaml` at the root of your project.
 
 1. First create a duplicate of that file and name it `kustomization.yaml`, keeping the original file intact, in case you need to restore the old config.
 2. Edit the `kustomization.yaml` file; you want to go to the very bottom where you have the links to the different source files; grab the latest versions for each on Github, and replace. If present, remove any local reference to traefik_config.yaml, as Traefik is updated automatically by the system upgrade controller.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ In this case, we don't deploy an external load-balancer but use the default [k3s
 
 <details>
 
+<summary>Use in Terraform cloud</summary>
+
+To use Kube-Hetzner on Terraform cloud, use as a Terraform module as mentioned above, but also change the execution mode from `remote` to `local`.
+
+</details>
+
+<details>
+
 <summary>Configure add-ons with HelmChartConfig</summary>
 
 For instance, to customize the Rancher install, if you choose to enable it, you can create and apply the following `HelmChartConfig`:

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ In this case, we don't deploy an external load-balancer but use the default [k3s
 
 </details>
 
+<details>
+
 <summary>Configure add-ons with HelmChartConfig</summary>
 
 For instance, to customize the Rancher install, if you choose to enable it, you can create and apply the following `HelmChartConfig`:

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -25,6 +25,6 @@ locals {
 
 resource "local_sensitive_file" "kubeconfig" {
   content         = local.kubeconfig_external
-  filename        = "kubeconfig.yaml"
+  filename        = "${var.cluster_name}_kubeconfig.yaml"
   file_permission = "600"
 }

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "null_resource" "destroy_traefik_loadbalancer" {
 
     environment = {
       kubeconfig_prefix = self.triggers.kubeconfig_prefix
-     }
+    }
   }
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,8 @@ resource "null_resource" "destroy_traefik_loadbalancer" {
 
   # this only gets triggered before total destruction of the cluster, but when the necessary elements to run the commands are still available
   triggers = {
-    kustomization_id = null_resource.kustomization.id
+    kustomization_id  = null_resource.kustomization.id
+    kubeconfig_prefix = var.cluster_name
   }
 
   # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted

--- a/main.tf
+++ b/main.tf
@@ -70,14 +70,14 @@ resource "null_resource" "destroy_traefik_loadbalancer" {
 
   # this only gets triggered before total destruction of the cluster, but when the necessary elements to run the commands are still available
   triggers = {
-    kustomization_id  = null_resource.kustomization.id
-    kubeconfig_prefix = var.cluster_name
+    kustomization_id = null_resource.kustomization.id
+    cluster_name     = var.cluster_name
   }
 
   # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted
   provisioner "local-exec" {
     when       = destroy
-    command    = "kubectl -n kube-system delete service traefik --kubeconfig ${self.triggers.kubeconfig_prefix}_kubeconfig.yaml"
+    command    = "kubectl -n kube-system delete service traefik --kubeconfig ${self.triggers.cluster_name}_kubeconfig.yaml"
     on_failure = continue
   }
 

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ data "hcloud_load_balancer" "traefik" {
 }
 
 resource "null_resource" "destroy_traefik_loadbalancer" {
+
   # this only gets triggered before total destruction of the cluster, but when the necessary elements to run the commands are still available
   triggers = {
     kustomization_id = null_resource.kustomization.id
@@ -75,10 +76,12 @@ resource "null_resource" "destroy_traefik_loadbalancer" {
   # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted
   provisioner "local-exec" {
     when       = destroy
-    command    = <<-EOT
-      kubectl -n kube-system delete service traefik --kubeconfig kubeconfig.yaml
-    EOT
+    command    = "kubectl -n kube-system delete service traefik --kubeconfig ${self.triggers.cluster_name}_kubeconfig.yaml"
     on_failure = continue
+
+    environment = {
+      kubeconfig_prefix = self.triggers.kubeconfig_prefix
+     }
   }
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -77,12 +77,8 @@ resource "null_resource" "destroy_traefik_loadbalancer" {
   # Important when issuing terraform destroy, otherwise the LB will not let the network get deleted
   provisioner "local-exec" {
     when       = destroy
-    command    = "kubectl -n kube-system delete service traefik --kubeconfig ${self.triggers.cluster_name}_kubeconfig.yaml"
+    command    = "kubectl -n kube-system delete service traefik --kubeconfig ${self.triggers.kubeconfig_prefix}_kubeconfig.yaml"
     on_failure = continue
-
-    environment = {
-      kubeconfig_prefix = self.triggers.kubeconfig_prefix
-    }
   }
 
   depends_on = [


### PR DESCRIPTION
Oh man, this took wayy too long to figure out - can only use `self` an `each.key` on destroy AND you need to specify those als triggers AND environment.
But it seems to be working now. Ofc if there is a better solution... ;)

relates to #190 