### PR TITLE
changed ssh keys from file to string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ brew install hcloud
 2. Generate a passphrase-less ed25519 SSH key pair for your cluster; take note of the respective paths of your private and public keys. Or, see our detailed [SSH options](https://github.com/kube-hetzner/kube-hetzner/blob/master/docs/ssh.md). ✅
 3. Prepare the module by copying `kube.tf.example` to `kube.tf` **in a new folder** which you cd into, then replace the values from steps 1 and 2. ✅
 4. (Optional) Many variables in `kube.tf` can be customized to suit your needs, you can do so if you want. ✅
-5. Make sure you have the latest Terraform version, ideally at least 1.2.0. You can check with `terraform -v`. ✅
+5. Make sure you have the latest Terraform version, at least 1.2.0. You can check with `terraform -v`. ✅
 6. At this stage you should be in your new folder, with a fresh `kube.tf` file, if it is so, you can proceed forward! ✅
 
 _It's important to realize that you do not even need to clone this git repo, as the module by default will be fetched from the Terraform registry. All you need, is to use the [kube.tf.example](https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example) file to make sure you get the format of your `kube.tf` file right._

--- a/agents.tf
+++ b/agents.tf
@@ -8,7 +8,7 @@ module "agents" {
   for_each = local.agent_nodes
 
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  ssh_keys                   = [hcloud_ssh_key.k3s.id]
+  ssh_keys                   = [local.hcloud_ssh_key_id]
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys

--- a/agents.tf
+++ b/agents.tf
@@ -11,7 +11,7 @@ module "agents" {
   ssh_keys                   = [hcloud_ssh_key.k3s.id]
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
-  additional_ssh_public_keys = var.additional_ssh_public_keys
+  ssh_additional_public_keys = var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
   placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.agent.*.id, ceil(each.value.index / 10))
   location                   = each.value.location

--- a/agents.tf
+++ b/agents.tf
@@ -7,17 +7,17 @@ module "agents" {
 
   for_each = local.agent_nodes
 
-  name                   = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  ssh_keys               = [hcloud_ssh_key.k3s.id]
-  public_key             = var.public_key
-  private_key            = var.private_key
-  additional_public_keys = var.additional_public_keys
-  firewall_ids           = [hcloud_firewall.k3s.id]
-  placement_group_id     = var.placement_group_disable ? 0 : element(hcloud_placement_group.agent.*.id, ceil(each.value.index / 10))
-  location               = each.value.location
-  server_type            = each.value.server_type
-  ipv4_subnet_id         = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install    = local.packages_to_install
+  name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  ssh_keys                   = [hcloud_ssh_key.k3s.id]
+  ssh_public_key             = var.ssh_public_key
+  ssh_private_key            = var.ssh_private_key
+  additional_ssh_public_keys = var.additional_ssh_public_keys
+  firewall_ids               = [hcloud_firewall.k3s.id]
+  placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.agent.*.id, ceil(each.value.index / 10))
+  location                   = each.value.location
+  server_type                = each.value.server_type
+  ipv4_subnet_id             = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  packages_to_install        = local.packages_to_install
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
@@ -40,8 +40,8 @@ resource "null_resource" "agents" {
 
   connection {
     user           = "root"
-    private_key    = local.ssh_private_key
-    agent_identity = local.ssh_identity
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
   }
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -7,17 +7,17 @@ module "control_planes" {
 
   for_each = local.control_plane_nodes
 
-  name                   = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  ssh_keys               = [hcloud_ssh_key.k3s.id]
-  public_key             = var.public_key
-  private_key            = var.private_key
-  additional_public_keys = var.additional_public_keys
-  firewall_ids           = [hcloud_firewall.k3s.id]
-  placement_group_id     = var.placement_group_disable ? 0 : element(hcloud_placement_group.control_plane.*.id, ceil(each.value.index / 10))
-  location               = each.value.location
-  server_type            = each.value.server_type
-  ipv4_subnet_id         = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install    = local.packages_to_install
+  name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  ssh_keys                   = [hcloud_ssh_key.k3s.id]
+  ssh_public_key             = var.ssh_public_key
+  ssh_private_key            = var.ssh_private_key
+  additional_ssh_public_keys = var.additional_ssh_public_keys
+  firewall_ids               = [hcloud_firewall.k3s.id]
+  placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.control_plane.*.id, ceil(each.value.index / 10))
+  location                   = each.value.location
+  server_type                = each.value.server_type
+  ipv4_subnet_id             = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  packages_to_install        = local.packages_to_install
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
@@ -42,8 +42,8 @@ resource "null_resource" "control_planes" {
 
   connection {
     user           = "root"
-    private_key    = local.ssh_private_key
-    agent_identity = local.ssh_identity
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
     host           = module.control_planes[each.key].ipv4_address
   }
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -8,7 +8,7 @@ module "control_planes" {
   for_each = local.control_plane_nodes
 
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  ssh_keys                   = [hcloud_ssh_key.k3s.id]
+  ssh_keys                   = [local.hcloud_ssh_key_id]
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -11,7 +11,7 @@ module "control_planes" {
   ssh_keys                   = [hcloud_ssh_key.k3s.id]
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
-  additional_ssh_public_keys = var.additional_ssh_public_keys
+  ssh_additional_public_keys = var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
   placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.control_plane.*.id, ceil(each.value.index / 10))
   location                   = each.value.location

--- a/init.tf
+++ b/init.tf
@@ -1,8 +1,8 @@
 resource "null_resource" "first_control_plane" {
   connection {
     user           = "root"
-    private_key    = local.ssh_private_key
-    agent_identity = local.ssh_identity
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
   }
 
@@ -70,8 +70,8 @@ resource "null_resource" "first_control_plane" {
 resource "null_resource" "kustomization" {
   connection {
     user           = "root"
-    private_key    = local.ssh_private_key
-    agent_identity = local.ssh_identity
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
   }
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -29,7 +29,7 @@ module "kube-hetzner" {
   # For more details on SSH see https://github.com/kube-hetzner/kube-hetzner/blob/master/docs/ssh.md
   ssh_private_key = file("/home/username/.ssh/id_ed25519")
   # You can add additional SSH public Keys to grant other team members root access to your cluster nodes.
-  # additional_ssh_public_keys = []
+  # ssh_additional_public_keys = []
 
   # These can be customized, or left with the default values
   # * For Hetzner locations see https://docs.hetzner.com/general/others/data-centers-and-connection/

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -23,11 +23,13 @@ module "kube-hetzner" {
   # This is to keep Terraform from re-provisioning all nodes at once, which would lose data. If you want to update
   # those, you should instead change the value here and manually re-provision each node. Grep for "lifecycle".
 
-  # * Your public key
-  public_key = "/home/username/.ssh/id_ed25519.pub"
-  # * Your private key must be "private_key = null" when you want to use ssh-agent for a Yubikey-like device authentification or an SSH key-pair with a passphrase.
+  # * Your ssh public key
+  ssh_public_key = file("/home/username/.ssh/id_ed25519.pub")
+  # * Your private key must be "ssh_private_key = null" when you want to use ssh-agent for a Yubikey-like device authentification or an SSH key-pair with a passphrase.
   # For more details on SSH see https://github.com/kube-hetzner/kube-hetzner/blob/master/docs/ssh.md
-  private_key = "/home/username/.ssh/id_ed25519"
+  ssh_private_key = file("/home/username/.ssh/id_ed25519")
+  # You can add additional SSH public Keys to grant other team members root access to your cluster nodes.
+  # additional_ssh_public_keys = []
 
   # These can be customized, or left with the default values
   # * For Hetzner locations see https://docs.hetzner.com/general/others/data-centers-and-connection/

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -242,6 +242,7 @@ provider "hcloud" {
 }
 
 terraform {
+  required_version = ">= 1.2.0"
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -30,6 +30,11 @@ module "kube-hetzner" {
   ssh_private_key = file("/home/username/.ssh/id_ed25519")
   # You can add additional SSH public Keys to grant other team members root access to your cluster nodes.
   # ssh_additional_public_keys = []
+  
+  # If you want to use an ssh key that is already registered within hetzner cloud, you can pass its id.
+  # If no id is passed, a new ssh key will be registered within hetzner cloud.
+  # It is important that exactly this key is passed via `ssh_public_key` & `ssh_private_key` vars. 
+  # hcloud_ssh_key_id = ""
 
   # These can be customized, or left with the default values
   # * For Hetzner locations see https://docs.hetzner.com/general/others/data-centers-and-connection/

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -4,8 +4,8 @@ data "remote_file" "kubeconfig" {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port        = 22
     user        = "root"
-    private_key = local.ssh_private_key
-    agent       = var.private_key == null
+    private_key = var.ssh_private_key
+    agent       = var.ssh_private_key == null
   }
   path = "/etc/rancher/k3s/k3s.yaml"
 

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -3,8 +3,8 @@ data "remote_file" "kustomization_backup" {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port        = 22
     user        = "root"
-    private_key = local.ssh_private_key
-    agent       = var.private_key == null
+    private_key = var.ssh_private_key
+    agent       = var.ssh_private_key == null
   }
   path = "/var/post_install/kustomization.yaml"
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,15 +1,7 @@
 locals {
-  ssh_public_key = trimspace(file(var.public_key))
-  # ssh_private_key is either the contents of var.private_key or null to use a ssh agent.
-  ssh_private_key = var.private_key == null ? null : trimspace(file(var.private_key))
-  # ssh_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
+  # ssh_agent_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
-  ssh_identity = var.private_key == null ? local.ssh_public_key : null
-  # ssh_identity_file is used for ssh "-i" flag, its the private key if that is set, or a public key file
-  # if an ssh agent is used.
-  ssh_identity_file = var.private_key == null ? var.public_key : var.private_key
-  # shared flags for ssh to ignore host keys, to use root and our ssh identity file for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${local.ssh_identity_file}"
+  ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
 
   ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,10 @@ locals {
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
   ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
 
+  # If passed, a key already registered within hetzner is used. 
+  # Otherwise, a new one will be created by the module.
+  hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
+
   ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag
   kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured.release_tag

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ resource "random_password" "k3s_token" {
 }
 
 resource "hcloud_ssh_key" "k3s" {
+  count      = var.hcloud_ssh_key_id == null ? 1 : 0
   name       = var.cluster_name
   public_key = var.ssh_public_key
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "random_password" "k3s_token" {
 
 resource "hcloud_ssh_key" "k3s" {
   name       = var.cluster_name
-  public_key = local.ssh_public_key
+  public_key = var.ssh_public_key
 }
 
 resource "hcloud_network" "k3s" {

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -8,10 +8,7 @@ locals {
   # ssh_client_identity is used for ssh "-i" flag, its the private key if that is set, or a public key
   # if an ssh agent is used.
   ssh_client_identity = var.ssh_private_key == null ? var.ssh_public_key : var.ssh_private_key
-  # ssh_client_identity_file is used to (temporary) store identity informations (from ssh_client_identity),
-  # used by the ssh client.
-  ssh_client_identity_file = "/tmp/${local.name}-ssh-identity"
-
+ 
   # Final list of packages to install
   needed_packages = join(" ", concat(["k3s-selinux"], var.packages_to_install))
 

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -131,7 +131,7 @@ data "cloudinit_config" "config" {
       "${path.module}/templates/userdata.yaml.tpl",
       {
         hostname          = local.name
-        sshAuthorizedKeys = concat([var.ssh_public_key], var.additional_ssh_public_keys)
+        sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
       }
     )
   }

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -13,7 +13,7 @@ variable "ssh_private_key" {
   type        = string
 }
 
-variable "additional_ssh_public_keys" {
+variable "ssh_additional_public_keys" {
   description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes"
   type        = list(string)
   default     = []

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -3,17 +3,17 @@ variable "name" {
   type        = string
 }
 
-variable "public_key" {
+variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string
 }
 
-variable "private_key" {
+variable "ssh_private_key" {
   description = "SSH private Key."
   type        = string
 }
 
-variable "additional_public_keys" {
+variable "additional_ssh_public_keys" {
   description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes"
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -4,17 +4,18 @@ variable "hcloud_token" {
   sensitive   = true
 }
 
-variable "public_key" {
+variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string
 }
 
-variable "private_key" {
+variable "ssh_private_key" {
   description = "SSH private Key."
   type        = string
+  sensitive   = true
 }
 
-variable "additional_public_keys" {
+variable "additional_ssh_public_keys" {
   description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes"
   type        = list(string)
   default     = []
@@ -212,6 +213,7 @@ variable "rancher_registration_manifest_url" {
   type        = string
   description = "The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)"
   default     = ""
+  sensitive   = true
 }
 
 variable "use_klipper_lb" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "ssh_private_key" {
   sensitive   = true
 }
 
-variable "additional_ssh_public_keys" {
+variable "ssh_additional_public_keys" {
   description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes"
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "ssh_additional_public_keys" {
   default     = []
 }
 
+variable "hcloud_ssh_key_id" {
+  description = "If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module."
+  type        = string
+  default     = null
+}
+
 variable "network_region" {
   description = "Default region for network"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.2.0"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
solves #167 #161

was a bit difficult to solve. It's not 100% clean either, but it does what it's supposed to. 

I tried both the way to create the ssh key via pipe & /dev/stdio and via a file created via terraform local_secret_file, which I then delete again. 

The first does not work because the rights must be set to 0600. 
The second is unattractive because changes are displayed on every rerun. 

I have now solved this so that the corresponding file is created under /tmp and then deleted again. The file is created with 0600, which I think should be acceptable from a security point of view.