### PR TITLE
Remove deprecated taint

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -78,7 +78,7 @@ locals {
   allow_scheduling_on_control_plane = local.is_single_node_cluster ? true : var.allow_scheduling_on_control_plane
 
   # Default k3s node taints
-  default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/master:NoSchedule"])
+  default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/control-plane:NoSchedule"])
 
   packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], var.extra_packages_to_install)
 

--- a/templates/plans.yaml.tpl
+++ b/templates/plans.yaml.tpl
@@ -15,7 +15,7 @@ spec:
     matchExpressions:
       - {key: k3s_upgrade, operator: Exists}
       - {key: k3s_upgrade, operator: NotIn, values: ["disabled", "false"]}
-      - {key: node-role.kubernetes.io/master, operator: NotIn, values: ["true"]}
+      - {key: node-role.kubernetes.io/control-plane, operator: NotIn, values: ["true"]}
   tolerations:
     - {key: server-usage, effect: NoSchedule, operator: Equal, value: storage}
   prepare:
@@ -43,9 +43,9 @@ spec:
     matchExpressions:
       - {key: k3s_upgrade, operator: Exists}
       - {key: k3s_upgrade, operator: NotIn, values: ["disabled", "false"]}
-      - {key: node-role.kubernetes.io/master, operator: In, values: ["true"]}
+      - {key: node-role.kubernetes.io/control-plane, operator: In, values: ["true"]}
   tolerations:
-    - {key: node-role.kubernetes.io/master, effect: NoSchedule, operator: Exists}
+    - {key: node-role.kubernetes.io/control-plane, effect: NoSchedule, operator: Exists}
     - {key: CriticalAddonsOnly, effect: NoExecute, operator: Exists}
   cordon: true
   upgrade:


### PR DESCRIPTION
This taint should match the new role name "control-plane"

Kubeadm [will remove this with 1.25][issue]. It's a bit of an awkward timing, because that looks like it will come out at the [end of this month](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.25#summary)

[issue]: https://github.com/kubernetes/kubeadm/issues/2200
