### PR TITLE
Allow setting alternative SSH port for host access

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -10,6 +10,7 @@ module "agents" {
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
   ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
@@ -42,6 +43,7 @@ resource "null_resource" "agents" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s agent config file

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -10,6 +10,7 @@ module "control_planes" {
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
   ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
@@ -80,6 +81,7 @@ resource "null_resource" "control_planes" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[each.key].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s server config file

--- a/init.tf
+++ b/init.tf
@@ -4,6 +4,7 @@ resource "null_resource" "first_control_plane" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
+    port           = var.ssh_port
   }
 
   # Generating k3s master config file
@@ -81,6 +82,7 @@ resource "null_resource" "kustomization" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
+    port           = var.ssh_port
   }
 
   # Upload kustomization.yaml, containing Hetzner CSI & CSM, as well as kured.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -23,6 +23,9 @@ module "kube-hetzner" {
   # This is to keep Terraform from re-provisioning all nodes at once, which would lose data. If you want to update
   # those, you should instead change the value here and manually re-provision each node. Grep for "lifecycle".
 
+  # Port intended for SSH use.
+  ssh_port = 22
+
   # * Your ssh public key
   ssh_public_key = file("/home/username/.ssh/id_ed25519.pub")
   # * Your private key must be "ssh_private_key = null" when you want to use ssh-agent for a Yubikey-like device authentification or an SSH key-pair with a passphrase.

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -2,7 +2,7 @@
 data "remote_file" "kubeconfig" {
   conn {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
-    port        = 22
+    port        = var.ssh_port
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -1,7 +1,7 @@
 data "remote_file" "kustomization_backup" {
   conn {
     host        = module.control_planes[keys(module.control_planes)[0]].ipv4_address
-    port        = 22
+    port        = var.ssh_port
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null

--- a/locals.tf
+++ b/locals.tf
@@ -133,11 +133,19 @@ locals {
       ]
     },
 
-    # Allow all traffic to the ssh port
+    # Allow all traffic to the ssh ports
     {
       direction = "in"
       protocol  = "tcp"
       port      = "22"
+      source_ips = [
+        "0.0.0.0/0"
+      ]
+    },
+    {
+      direction = "in"
+      protocol  = "tcp"
+      port      = var.ssh_port
       source_ips = [
         "0.0.0.0/0"
       ]

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -47,9 +47,10 @@ resource "hcloud_server" "server" {
     private_key    = var.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = self.ipv4_address
+    port           = var.ssh_port
   }
 
-  # Prepare ssh identity file 
+  # Prepare ssh identity file
   provisioner "local-exec" {
     command = <<-EOT
       install -b -m 600 /dev/null /tmp/${random_string.identity_file.id}
@@ -59,6 +60,17 @@ resource "hcloud_server" "server" {
 
   # Install MicroOS
   provisioner "remote-exec" {
+    connection {
+      user           = "root"
+      private_key    = var.ssh_private_key
+      agent_identity = local.ssh_agent_identity
+      host           = self.ipv4_address
+
+      # We cannot use different ports here as this runs inside Hetzner Rescue image and thus uses the
+      # standard 22 TCP port.
+      port = 22
+    }
+
     inline = [
       "set -ex",
       "apt-get update",
@@ -68,11 +80,17 @@ resource "hcloud_server" "server" {
     ]
   }
 
-  # Issue a reboot command and wait for MicroOS to reboot and be ready
+  # Issue a reboot command.
   provisioner "local-exec" {
     command = <<-EOT
       ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
-      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+    EOT
+  }
+
+  # Wait for MicroOS to reboot and be ready.
+  provisioner "local-exec" {
+    command = <<-EOT
+      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 3
@@ -82,6 +100,14 @@ resource "hcloud_server" "server" {
 
   # Install k3s-selinux (compatible version) and open-iscsi
   provisioner "remote-exec" {
+    connection {
+      user           = "root"
+      private_key    = var.ssh_private_key
+      agent_identity = local.ssh_agent_identity
+      host           = self.ipv4_address
+      port           = var.ssh_port
+    }
+
     inline = [<<-EOT
       set -ex
       transactional-update shell <<< "zypper --gpg-auto-import-keys install -y ${local.needed_packages}"
@@ -89,11 +115,17 @@ resource "hcloud_server" "server" {
     ]
   }
 
-  # Issue a reboot command and wait for MicroOS to reboot and be ready
+  # Issue a reboot command.
   provisioner "local-exec" {
     command = <<-EOT
-      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
-      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 root@${self.ipv4_address} true 2> /dev/null
+      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -p ${var.ssh_port} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
+    EOT
+  }
+
+  # Wait for MicroOS to reboot and be ready
+  provisioner "local-exec" {
+    command = <<-EOT
+      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
       do
         echo "Waiting for MicroOS to reboot and become available..."
         sleep 3
@@ -145,6 +177,7 @@ data "cloudinit_config" "config" {
       "${path.module}/templates/userdata.yaml.tpl",
       {
         hostname          = local.name
+        sshPort           = var.ssh_port
         sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
         dnsServers        = var.dns_servers
       }

--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -10,6 +10,7 @@ write_files:
 
 # Disable ssh password authentication
 - content: |
+    Port ${sshPort}
     PasswordAuthentication no
     X11Forwarding no
     MaxAuthTries 2

--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -51,6 +51,8 @@ preserve_hostname: true
 
 runcmd:
 
+- [sed, '-i', '/Port /d', /etc/ssh/sshd_config]
+
 # As above, make sure the hostname is not reset
 - [sed, '-i', 's/NETCONFIG_NIS_SETDOMAINNAME="yes"/NETCONFIG_NIS_SETDOMAINNAME="no"/g', /etc/sysconfig/network/config]
 - [sed, '-i', 's/DHCLIENT_SET_HOSTNAME="yes"/DHCLIENT_SET_HOSTNAME="no"/g', /etc/sysconfig/network/dhcp]

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -8,6 +8,16 @@ variable "base_domain" {
   type        = string
 }
 
+variable "ssh_port" {
+  description = "SSH port"
+  type        = number
+
+  validation {
+    condition     = var.ssh_port >= 0 && var.ssh_port <= 65535
+    error_message = "The ssh_port must use a valid range from 0 to 65535.."
+  }
+}
+
 variable "ssh_public_key" {
   description = "SSH public Key"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,17 @@ variable "hcloud_token" {
   sensitive   = true
 }
 
+variable "ssh_port" {
+  description = "SSH port."
+  type        = number
+  default     = 22
+
+  validation {
+    condition     = var.ssh_port >= 0 && var.ssh_port <= 65535
+    error_message = "The ssh_port must use a valid range from 0 to 65535.."
+  }
+}
+
 variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string


### PR DESCRIPTION
The use of alternative SSH port is useful for different use cases or
when we need to provide the port for other service.

Fixes: #277.
Refs: #279.
