### PR TITLE
Allow the dns to be configurable

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -19,6 +19,7 @@ module "agents" {
   server_type                = each.value.server_type
   ipv4_subnet_id             = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
   packages_to_install        = local.packages_to_install
+  dns_servers                = var.dns_servers
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -19,6 +19,7 @@ module "control_planes" {
   server_type                = each.value.server_type
   ipv4_subnet_id             = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
   packages_to_install        = local.packages_to_install
+  dns_servers                = var.dns_servers
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -97,6 +97,7 @@
 | <a name="input_traefik_enabled"></a> [traefik\_enabled](#input\_traefik\_enabled) | Whether to enable or disbale k3s traefik installation | `bool` | `true` | no |
 | <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name | `bool` | `true` | no |
 | <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | `["1.1.1.1", " 1.0.0.1", "8.8.8.8"]` | no |
 
 ### Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -62,6 +62,7 @@
 | <a name="input_allow_scheduling_on_control_plane"></a> [allow\_scheduling\_on\_control\_plane](#input\_allow\_scheduling\_on\_control\_plane) | Whether to allow non-control-plane workloads to run on the control-plane nodes | `bool` | `false` | no |
 | <a name="input_automatically_upgrade_k3s"></a> [automatically\_upgrade\_k3s](#input\_automatically\_upgrade\_k3s) | Whether to automatically upgrade k3s based on the selected channel | `bool` | `true` | no |
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain of the cluster, used for reserve dns | `string` | `""` | no |
+| <a name="input_block_icmp_ping_in"></a> [block\_icmp\_ping\_in](#input\_block\_icmp\_ping\_in) | Block ICMP ping in | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | `"k3s"` | no |
 | <a name="input_cni_plugin"></a> [cni\_plugin](#input\_cni\_plugin) | CNI plugin for k3s | `string` | `"flannel"` | no |
 | <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |
@@ -79,7 +80,7 @@
 | <a name="input_kured_version"></a> [kured\_version](#input\_kured\_version) | Version of Kured | `string` | `null` | no |
 | <a name="input_load_balancer_disable_ipv6"></a> [load\_balancer\_disable\_ipv6](#input\_load\_balancer\_disable\_ipv6) | Disable ipv6 for the load balancer | `bool` | `false` | no |
 | <a name="input_load_balancer_location"></a> [load\_balancer\_location](#input\_load\_balancer\_location) | Default load balancer location | `string` | `"fsn1"` | no |
-| <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Default load balancer server type | `string` | `"cpx11"` | no |
+| <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Default load balancer server type | `string` | `"lb11"` | no |
 | <a name="input_metrics_server_enabled"></a> [metrics\_server\_enabled](#input\_metrics\_server\_enabled) | Whether to enable or disbale k3s mertric server | `bool` | `true` | no |
 | <a name="input_network_region"></a> [network\_region](#input\_network\_region) | Default region for network | `string` | `"eu-central"` | no |
 | <a name="input_placement_group_disable"></a> [placement\_group\_disable](#input\_placement\_group\_disable) | Whether to disable placement groups | `bool` | `false` | no |

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -146,6 +146,7 @@ data "cloudinit_config" "config" {
       {
         hostname          = local.name
         sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        dnsServers = var.dns_servers
       }
     )
   }

--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -54,8 +54,10 @@ runcmd:
 - [sed, '-i', 's/NETCONFIG_NIS_SETDOMAINNAME="yes"/NETCONFIG_NIS_SETDOMAINNAME="no"/g', /etc/sysconfig/network/config]
 - [sed, '-i', 's/DHCLIENT_SET_HOSTNAME="yes"/DHCLIENT_SET_HOSTNAME="no"/g', /etc/sysconfig/network/dhcp]
 
-# We set Cloudflare DNS servers, followed by Google as a backup
-- [sed, '-i', 's/NETCONFIG_DNS_STATIC_SERVERS=""/NETCONFIG_DNS_STATIC_SERVERS="1.1.1.1 1.0.0.1 8.8.8.8"/g', /etc/sysconfig/network/config]
+%{ if length(dnsServers) > 0 }
+# We set the user provided DNS servers, or leave the value empty to default to Hetzners
+- [sed, '-i', 's/NETCONFIG_DNS_STATIC_SERVERS=""/NETCONFIG_DNS_STATIC_SERVERS="${join(" ", dnsServers)}"/g', /etc/sysconfig/network/config]
+%{ endif }
 
 # Bounds the amount of logs that can survive on the system
 - [sed, '-i', 's/#SystemMaxUse=/SystemMaxUse=3G/g', /etc/systemd/journald.conf]

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -73,3 +73,8 @@ variable "packages_to_install" {
   type        = list(string)
   default     = []
 }
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -256,3 +256,9 @@ variable "block_icmp_ping_in" {
   default     = false
   description = "Block ICMP ping in"
 }
+
+variable "dns_servers" {
+  type        = list(string)
+  default     = ["1.1.1.1", " 1.0.0.1", "8.8.8.8"]
+  description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner"
+}


### PR DESCRIPTION
Hetzner as authorative DNS servers on their cloud servers that resolve
different IP addresses for some of their products, such as Storage Box,
when we overwrite them, we stop those services from being connectable
from Hetzner Cloud.

This change allows users to choose their own DNS Servers (or default to
the current Google/Cloudflare combo), or even provide an empty list and
use Hetzner.

Relates-to: #249