### PR TITLE
Expose loadbalancer IPv4 when Traefik disabled.

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -19,7 +19,7 @@ output "agents_public_ipv4" {
 
 output "load_balancer_public_ipv4" {
   description = "The public IPv4 address of the Hetzner load balancer"
-  value       = (local.using_klipper_lb == true || var.traefik_enabled == false) ? null : data.hcloud_load_balancer.traefik[0].ipv4
+  value       = local.using_klipper_lb ? null : data.hcloud_load_balancer.traefik[0].ipv4
 }
 
 output "kubeconfig_file" {


### PR DESCRIPTION
This PR removes the check for Traefik enabled when exposing the loadbalancer IPv4. Addresses https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/240.