### PR TITLE
Allow additional packages to be installed on the nodes

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -98,6 +98,7 @@
 | <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name | `bool` | `true` | no |
 | <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | `["1.1.1.1", " 1.0.0.1", "8.8.8.8"]` | no |
+| <a name="input_extra_packages_to_install"></a> [extra\_packages\_to\_install](#input\_extra\_packages\_to\_install) | A list of additional packages to install on nodes | `list(string)` | `[]` | no |
 
 ### Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -80,7 +80,7 @@ locals {
   # Default k3s node taints
   default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/master:NoSchedule"])
 
-  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], [])
+  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], var.extra_packages_to_install)
 
   # The following IPs are important to be whitelisted because they communicate with Hetzner services and enable the CCM and CSI to work properly.
   # Source https://github.com/hetznercloud/csi-driver/issues/204#issuecomment-848625566

--- a/variables.tf
+++ b/variables.tf
@@ -262,3 +262,9 @@ variable "dns_servers" {
   default     = ["1.1.1.1", " 1.0.0.1", "8.8.8.8"]
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner"
 }
+
+variable "extra_packages_to_install" {
+  type        = list(string)
+  default     = []
+  description = "A list of additional packages to install on nodes"
+}


### PR DESCRIPTION
When using some csi, such as the smb csi, you need additional packages
on the host nodes. Currently you need an additional null resource to
install these, and that will cause problems if autoscaling is ever
implemented. This change allows the user to specify additional packages
to include.

This has already been implemented in #244 however that seems to have
stalled, so this change reinstates the idea.
