### PR TITLE
Allow setting alternative SSH port for host access

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ _Once you start with Terraform, it's best not to change the state manually in He
 
 ## CNI
 
-The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`. For both, you can create a HelmChartConfig to edit their respective configuration post cluster deploy!
+The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`.
 
 As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. You can also find the default values that we use in the [cilium.yaml.tpl](https://github.com/kube-hetzner/kube-hetzner/blob/master/templates/cilium.yaml.tpl) file. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ _Once you start with Terraform, it's best not to change the state manually in He
 
 ## CNI
 
-The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`. For both, you can create a HelmChartConfig to edit their respective configuration post cluster deploy! Read more about HelmChartConfig [here](https://rancher.com/docs/k3s/latest/en/helm/#customizing-packaged-components-with-helmchartconfig).
+The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`. For both, you can create a HelmChartConfig to edit their respective configuration post cluster deploy!
 
-As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the [Cilium values.yaml file](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml), but with the values you want to modify. You can also find the default values that we use in the [cilium.yaml.tpl][https://github.com/kube-hetzner/kube-hetzner/blob/master/templates/cilium.yaml.tpl] file. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
+As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. You can also find the default values that we use in the [cilium.yaml.tpl](https://github.com/kube-hetzner/kube-hetzner/blob/master/templates/cilium.yaml.tpl) file. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
 
 ### Scaling Nodes
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ _Once you start with Terraform, it's best not to change the state manually in He
 
 The default is flannel, but you can also choose Calico or Cilium, by setting the cni_plugin variable in `kube.tf` to `calico` or `cilium`.
 
-As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. You can also find the default values that we use in the [cilium.yaml.tpl](https://github.com/kube-hetzner/kube-hetzner/blob/master/templates/cilium.yaml.tpl) file. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
+As Cilium has a lot of interesting and powerful configurations possibility. We give you the possibiliy to add a `cilium_values.yaml` file to the root of your module before you deploy your cluster, the same place where you have your `kube.tf` file. This file must be of the same format as the Cilium Helm [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml) file, but with the values you want to modify. During the deploy, Terraform will test to see if this file is present and if so will use those values to deploy the Cilium Helm chart.
 
 ### Scaling Nodes
 

--- a/agents.tf
+++ b/agents.tf
@@ -10,6 +10,7 @@ module "agents" {
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
   ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
@@ -42,6 +43,7 @@ resource "null_resource" "agents" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s agent config file

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -10,6 +10,7 @@ module "control_planes" {
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
   ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
@@ -80,6 +81,7 @@ resource "null_resource" "control_planes" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[each.key].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s server config file

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -71,7 +71,7 @@
 | <a name="input_cni_plugin"></a> [cni\_plugin](#input\_cni\_plugin) | CNI plugin for k3s | `string` | `"flannel"` | no |
 | <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |
 | <a name="input_disable_hetzner_csi"></a> [disable\_hetzner\_csi](#input\_disable\_hetzner\_csi) | Disable hetzner csi driver | `bool` | `false` | no |
-| <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico) | `bool` | `false` | no |
+| <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico and cilium) | `bool` | `false` | no |
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | <pre>[<br>  "1.1.1.1",<br>  " 1.0.0.1",<br>  "8.8.8.8"<br>]</pre> | no |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable cert manager | `bool` | `false` | no |
 | <a name="input_enable_longhorn"></a> [enable\_longhorn](#input\_enable\_longhorn) | Enable Longhorn | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,6 +32,10 @@
 | Name | Type |
 |------|------|
 | [hcloud_firewall.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall) | resource |
+| [hcloud_load_balancer.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer) | resource |
+| [hcloud_load_balancer_network.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_network) | resource |
+| [hcloud_load_balancer_service.load_balancer_service](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_service) | resource |
+| [hcloud_load_balancer_target.load_balancer_target](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_target) | resource |
 | [hcloud_network.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network) | resource |
 | [hcloud_network_subnet.agent](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet) | resource |
 | [hcloud_network_subnet.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet) | resource |
@@ -68,10 +72,12 @@
 | <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |
 | <a name="input_disable_hetzner_csi"></a> [disable\_hetzner\_csi](#input\_disable\_hetzner\_csi) | Disable hetzner csi driver | `bool` | `false` | no |
 | <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico) | `bool` | `false` | no |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | <pre>[<br>  "1.1.1.1",<br>  " 1.0.0.1",<br>  "8.8.8.8"<br>]</pre> | no |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable cert manager | `bool` | `false` | no |
 | <a name="input_enable_longhorn"></a> [enable\_longhorn](#input\_enable\_longhorn) | Enable Longhorn | `bool` | `false` | no |
 | <a name="input_enable_rancher"></a> [enable\_rancher](#input\_enable\_rancher) | Enable rancher | `bool` | `false` | no |
 | <a name="input_extra_firewall_rules"></a> [extra\_firewall\_rules](#input\_extra\_firewall\_rules) | Additional firewall rules to apply to the cluster | `list(any)` | `[]` | no |
+| <a name="input_extra_packages_to_install"></a> [extra\_packages\_to\_install](#input\_extra\_packages\_to\_install) | A list of additional packages to install on nodes | `list(string)` | `[]` | no |
 | <a name="input_hcloud_ssh_key_id"></a> [hcloud\_ssh\_key\_id](#input\_hcloud\_ssh\_key\_id) | If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module. | `string` | `null` | no |
 | <a name="input_hcloud_token"></a> [hcloud\_token](#input\_hcloud\_token) | Hetzner Cloud API Token | `string` | n/a | yes |
 | <a name="input_hetzner_ccm_version"></a> [hetzner\_ccm\_version](#input\_hetzner\_ccm\_version) | Version of Kubernetes Cloud Controller Manager for Hetzner Cloud | `string` | `null` | no |
@@ -86,7 +92,7 @@
 | <a name="input_placement_group_disable"></a> [placement\_group\_disable](#input\_placement\_group\_disable) | Whether to disable placement groups | `bool` | `false` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Rancher bootstrap password | `string` | `""` | no |
 | <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Enable rancher | `string` | `"rancher.example.com"` | no |
-| <a name="input_rancher_install_channel"></a> [rancher\_install\_channel](#input\_rancher\_install\_channel) | Rancher install channel | `string` | `"stable"` | no |
+| <a name="input_rancher_install_channel"></a> [rancher\_install\_channel](#input\_rancher\_install\_channel) | Rancher install channel | `string` | `"latest"` | no |
 | <a name="input_rancher_registration_manifest_url"></a> [rancher\_registration\_manifest\_url](#input\_rancher\_registration\_manifest\_url) | The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/) | `string` | `""` | no |
 | <a name="input_ssh_additional_public_keys"></a> [ssh\_additional\_public\_keys](#input\_ssh\_additional\_public\_keys) | Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes | `list(string)` | `[]` | no |
 | <a name="input_ssh_private_key"></a> [ssh\_private\_key](#input\_ssh\_private\_key) | SSH private Key. | `string` | n/a | yes |
@@ -96,10 +102,8 @@
 | <a name="input_traefik_additional_options"></a> [traefik\_additional\_options](#input\_traefik\_additional\_options) | n/a | `list(string)` | `[]` | no |
 | <a name="input_traefik_enabled"></a> [traefik\_enabled](#input\_traefik\_enabled) | Whether to enable or disbale k3s traefik installation | `bool` | `true` | no |
 | <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name | `bool` | `true` | no |
-| <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
-| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | `["1.1.1.1", " 1.0.0.1", "8.8.8.8"]` | no |
 | <a name="input_use_control_plane_lb"></a> [use\_control\_plane\_lb](#input\_use\_control\_plane\_lb) | When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability | `bool` | `false` | no |
-| <a name="input_extra_packages_to_install"></a> [extra\_packages\_to\_install](#input\_extra\_packages\_to\_install) | A list of additional packages to install on nodes | `list(string)` | `[]` | no |
+| <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
 
 ### Outputs
 

--- a/init.tf
+++ b/init.tf
@@ -4,6 +4,7 @@ resource "null_resource" "first_control_plane" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s master config file
@@ -81,6 +82,7 @@ resource "null_resource" "kustomization" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
+    port           = var.ssh_port
   }
 
   # Upload kustomization.yaml, containing Hetzner CSI & CSM, as well as kured.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -23,6 +23,9 @@ module "kube-hetzner" {
   # This is to keep Terraform from re-provisioning all nodes at once, which would lose data. If you want to update
   # those, you should instead change the value here and manually re-provision each node. Grep for "lifecycle".
 
+  # Port intended for SSH use.
+  ssh_port = 22
+
   # * Your ssh public key
   ssh_public_key = file("/home/username/.ssh/id_ed25519.pub")
   # * Your private key must be "ssh_private_key = null" when you want to use ssh-agent for a Yubikey-like device authentification or an SSH key-pair with a passphrase.

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -2,7 +2,7 @@
 data "remote_file" "kubeconfig" {
   conn {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
-    port        = 22
+    port        = var.ssh_port
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -1,7 +1,7 @@
 data "remote_file" "kustomization_backup" {
   conn {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
-    port        = 22
+    port        = var.ssh_port
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null

--- a/locals.tf
+++ b/locals.tf
@@ -133,11 +133,19 @@ locals {
       ]
     },
 
-    # Allow all traffic to the ssh port
+    # Allow all traffic to the ssh ports
     {
       direction = "in"
       protocol  = "tcp"
       port      = "22"
+      source_ips = [
+        "0.0.0.0/0"
+      ]
+    },
+    {
+      direction = "in"
+      protocol  = "tcp"
+      port      = var.ssh_port
       source_ips = [
         "0.0.0.0/0"
       ]

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -47,9 +47,10 @@ resource "hcloud_server" "server" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = self.ipv4_address
+    port           = var.ssh_port
   }
 
-  # Prepare ssh identity file 
+  # Prepare ssh identity file
   provisioner "local-exec" {
     command = <<-EOT
       install -b -m 600 /dev/null /tmp/${random_string.identity_file.id}
@@ -59,6 +60,17 @@ resource "hcloud_server" "server" {
 
   # Install MicroOS
   provisioner "remote-exec" {
+    connection {
+      user           = "root"
+      private_key    = var.ssh_private_key
+      agent_identity = local.ssh_agent_identity
+      host           = self.ipv4_address
+
+      # We cannot use different ports here as this runs inside Hetzner Rescue image and thus uses the
+      # standard 22 TCP port.
+      #port = var.ssh_port
+    }
+
     inline = [
       "set -ex",
       "apt-get update",
@@ -68,11 +80,17 @@ resource "hcloud_server" "server" {
     ]
   }
 
-  # Issue a reboot command and wait for MicroOS to reboot and be ready
+  # Issue a reboot command.
   provisioner "local-exec" {
     command = <<-EOT
       ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
-      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+    EOT
+  }
+
+  # Wait for MicroOS to reboot and be ready.
+  provisioner "local-exec" {
+    command = <<-EOT
+      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 3
@@ -82,6 +100,14 @@ resource "hcloud_server" "server" {
 
   # Install k3s-selinux (compatible version) and open-iscsi
   provisioner "remote-exec" {
+    connection {
+      user           = "root"
+      private_key    = var.ssh_private_key
+      agent_identity = local.ssh_agent_identity
+      host           = self.ipv4_address
+      port           = var.ssh_port
+    }
+
     inline = [<<-EOT
       set -ex
       transactional-update shell <<< "zypper --gpg-auto-import-keys install -y ${local.needed_packages}"
@@ -89,11 +115,17 @@ resource "hcloud_server" "server" {
     ]
   }
 
-  # Issue a reboot command and wait for MicroOS to reboot and be ready
+  # Issue a reboot command.
   provisioner "local-exec" {
     command = <<-EOT
-      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
-      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -p ${var.ssh_port} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
+    EOT
+  }
+
+  # Wait for MicroOS to reboot and be ready
+  provisioner "local-exec" {
+    command = <<-EOT
+      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 3
@@ -145,6 +177,7 @@ data "cloudinit_config" "config" {
       "${path.module}/templates/userdata.yaml.tpl",
       {
         hostname          = local.name
+        sshPort           = var.ssh_port
         sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
         dnsServers        = var.dns_servers
       }

--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -10,6 +10,7 @@ write_files:
 
 # Disable ssh password authentication
 - content: |
+    Port ${sshPort}
     PasswordAuthentication no
     X11Forwarding no
     MaxAuthTries 2
@@ -49,6 +50,8 @@ hostname: ${hostname}
 preserve_hostname: true
 
 runcmd:
+
+- [sed, '-i', '/Port /d', /etc/ssh/sshd_config]
 
 # As above, make sure the hostname is not reset
 - [sed, '-i', 's/NETCONFIG_NIS_SETDOMAINNAME="yes"/NETCONFIG_NIS_SETDOMAINNAME="no"/g', /etc/sysconfig/network/config]

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -8,6 +8,11 @@ variable "base_domain" {
   type        = string
 }
 
+variable "ssh_port" {
+  description = "SSH port"
+  type        = string
+}
+
 variable "ssh_public_key" {
   description = "SSH public Key"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "hcloud_token" {
   sensitive   = true
 }
 
+variable "ssh_port" {
+  description = "SSH port."
+  type        = string
+  default     = 22
+}
+
 variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string


### PR DESCRIPTION
The use of alternative SSH port is useful for different use cases or
when we need to provide the port for other service.

Fixes: #277.
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
