### PR TITLE
Added longhorn variables for fstype and default replica count

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ _Once you start with Terraform, it's best not to change the state manually in He
 
 The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`.
 
-As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. You can also find the default values that we use in the [cilium.yaml.tpl](https://github.com/kube-hetzner/kube-hetzner/blob/master/templates/cilium.yaml.tpl) file. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
+As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
 
 ### Scaling Nodes
 

--- a/init.tf
+++ b/init.tf
@@ -183,7 +183,7 @@ resource "null_resource" "kustomization" {
       "${path.module}/templates/longhorn.yaml.tpl",
       {
         disable_hetzner_csi = var.disable_hetzner_csi,
-        longhorn_fstype = var.longhorn_fstype == null ? "ext4" : var.longhorn_fstype
+        longhorn_fstype = var.longhorn_fstype == null ? "ext4" : var.longhorn_fstype,
         longhorn_replica_count = var.longhorn_replica_count == null ? 3 : var.longhorn_replica_count
     })
     destination = "/var/post_install/longhorn.yaml"

--- a/init.tf
+++ b/init.tf
@@ -182,8 +182,8 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/longhorn.yaml.tpl",
       {
-        disable_hetzner_csi = var.disable_hetzner_csi,
-        longhorn_fstype = var.longhorn_fstype == null ? "ext4" : var.longhorn_fstype,
+        disable_hetzner_csi    = var.disable_hetzner_csi,
+        longhorn_fstype        = var.longhorn_fstype == null ? "ext4" : var.longhorn_fstype,
         longhorn_replica_count = var.longhorn_replica_count == null ? 3 : var.longhorn_replica_count
     })
     destination = "/var/post_install/longhorn.yaml"

--- a/init.tf
+++ b/init.tf
@@ -182,7 +182,9 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/longhorn.yaml.tpl",
       {
-        disable_hetzner_csi = var.disable_hetzner_csi
+        disable_hetzner_csi = var.disable_hetzner_csi,
+        longhorn_fstype = var.longhorn_fstype == null ? "ext4" : var.longhorn_fstype
+        longhorn_replica_count = var.longhorn_replica_count == null ? 3 : var.longhorn_replica_count
     })
     destination = "/var/post_install/longhorn.yaml"
   }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -134,6 +134,12 @@ module "kube-hetzner" {
   # To use local storage on the nodes, you can enable Longhorn, default is "false".
   # enable_longhorn = true
 
+  # file system for longhorn, if enabled (ext4 is the default, otherwise you can choose xfs)
+  # longhorn_fstype = "xfs"
+
+  # how many replica volumes should longhorn create? (default is 3)
+  # longhorn_replica_count = 1
+
   # To disable Hetzner CSI storage, you can set the following to true, default is "false".
   # disable_hetzner_csi = true
 

--- a/templates/longhorn.yaml.tpl
+++ b/templates/longhorn.yaml.tpl
@@ -29,6 +29,6 @@ spec:
     defaultSettings:
       defaultDataPath: /var/longhorn
     persistence:
-      defaultFsType: ext4
-      defaultClassReplicaCount: 3
+      defaultFsType: ${longhorn_fstype}
+      defaultClassReplicaCount: ${longhorn_replica_count}
       %{ if disable_hetzner_csi ~}defaultClass: true%{ else ~}defaultClass: false%{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,18 @@ variable "enable_longhorn" {
   description = "Enable Longhorn"
 }
 
+variable "longhorn_fstype" {
+  type        = string
+  default     = false
+  description = "ext4 or xfs longhorn fstype"
+}
+
+variable "longhorn_replica_count" {
+  type        = number
+  default     = 3
+  description = "Number of replicas per longhorn volume"
+}
+
 variable "disable_hetzner_csi" {
   type        = bool
   default     = false


### PR DESCRIPTION
I added two variables to accommodate my needs with mongodb (which strongly recommends the xfs file system). I imagine a better solution would be expanding PR #244 and allowing these options to be set during volume creation instead of as a global in the longhorn.yml file, but I wanted to get his out there regardless in case it does prove useful.

Thanks!