### PR TITLE
import downstream cluster via access + secret token

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -5,7 +5,8 @@ locals {
 
 module "kube-hetzner" {
   providers = {
-    hcloud = hcloud
+    hcloud   = hcloud
+    rancher2 = rancher2
   }
   hcloud_token = local.hcloud_token
 
@@ -228,16 +229,24 @@ module "kube-hetzner" {
   # rancher_hostname = "rancher.xyz.dev"
 
   # Separate from the above Rancher config (only use one or the other). You can import this cluster directly on an
-  # an already active Rancher install. By clicking "import cluster" choosing "generic", giving it a name and pasting
-  # the cluster registration url below. However, you can also ignore that and apply the url via kubectl as instructed
-  # by Rancher in the wizard, and that would register your cluster too.
+  # an already active Rancher install. Setting `rancher_hostname`, `enable_rancher_import` and enabling the rancher2-provider
+  # with your credentials will automatically import the cluster.
+  # However, you can also ignore that and apply the url via kubectl as instructed by Rancher in the wizard, and that would register your cluster too.
   # More information about the registration can be found here https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/
-  # rancher_registration_manifest_url = "https://rancher.xyz.dev/v3/import/xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz.yaml"
+  enable_rancher_import = true
 }
 
 provider "hcloud" {
   token = local.hcloud_token
 }
+
+#provider "rancher2" {
+#  api_url    = "https://${local.rancher_hostname}"
+#  access_key = ""xxxxxxxxxxxxxxxxYYYYYYYYYYzzzzzzzzzzzzzzzzz"
+#  secret_key = ""xxxxxxxxxxxxxxxxYYYYYYYYYYzzzzzzzzzzzzzzzzz"
+#  insecure   = false
+#}
+
 
 terraform {
   required_providers {
@@ -245,5 +254,10 @@ terraform {
       source  = "hetznercloud/hcloud"
       version = ">= 1.0.0"
     }
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = ">= 1.23.0"
+    }
+
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -203,8 +203,8 @@ variable "rancher_install_channel" {
 }
 
 variable "enable_rancher_import" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable import of cluster into rancher"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -202,16 +202,16 @@ variable "rancher_install_channel" {
   }
 }
 
+variable "enable_rancher_import" {
+  type = bool
+  default = false
+  description = "Enable import of cluster into rancher"
+}
+
 variable "rancher_hostname" {
   type        = string
   default     = "rancher.example.com"
   description = "Enable rancher"
-}
-
-variable "rancher_registration_manifest_url" {
-  type        = string
-  description = "The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)"
-  default     = ""
 }
 
 variable "use_klipper_lb" {

--- a/versions.tf
+++ b/versions.tf
@@ -16,5 +16,9 @@ terraform {
       source  = "tenstad/remote"
       version = ">= 0.0.23"
     }
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = ">= 1.23.0"
+    }
   }
 }


### PR DESCRIPTION
This replaces #176 and allow the programmatical import of clusters by the use of access + secret token.
Furthermore it will allow to use the rancher2-provider to install more rancher-addons from their catalog (e.g. monitoring, logging-charts..).

(By using hdns for the racher dns-records + a local-exec  "while .. nslookup rancher-ui" it would even be possible to do both with 1 terraform-plan).

On destroy this will obviously fail  if the rancher-ui server is non-responsive/has already been deleted. But this usually shouldn't happen. 

@mysticaltech as already mentioned, please check. Especially regarding the provider-setup - i'm not sure i have the new layout already internalized. Hopre this one goes smoother than the previous one.;)
