### PR TITLE
Remove icmp from WWW

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -137,15 +137,6 @@ locals {
       ]
     },
 
-    # Allow ping on ipv4
-    {
-      direction = "in"
-      protocol  = "icmp"
-      source_ips = [
-        "0.0.0.0/0"
-      ]
-    },
-
     # Allow basic out traffic
     # ICMP to ping outside services
     {


### PR DESCRIPTION
Since ICMP doesn't have any active role for cluster creation it should be disabled because there is no point for bots which scans randomly ip's to find any of my public ip's available