### PR TITLE
deprecation fix: changed number to numeric in host/main.tf

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,6 +61,7 @@
 | <a name="input_agent_nodepools"></a> [agent\_nodepools](#input\_agent\_nodepools) | Number of agent nodes. | `list(any)` | `[]` | no |
 | <a name="input_allow_scheduling_on_control_plane"></a> [allow\_scheduling\_on\_control\_plane](#input\_allow\_scheduling\_on\_control\_plane) | Whether to allow non-control-plane workloads to run on the control-plane nodes | `bool` | `false` | no |
 | <a name="input_automatically_upgrade_k3s"></a> [automatically\_upgrade\_k3s](#input\_automatically\_upgrade\_k3s) | Whether to automatically upgrade k3s based on the selected channel | `bool` | `true` | no |
+| <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain of the cluster, used for reserve dns | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | `"k3s"` | no |
 | <a name="input_cni_plugin"></a> [cni\_plugin](#input\_cni\_plugin) | CNI plugin for k3s | `string` | `"flannel"` | no |
 | <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -2,7 +2,7 @@ resource "random_string" "server" {
   length  = 3
   lower   = true
   special = false
-  number  = false
+  numeric  = false
   upper   = false
 
   keepers = {
@@ -15,7 +15,7 @@ resource "random_string" "identity_file" {
   length  = 20
   lower   = true
   special = false
-  number  = true
+  numeric  = true
   upper   = false
 }
 


### PR DESCRIPTION
**Why**?

```
│ Warning: Argument is deprecated
│ 
│   with module.kube-hetzner.module.control_planes.random_string.server,
│   on .terraform/modules/kube-hetzner/modules/host/main.tf line 5, in resource "random_string" "server":
│    5:   number  = false
│ 
│ Use numeric instead.
│ 
│ (and 11 more similar warnings elsewhere)
```

According to docs https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string 

**Effect**

Literally just changed "number" to "numeric"