### PR TITLE
Added nfs-client package if Longhorn is enabled

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -17,7 +17,7 @@ module "agents" {
   location               = each.value.location
   server_type            = each.value.server_type
   ipv4_subnet_id         = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install    = concat(var.enable_longhorn ? ["open-iscsi"] : [], [])
+  packages_to_install    = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], [])
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -17,7 +17,7 @@ module "control_planes" {
   location               = each.value.location
   server_type            = each.value.server_type
   ipv4_subnet_id         = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install    = concat(var.enable_longhorn ? ["open-iscsi"] : [], [])
+  packages_to_install    = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], [])
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.


### PR DESCRIPTION
When I try to deploy a PVC with ReadWriteMany I get an error 

```
rpc error: code = Internal desc = mount failed: exit status 32 .... helper program, or other error
(for several filesystems (e.g. nfs, cifs) you might
need a /sbin/mount. helper program)
```

Therefore, I've added the `nfs-client` to our servers for supporting RWX mounts. This option is only enabled if Longhorn is enabled.

Relates to: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/184