### PR TITLE
Set default lb location to hcloud ccm

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -139,6 +139,7 @@ resource "null_resource" "kustomization" {
       {
         cluster_cidr_ipv4                 = local.cluster_cidr_ipv4
         allow_scheduling_on_control_plane = local.allow_scheduling_on_control_plane
+        default_lb_location               = var.load_balancer_location
     })
     destination = "/var/post_install/ccm.yaml"
   }
@@ -218,7 +219,7 @@ resource "null_resource" "kustomization" {
       # manifests themselves
       "sed -i 's/^- |[0-9]\\+$/- |/g' /var/post_install/kustomization.yaml",
 
-      # Wait for k3s to become ready (we check one more time) because in some edge cases, 
+      # Wait for k3s to become ready (we check one more time) because in some edge cases,
       # the cluster had become unvailable for a few seconds, at this very instant.
       <<-EOT
       timeout 120 bash <<EOF

--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -15,4 +15,11 @@ spec:
             - "--allow-untagged-cloud"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=${cluster_cidr_ipv4}"
-            %{ if allow_scheduling_on_control_plane ~}- "--feature-gates=LegacyNodeRoleBehavior=false"%{ endif ~}
+%{ if allow_scheduling_on_control_plane ~}
+            - "--feature-gates=LegacyNodeRoleBehavior=false" 
+%{ endif ~}
+          env:
+            - name: "HCLOUD_LOAD_BALANCERS_LOCATION"
+              value: "${default_lb_location}"
+            - name: "HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP"
+              value: "true"


### PR DESCRIPTION
Hi
This PR sets these two environments variables to the hcloud ccm. The settings are the same as for the treafik lb, but this way they are default values for the hole cluster. 
More informations about these env here: https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/docs/load_balancers.md 

It is related to #175 .