### PR TITLE
Loadbalance control plane

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -23,10 +23,7 @@ module "agents" {
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = {
-    "provisioner" = "terraform",
-    "engine"      = "k3s"
-  }
+  labels = merge(local.labels, local.labels_agent_node)
 
   depends_on = [
     hcloud_network_subnet.agent
@@ -51,7 +48,7 @@ resource "null_resource" "agents" {
   provisioner "file" {
     content = yamlencode({
       node-name     = module.agents[each.key].name
-      server        = "https://${module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+      server        = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
       token         = random_password.k3s_token.result
       kubelet-arg   = ["cloud-provider=external", "volume-plugin-dir=/var/lib/kubelet/volumeplugins"]
       flannel-iface = "eth1"

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -25,14 +25,47 @@ module "control_planes" {
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
   private_ipv4 = cidrhost(hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = {
-    "provisioner" = "terraform",
-    "engine"      = "k3s"
-  }
+  labels = merge(local.labels, local.labels_control_plane_node)
 
   depends_on = [
     hcloud_network_subnet.control_plane
   ]
+}
+
+resource "hcloud_load_balancer" "control_plane" {
+  count = var.use_control_plane_lb ? 1 : 0
+
+  load_balancer_type = var.load_balancer_type
+  name               = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}control-plane"
+  location           = var.load_balancer_location
+
+  labels = merge(local.labels, local.labels_control_plane_lb)
+}
+
+resource "hcloud_load_balancer_network" "control_plane" {
+  count = var.use_control_plane_lb ? 1 : 0
+
+  load_balancer_id = hcloud_load_balancer.control_plane.*.id[0]
+  subnet_id        = hcloud_network_subnet.control_plane.*.id[0]
+}
+
+resource "hcloud_load_balancer_target" "load_balancer_target" {
+  count = var.use_control_plane_lb ? 1 : 0
+
+  depends_on       = [hcloud_load_balancer_network.control_plane]
+  type             = "label_selector"
+  load_balancer_id = hcloud_load_balancer.control_plane.*.id[0]
+  label_selector   = join(",", [for k, v in merge(local.labels, local.labels_control_plane_node) : "${k}=${v}"])
+  use_private_ip   = true
+}
+
+resource "hcloud_load_balancer_service" "load_balancer_service" {
+  count = var.use_control_plane_lb ? 1 : 0
+
+  load_balancer_id = hcloud_load_balancer.control_plane.*.id[0]
+  protocol         = "tcp"
+  destination_port = "6443"
+  listen_port      = "6443"
 }
 
 resource "null_resource" "control_planes" {
@@ -52,8 +85,12 @@ resource "null_resource" "control_planes" {
   # Generating k3s server config file
   provisioner "file" {
     content = yamlencode(merge({
-      node-name                   = module.control_planes[each.key].name
-      server                      = length(module.control_planes) == 1 ? null : "https://${module.control_planes[each.key].private_ipv4_address == module.control_planes[keys(module.control_planes)[0]].private_ipv4_address ? module.control_planes[keys(module.control_planes)[1]].private_ipv4_address : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+      node-name = module.control_planes[each.key].name
+      server = length(module.control_planes) == 1 ? null : "https://${
+        var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] :
+        module.control_planes[each.key].private_ipv4_address == module.control_planes[keys(module.control_planes)[0]].private_ipv4_address ?
+        module.control_planes[keys(module.control_planes)[1]].private_ipv4_address :
+      module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
       token                       = random_password.k3s_token.result
       disable-cloud-controller    = true
       disable                     = local.disable_extras

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -98,6 +98,7 @@
 | <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name | `bool` | `true` | no |
 | <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | `["1.1.1.1", " 1.0.0.1", "8.8.8.8"]` | no |
+| <a name="input_use_control_plane_lb"></a> [use\_control\_plane\_lb](#input\_use\_control\_plane\_lb) | When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability | `bool` | `false` | no |
 
 ### Outputs
 

--- a/init.tf
+++ b/init.tf
@@ -25,7 +25,8 @@ resource "null_resource" "first_control_plane" {
       },
       var.cni_plugin == "calico" ? {
         flannel-backend = "none"
-    } : {}))
+      } : {},
+    var.use_control_plane_lb ? { tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip] } : {}))
 
     destination = "/tmp/config.yaml"
   }
@@ -95,7 +96,9 @@ resource "null_resource" "kustomization" {
           "https://github.com/weaveworks/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-dockerhub.yaml",
           "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml",
         ],
-        var.disable_hetzner_csi ? [] : ["https://raw.githubusercontent.com/hetznercloud/csi-driver/${local.csi_version}/deploy/kubernetes/hcloud-csi.yml"],
+        var.disable_hetzner_csi ? [] : [
+          "https://raw.githubusercontent.com/hetznercloud/csi-driver/${local.csi_version}/deploy/kubernetes/hcloud-csi.yml"
+        ],
         var.traefik_enabled ? ["traefik_config.yaml"] : [],
         var.cni_plugin == "calico" ? ["https://projectcalico.docs.tigera.io/manifests/calico.yaml"] : [],
         var.enable_longhorn ? ["longhorn.yaml"] : [],
@@ -237,9 +240,9 @@ resource "null_resource" "kustomization" {
       "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
       "kubectl -n system-upgrade wait --for=condition=available --timeout=120s deployment/system-upgrade-controller",
       "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml"
-      ]
-      ,
-      local.using_klipper_lb || var.traefik_enabled == false ? [] : [<<-EOT
+      ],
+      local.using_klipper_lb || var.traefik_enabled == false ? [] : [
+        <<-EOT
       timeout 120 bash <<EOF
       until [ -n "\$(kubectl get -n kube-system service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2> /dev/null)" ]; do
           echo "Waiting for load-balancer to get an IP..."

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -13,10 +13,10 @@ data "remote_file" "kubeconfig" {
 }
 
 locals {
-  kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", module.control_planes[keys(module.control_planes)[0]].ipv4_address)
+  kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
-    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
+    host                   = var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])

--- a/locals.tf
+++ b/locals.tf
@@ -220,4 +220,21 @@ locals {
       ]
     }
   ])
+
+  labels = {
+    "provisioner" = "terraform",
+    "engine"      = "k3s"
+    "cluster"     = var.cluster_name
+  }
+
+  labels_control_plane_node = {
+    role = "control_plane_node"
+  }
+  labels_control_plane_lb = {
+    role = "control_plane_lb"
+  }
+
+  labels_agent_node = {
+    role = "agent_node"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -257,6 +257,12 @@ variable "block_icmp_ping_in" {
   description = "Block ICMP ping in"
 }
 
+variable "use_control_plane_lb" {
+  type        = bool
+  default     = false
+  description = "When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability"
+}
+
 variable "dns_servers" {
   type        = list(string)
   default     = ["1.1.1.1", " 1.0.0.1", "8.8.8.8"]


### PR DESCRIPTION
Currently all incoming connections go to the first control-plane node.
This means that if kured is restarting that node, an API user can
experience downtime. This change loadbalances the incoming requests via
a loadbalancer, meaning the service never appears down.

To facilitate that, we also add a few new labels to resources to allow
for easy identification.

This also means the cluster will be highly available, as we can use the
loadbalancer rather than node IPs for the server ip address.