### PR TITLE
Cilium fix

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -84,8 +84,8 @@ locals {
   allow_scheduling_on_control_plane = local.is_single_node_cluster ? true : var.allow_scheduling_on_control_plane
 
   # Default k3s node taints
-  default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["CriticalAddonsOnly=true:NoSchedule"], var.cni_plugin == "cilium" ? ["node.kubernetes.io/not-ready:NoSchedule"] : [])
-  default_agent_taints         = concat([], var.cni_plugin == "cilium" ? ["CriticalAddonsOnly=true:NoSchedule"] : [])
+  default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/control-plane:NoSchedule"])
+  default_agent_taints         = concat([], var.cni_plugin == "cilium" ? ["node.cilium.io/agent-not-ready:NoExecute"] : [])
 
 
   packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], var.extra_packages_to_install)
@@ -292,7 +292,6 @@ ipam:
   clusterPoolIPv4PodCIDRList:
    - ${local.cluster_cidr_ipv4}
 devices: "eth1"
-agent-not-ready-taint-key: "CriticalAddonsOnly"
 EOT
 }
 


### PR DESCRIPTION
This fixes #270. 

@t1murl @PurpleBooth This turned out easier than I thought.

I tested by forcefully rebooting the nodes with a custom kured-config that checks every minute and manually touching /var/run/reboot-required.

Everything works as it is supposed to! Turns out only the agent nodes need the taint; I gather this from the name of the Cilium config, where we can specify the key "agent-not-ready-taint-key".

In the testing, I also tried the cilium cli, which also worked. But did not produce an optimal config out of the box, so choosing to remain with the HelmChart definition for now.

Please forgive the diff; it shows some changes but not too many, as I created the branch late. But at least you'll get an idea. 

Unless you folks find something, I will push out this long-awaited fix ASAP.