### PR TITLE
Allow Hetzner LB to point at schedulable controlplane nodes

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -128,7 +128,8 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/ccm.yaml.tpl",
       {
-        cluster_cidr_ipv4 = local.cluster_cidr_ipv4
+        cluster_cidr_ipv4                 = local.cluster_cidr_ipv4
+        allow_scheduling_on_control_plane = var.allow_scheduling_on_control_plane
     })
     destination = "/var/post_install/ccm.yaml"
   }

--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -15,3 +15,4 @@ spec:
             - "--allow-untagged-cloud"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=${cluster_cidr_ipv4}"
+            %{ if allow_scheduling_on_control_plane ~}- "--feature-gates=LegacyNodeRoleBehavior=false"%{ endif ~}


### PR DESCRIPTION
This PR introduces the `LegacyNodeRoleBehavior=false` feature gate to the CCM to allow the Hetzner loadbalancer to point at schedulable controlplane nodes. I'm guarding the feature gate behind the `allow_scheduling_on_control_plane` setting, but if you feel that this is not necessary, I can drop the guard and set it as default for all new clusters.

Resolves https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/55.