### PR TITLE
Add Nginx ingress controller + various tweaks | ⚠️ Breaking changes in some variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <h2 align="center">Kube-Hetzner</h2>
 
   <p align="center">
-    A highly optimized and auto-upgradable, HA-default & Load-Balanced, Kubernetes cluster powered by k3s-on-MicroOS and deployed for peanuts on <a href="https://hetzner.com" target="_blank">Hetzner Cloud</a> 🤑 🚀
+    An optimal, easy-to-use, auto-upgradable, HA-default & Load-Balanced, Kubernetes cluster powered by k3s on MicroOS and deployed for peanuts on <a href="https://hetzner.com" target="_blank">Hetzner Cloud</a> 🤑 🚀
   </p>
   <hr />
 </p>
@@ -23,23 +23,24 @@
 
 [Hetzner Cloud](https://hetzner.com) is a good cloud provider that offers very affordable prices for cloud instances, with data center locations in both Europe and the US.
 
-This project aims to create an optimal and highly optimized Kubernetes installation that is easily maintained, secure and automatic upgrades. We aimed for functionality as close as possible to GKE's auto-pilot.
+This project aims to create a highly optimized Kubernetes installation that is easy to maintain, secure and automatically upgrades both the nodes and Kubernetes. We aimed for functionality as close as possible to GKE's Auto-Pilot.
 
-To achieve this, we built it on the shoulders of giants by choosing [openSUSE MicroOS](https://en.opensuse.org/Portal:MicroOS) as the base operating system and [k3s](https://k3s.io/) as the Kubernetes engine.
+To achieve this, we built it on the shoulders of giants by choosing [openSUSE MicroOS](https://en.opensuse.org/Portal:MicroOS) as the base operating system and [k3s](https://k3s.io/) as the k8s engine.
 
 _Please note that we are not affiliates of Hetzner; this is just an open-source project striving to be an optimal solution for deploying and maintaining Kubernetes on Hetzner Cloud._
 
 ### Features
 
-- Maintenance-free with auto-upgrade to the latest version of MicroOS and k3s.
+- Maintenance-free with auto-upgrades to the latest version of MicroOS and k3s.
 - Proper use of the Hetzner private network to minimize latency and remove the need for encryption.
+- Traefik or Nginx as ingress controller attached to a Hetzner load balancer with Proxy Protocol turned on.
 - Automatic HA with the default setting of three control-plane nodes and two agent nodes.
 - Super-HA: Nodepools for both control-plane and agent nodes can be in different locations.
 - Possibility to have a single node cluster with a proper ingress controller.
+- Can use Klipper as an "on-metal" LB instead of the Hetzner LB.
 - Ability to add nodes and nodepools when the cluster is running.
-- Traefik ingress controller attached to a Hetzner load balancer with proxy protocol turned on.
-- Possibility to turn Longhorn on, and optionally also turn Hetzner CSI off.
-- Ability to switch from Flannel to Calico or Cilium as CNI.
+- Possibility to turn Longhorn (using either Hetzner volumes or node storage), and/or Hetzner CSI.
+- Choose between Flannel (default), Calico, or Cilium as CNI.
 - Tons of flexible configuration options to suit all needs.
 
 _It uses Terraform to deploy as it's easy to use, and Hetzner provides a great [Hetzner Terraform Provider](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs)._
@@ -162,6 +163,24 @@ Rarely needed, but can be handy in the long run. During the installation, we aut
 1. First create a duplicate of that file and name it `kustomization.yaml`, keeping the original file intact, in case you need to restore the old config.
 2. Edit the `kustomization.yaml` file; you want to go to the very bottom where you have the links to the different source files; grab the latest versions for each on Github, and replace. If present, remove any local reference to traefik_config.yaml, as Traefik is updated automatically by the system upgrade controller.
 3. Apply the the updated `kustomization.yaml` with `kubectl apply -k ./`.
+
+## Customizing the Cluster Components
+
+Most cluster components of Kube-Hetzner are deployed with the Rancher [Helm Chart](https://rancher.com/docs/k3s/latest/en/helm/) yaml definition and managed by the Helm Controller inside of k3s.
+
+By default, we strive to give you optimal defaults, but if you with to customize them, you can do so.
+
+### Before deploying
+
+In the case of Traefik, Rancher, and Longhorn, we provide you with variables to configure everything you need.
+
+On top of the above, for Nginx, Rancher, Cilium and Longhorn, for maximum flexibility, we give you the ability to add a Helm values.yaml file (for instance, `cilium_values.yaml`) to the root of your module, the same place where you have your `kube.tf` file. _You can find a `_values.yaml.example` value file for each listed component at the root of this project._
+
+### After deploying
+
+Once the Cluster is up and running, you can easily customize many components like Traefik, Nginx, Rancher, Cilium, Cert-Manager and Longhorn by using HelmChartConfig definitions. See the [examples](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner#examples) section, for more information.
+
+For other components like Calico and Kured (which uses manifests), we automatically save a `kustomization_backup.yaml` file in the root of your module during the deploy, so you can use that as a starting point. This is also useful when creating the HelmChartConfig definitions, as both HelmChart and HelmChartConfig definitions are very similar.
 
 ## Examples
 

--- a/data.tf
+++ b/data.tf
@@ -16,3 +16,10 @@ data "github_release" "kured" {
   owner       = "weaveworks"
   retrieve_by = "latest"
 }
+
+data "hcloud_load_balancer" "cluster" {
+  count = local.using_klipper_lb ? 0 : local.ingress_controller == "none" ? 0 : 1
+  name  = var.cluster_name
+
+  depends_on = [null_resource.kustomization]
+}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,123 +1,125 @@
 <!-- BEGIN_TF_DOCS -->
+
 ### Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.0.0 |
-| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | >= 1.35.1 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
-| <a name="requirement_remote"></a> [remote](#requirement\_remote) | >= 0.0.23 |
+| Name                                                                     | Version   |
+| ------------------------------------------------------------------------ | --------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.2.0  |
+| <a name="requirement_github"></a> [github](#requirement_github)          | >= 4.0.0  |
+| <a name="requirement_hcloud"></a> [hcloud](#requirement_hcloud)          | >= 1.35.1 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | >= 2.0.0  |
+| <a name="requirement_remote"></a> [remote](#requirement_remote)          | >= 0.0.23 |
 
 ### Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 4.0.0 |
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.35.1 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_remote"></a> [remote](#provider\_remote) | >= 0.0.23 |
+| Name                                                      | Version   |
+| --------------------------------------------------------- | --------- |
+| <a name="provider_github"></a> [github](#provider_github) | >= 4.0.0  |
+| <a name="provider_hcloud"></a> [hcloud](#provider_hcloud) | >= 1.35.1 |
+| <a name="provider_local"></a> [local](#provider_local)    | >= 2.0.0  |
+| <a name="provider_null"></a> [null](#provider_null)       | n/a       |
+| <a name="provider_random"></a> [random](#provider_random) | n/a       |
+| <a name="provider_remote"></a> [remote](#provider_remote) | >= 0.0.23 |
 
 ### Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_agents"></a> [agents](#module\_agents) | ./modules/host | n/a |
-| <a name="module_control_planes"></a> [control\_planes](#module\_control\_planes) | ./modules/host | n/a |
+| Name                                                                          | Source         | Version |
+| ----------------------------------------------------------------------------- | -------------- | ------- |
+| <a name="module_agents"></a> [agents](#module_agents)                         | ./modules/host | n/a     |
+| <a name="module_control_planes"></a> [control_planes](#module_control_planes) | ./modules/host | n/a     |
 
 ### Resources
 
-| Name | Type |
-|------|------|
-| [hcloud_firewall.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall) | resource |
-| [hcloud_load_balancer.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer) | resource |
-| [hcloud_load_balancer_network.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_network) | resource |
-| [hcloud_load_balancer_service.load_balancer_service](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_service) | resource |
-| [hcloud_load_balancer_target.load_balancer_target](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_target) | resource |
-| [hcloud_network.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network) | resource |
-| [hcloud_network_subnet.agent](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet) | resource |
-| [hcloud_network_subnet.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet) | resource |
-| [hcloud_placement_group.agent](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/placement_group) | resource |
-| [hcloud_placement_group.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/placement_group) | resource |
-| [hcloud_ssh_key.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/ssh_key) | resource |
-| [hcloud_volume.longhorn_volume](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/volume) | resource |
-| [local_file.kustomization_backup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_sensitive_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
-| [null_resource.agents](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.configure_longhorn_volume](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.control_planes](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.destroy_traefik_loadbalancer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.first_control_plane](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.kustomization](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [random_password.k3s_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.rancher_bootstrap](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [github_release.hetzner_ccm](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [github_release.hetzner_csi](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [github_release.kured](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [hcloud_load_balancer.traefik](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/load_balancer) | data source |
-| [remote_file.kubeconfig](https://registry.terraform.io/providers/tenstad/remote/latest/docs/data-sources/file) | data source |
-| [remote_file.kustomization_backup](https://registry.terraform.io/providers/tenstad/remote/latest/docs/data-sources/file) | data source |
+| Name                                                                                                                                                          | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [hcloud_firewall.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall)                                             | resource    |
+| [hcloud_load_balancer.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer)                         | resource    |
+| [hcloud_load_balancer_network.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_network)         | resource    |
+| [hcloud_load_balancer_service.load_balancer_service](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_service) | resource    |
+| [hcloud_load_balancer_target.load_balancer_target](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/load_balancer_target)    | resource    |
+| [hcloud_network.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network)                                               | resource    |
+| [hcloud_network_subnet.agent](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet)                               | resource    |
+| [hcloud_network_subnet.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/network_subnet)                       | resource    |
+| [hcloud_placement_group.agent](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/placement_group)                             | resource    |
+| [hcloud_placement_group.control_plane](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/placement_group)                     | resource    |
+| [hcloud_ssh_key.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/ssh_key)                                               | resource    |
+| [hcloud_volume.longhorn_volume](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/volume)                                     | resource    |
+| [local_file.kustomization_backup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file)                                         | resource    |
+| [local_sensitive_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file)                               | resource    |
+| [null_resource.agents](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                                 | resource    |
+| [null_resource.configure_longhorn_volume](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                              | resource    |
+| [null_resource.control_planes](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                         | resource    |
+| [null_resource.destroy_traefik_loadbalancer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                           | resource    |
+| [null_resource.first_control_plane](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                    | resource    |
+| [null_resource.kustomization](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                          | resource    |
+| [random_password.k3s_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                          | resource    |
+| [random_password.rancher_bootstrap](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                  | resource    |
+| [github_release.hetzner_ccm](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release)                                    | data source |
+| [github_release.hetzner_csi](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release)                                    | data source |
+| [github_release.kured](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release)                                          | data source |
+| [hcloud_load_balancer.traefik](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/load_balancer)                            | data source |
+| [remote_file.kubeconfig](https://registry.terraform.io/providers/tenstad/remote/latest/docs/data-sources/file)                                                | data source |
+| [remote_file.kustomization_backup](https://registry.terraform.io/providers/tenstad/remote/latest/docs/data-sources/file)                                      | data source |
 
 ### Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_agent_nodepools"></a> [agent\_nodepools](#input\_agent\_nodepools) | Number of agent nodes. | `list(any)` | `[]` | no |
-| <a name="input_allow_scheduling_on_control_plane"></a> [allow\_scheduling\_on\_control\_plane](#input\_allow\_scheduling\_on\_control\_plane) | Whether to allow non-control-plane workloads to run on the control-plane nodes | `bool` | `false` | no |
-| <a name="input_automatically_upgrade_k3s"></a> [automatically\_upgrade\_k3s](#input\_automatically\_upgrade\_k3s) | Whether to automatically upgrade k3s based on the selected channel | `bool` | `true` | no |
-| <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain of the cluster, used for reserve dns | `string` | `""` | no |
-| <a name="input_block_icmp_ping_in"></a> [block\_icmp\_ping\_in](#input\_block\_icmp\_ping\_in) | Block ICMP ping in | `bool` | `false` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | `"k3s"` | no |
-| <a name="input_cni_plugin"></a> [cni\_plugin](#input\_cni\_plugin) | CNI plugin for k3s | `string` | `"flannel"` | no |
-| <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |
-| <a name="input_disable_hetzner_csi"></a> [disable\_hetzner\_csi](#input\_disable\_hetzner\_csi) | Disable hetzner csi driver | `bool` | `false` | no |
-| <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico and cilium) | `bool` | `false` | no |
-| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner | `list(string)` | <pre>[<br>  "1.1.1.1",<br>  " 1.0.0.1",<br>  "8.8.8.8"<br>]</pre> | no |
-| <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable cert manager | `bool` | `false` | no |
-| <a name="input_enable_longhorn"></a> [enable\_longhorn](#input\_enable\_longhorn) | Enable Longhorn | `bool` | `false` | no |
-| <a name="input_enable_rancher"></a> [enable\_rancher](#input\_enable\_rancher) | Enable rancher | `bool` | `false` | no |
-| <a name="input_extra_firewall_rules"></a> [extra\_firewall\_rules](#input\_extra\_firewall\_rules) | Additional firewall rules to apply to the cluster | `list(any)` | `[]` | no |
-| <a name="input_extra_packages_to_install"></a> [extra\_packages\_to\_install](#input\_extra\_packages\_to\_install) | A list of additional packages to install on nodes | `list(string)` | `[]` | no |
-| <a name="input_hcloud_ssh_key_id"></a> [hcloud\_ssh\_key\_id](#input\_hcloud\_ssh\_key\_id) | If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module. | `string` | `null` | no |
-| <a name="input_hcloud_token"></a> [hcloud\_token](#input\_hcloud\_token) | Hetzner Cloud API Token | `string` | n/a | yes |
-| <a name="input_hetzner_ccm_version"></a> [hetzner\_ccm\_version](#input\_hetzner\_ccm\_version) | Version of Kubernetes Cloud Controller Manager for Hetzner Cloud | `string` | `null` | no |
-| <a name="input_hetzner_csi_version"></a> [hetzner\_csi\_version](#input\_hetzner\_csi\_version) | Version of Container Storage Interface driver for Hetzner Cloud | `string` | `null` | no |
-| <a name="input_initial_k3s_channel"></a> [initial\_k3s\_channel](#input\_initial\_k3s\_channel) | Allows you to specify an initial k3s channel | `string` | `"stable"` | no |
-| <a name="input_kured_version"></a> [kured\_version](#input\_kured\_version) | Version of Kured | `string` | `null` | no |
-| <a name="input_load_balancer_disable_ipv6"></a> [load\_balancer\_disable\_ipv6](#input\_load\_balancer\_disable\_ipv6) | Disable ipv6 for the load balancer | `bool` | `false` | no |
-| <a name="input_load_balancer_location"></a> [load\_balancer\_location](#input\_load\_balancer\_location) | Default load balancer location | `string` | `"fsn1"` | no |
-| <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Default load balancer server type | `string` | `"lb11"` | no |
-| <a name="input_longhorn_fstype"></a> [longhorn\_fstype](#input\_longhorn\_fstype) | The longhorn fstype | `string` | `"ext4"` | no |
-| <a name="input_longhorn_replica_count"></a> [longhorn\_replica\_count](#input\_longhorn\_replica\_count) | Number of replicas per longhorn volume | `number` | `3` | no |
-| <a name="input_metrics_server_enabled"></a> [metrics\_server\_enabled](#input\_metrics\_server\_enabled) | Whether to enable or disbale k3s mertric server | `bool` | `true` | no |
-| <a name="input_network_region"></a> [network\_region](#input\_network\_region) | Default region for network | `string` | `"eu-central"` | no |
-| <a name="input_placement_group_disable"></a> [placement\_group\_disable](#input\_placement\_group\_disable) | Whether to disable placement groups | `bool` | `false` | no |
-| <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Rancher bootstrap password | `string` | `""` | no |
-| <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Enable rancher | `string` | `"rancher.example.com"` | no |
-| <a name="input_rancher_install_channel"></a> [rancher\_install\_channel](#input\_rancher\_install\_channel) | Rancher install channel | `string` | `"latest"` | no |
-| <a name="input_rancher_registration_manifest_url"></a> [rancher\_registration\_manifest\_url](#input\_rancher\_registration\_manifest\_url) | The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/) | `string` | `""` | no |
-| <a name="input_ssh_additional_public_keys"></a> [ssh\_additional\_public\_keys](#input\_ssh\_additional\_public\_keys) | Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes | `list(string)` | `[]` | no |
-| <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port. | `number` | `22` | no |
-| <a name="input_ssh_private_key"></a> [ssh\_private\_key](#input\_ssh\_private\_key) | SSH private Key. | `string` | n/a | yes |
-| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH public Key. | `string` | n/a | yes |
-| <a name="input_traefik_acme_email"></a> [traefik\_acme\_email](#input\_traefik\_acme\_email) | Email used to recieved expiration notice for certificate | `string` | `false` | no |
-| <a name="input_traefik_acme_tls"></a> [traefik\_acme\_tls](#input\_traefik\_acme\_tls) | Whether to include the TLS configuration with the Traefik configuration | `bool` | `false` | no |
-| <a name="input_traefik_additional_options"></a> [traefik\_additional\_options](#input\_traefik\_additional\_options) | n/a | `list(string)` | `[]` | no |
-| <a name="input_traefik_enabled"></a> [traefik\_enabled](#input\_traefik\_enabled) | Whether to enable or disbale k3s traefik installation | `bool` | `true` | no |
-| <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name | `bool` | `true` | no |
-| <a name="input_use_control_plane_lb"></a> [use\_control\_plane\_lb](#input\_use\_control\_plane\_lb) | When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability | `bool` | `false` | no |
-| <a name="input_use_klipper_lb"></a> [use\_klipper\_lb](#input\_use\_klipper\_lb) | Use klipper load balancer | `bool` | `false` | no |
+| Name                                                                                                                                 | Description                                                                                                                                            | Type           | Default                                                        | Required |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------------------- | :------: |
+| <a name="input_agent_nodepools"></a> [agent_nodepools](#input_agent_nodepools)                                                       | Number of agent nodes.                                                                                                                                 | `list(any)`    | `[]`                                                           |    no    |
+| <a name="input_allow_scheduling_on_control_plane"></a> [allow_scheduling_on_control_plane](#input_allow_scheduling_on_control_plane) | Whether to allow non-control-plane workloads to run on the control-plane nodes                                                                         | `bool`         | `false`                                                        |    no    |
+| <a name="input_automatically_upgrade_k3s"></a> [automatically_upgrade_k3s](#input_automatically_upgrade_k3s)                         | Whether to automatically upgrade k3s based on the selected channel                                                                                     | `bool`         | `true`                                                         |    no    |
+| <a name="input_base_domain"></a> [base_domain](#input_base_domain)                                                                   | Base domain of the cluster, used for reserve dns                                                                                                       | `string`       | `""`                                                           |    no    |
+| <a name="input_block_icmp_ping_in"></a> [block_icmp_ping_in](#input_block_icmp_ping_in)                                              | Block ICMP ping in                                                                                                                                     | `bool`         | `false`                                                        |    no    |
+| <a name="input_cluster_name"></a> [cluster_name](#input_cluster_name)                                                                | Name of the cluster                                                                                                                                    | `string`       | `"k3s"`                                                        |    no    |
+| <a name="input_cni_plugin"></a> [cni_plugin](#input_cni_plugin)                                                                      | CNI plugin for k3s                                                                                                                                     | `string`       | `"flannel"`                                                    |    no    |
+| <a name="input_control_plane_nodepools"></a> [control_plane_nodepools](#input_control_plane_nodepools)                               | Number of control plane nodes.                                                                                                                         | `list(any)`    | `[]`                                                           |    no    |
+| <a name="input_disable_hetzner_csi"></a> [disable_hetzner_csi](#input_disable_hetzner_csi)                                           | Disable hetzner csi driver                                                                                                                             | `bool`         | `false`                                                        |    no    |
+| <a name="input_disable_network_policy"></a> [disable_network_policy](#input_disable_network_policy)                                  | Disable k3s default network policy controller (default false, automatically true for calico and cilium)                                                | `bool`         | `false`                                                        |    no    |
+| <a name="input_dns_servers"></a> [dns_servers](#input_dns_servers)                                                                   | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner                                                      | `list(string)` | <pre>[<br> "1.1.1.1",<br> " 1.0.0.1",<br> "8.8.8.8"<br>]</pre> |    no    |
+| <a name="input_enable_cert_manager"></a> [enable_cert_manager](#input_enable_cert_manager)                                           | Enable cert manager                                                                                                                                    | `bool`         | `false`                                                        |    no    |
+| <a name="input_enable_longhorn"></a> [enable_longhorn](#input_enable_longhorn)                                                       | Enable Longhorn                                                                                                                                        | `bool`         | `false`                                                        |    no    |
+| <a name="input_enable_rancher"></a> [enable_rancher](#input_enable_rancher)                                                          | Enable rancher                                                                                                                                         | `bool`         | `false`                                                        |    no    |
+| <a name="input_extra_firewall_rules"></a> [extra_firewall_rules](#input_extra_firewall_rules)                                        | Additional firewall rules to apply to the cluster                                                                                                      | `list(any)`    | `[]`                                                           |    no    |
+| <a name="input_extra_packages_to_install"></a> [extra_packages_to_install](#input_extra_packages_to_install)                         | A list of additional packages to install on nodes                                                                                                      | `list(string)` | `[]`                                                           |    no    |
+| <a name="input_hcloud_ssh_key_id"></a> [hcloud_ssh_key_id](#input_hcloud_ssh_key_id)                                                 | If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module.                                        | `string`       | `null`                                                         |    no    |
+| <a name="input_hcloud_token"></a> [hcloud_token](#input_hcloud_token)                                                                | Hetzner Cloud API Token                                                                                                                                | `string`       | n/a                                                            |   yes    |
+| <a name="input_hetzner_ccm_version"></a> [hetzner_ccm_version](#input_hetzner_ccm_version)                                           | Version of Kubernetes Cloud Controller Manager for Hetzner Cloud                                                                                       | `string`       | `null`                                                         |    no    |
+| <a name="input_hetzner_csi_version"></a> [hetzner_csi_version](#input_hetzner_csi_version)                                           | Version of Container Storage Interface driver for Hetzner Cloud                                                                                        | `string`       | `null`                                                         |    no    |
+| <a name="input_initial_k3s_channel"></a> [initial_k3s_channel](#input_initial_k3s_channel)                                           | Allows you to specify an initial k3s channel                                                                                                           | `string`       | `"stable"`                                                     |    no    |
+| <a name="input_kured_version"></a> [kured_version](#input_kured_version)                                                             | Version of Kured                                                                                                                                       | `string`       | `null`                                                         |    no    |
+| <a name="input_load_balancer_disable_ipv6"></a> [load_balancer_disable_ipv6](#input_load_balancer_disable_ipv6)                      | Disable ipv6 for the load balancer                                                                                                                     | `bool`         | `false`                                                        |    no    |
+| <a name="input_load_balancer_location"></a> [load_balancer_location](#input_load_balancer_location)                                  | Default load balancer location                                                                                                                         | `string`       | `"fsn1"`                                                       |    no    |
+| <a name="input_load_balancer_type"></a> [load_balancer_type](#input_load_balancer_type)                                              | Default load balancer server type                                                                                                                      | `string`       | `"lb11"`                                                       |    no    |
+| <a name="input_longhorn_fstype"></a> [longhorn_fstype](#input_longhorn_fstype)                                                       | The longhorn fstype                                                                                                                                    | `string`       | `"ext4"`                                                       |    no    |
+| <a name="input_longhorn_replica_count"></a> [longhorn_replica_count](#input_longhorn_replica_count)                                  | Number of replicas per longhorn volume                                                                                                                 | `number`       | `3`                                                            |    no    |
+| <a name="input_enable_metrics_server"></a> [enable_metrics_server](#input_enable_metrics_server)                                   | Whether to enable or disbale k3s mertric server                                                                                                        | `bool`         | `true`                                                         |    no    |
+| <a name="input_network_region"></a> [network_region](#input_network_region)                                                          | Default region for network                                                                                                                             | `string`       | `"eu-central"`                                                 |    no    |
+| <a name="input_placement_group_disable"></a> [placement_group_disable](#input_placement_group_disable)                               | Whether to disable placement groups                                                                                                                    | `bool`         | `false`                                                        |    no    |
+| <a name="input_rancher_bootstrap_password"></a> [rancher_bootstrap_password](#input_rancher_bootstrap_password)                      | Rancher bootstrap password                                                                                                                             | `string`       | `""`                                                           |    no    |
+| <a name="input_rancher_hostname"></a> [rancher_hostname](#input_rancher_hostname)                                                    | Enable rancher                                                                                                                                         | `string`       | `"rancher.example.com"`                                        |    no    |
+| <a name="input_rancher_install_channel"></a> [rancher_install_channel](#input_rancher_install_channel)                               | Rancher install channel                                                                                                                                | `string`       | `"latest"`                                                     |    no    |
+| <a name="input_rancher_registration_manifest_url"></a> [rancher_registration_manifest_url](#input_rancher_registration_manifest_url) | The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)          | `string`       | `""`                                                           |    no    |
+| <a name="input_ssh_additional_public_keys"></a> [ssh_additional_public_keys](#input_ssh_additional_public_keys)                      | Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes                                                     | `list(string)` | `[]`                                                           |    no    |
+| <a name="input_ssh_port"></a> [ssh_port](#input_ssh_port)                                                                            | SSH port.                                                                                                                                              | `number`       | `22`                                                           |    no    |
+| <a name="input_ssh_private_key"></a> [ssh_private_key](#input_ssh_private_key)                                                       | SSH private Key.                                                                                                                                       | `string`       | n/a                                                            |   yes    |
+| <a name="input_ssh_public_key"></a> [ssh_public_key](#input_ssh_public_key)                                                          | SSH public Key.                                                                                                                                        | `string`       | n/a                                                            |   yes    |
+| <a name="input_traefik_acme_email"></a> [traefik_acme_email](#input_traefik_acme_email)                                              | Email used to recieved expiration notice for certificate                                                                                               | `string`       | `false`                                                        |    no    |
+| <a name="input_traefik_acme_tls"></a> [traefik_acme_tls](#input_traefik_acme_tls)                                                    | Whether to include the TLS configuration with the Traefik configuration                                                                                | `bool`         | `false`                                                        |    no    |
+| <a name="input_traefik_additional_options"></a> [traefik_additional_options](#input_traefik_additional_options)                      | n/a                                                                                                                                                    | `list(string)` | `[]`                                                           |    no    |
+| <a name="input_enable_traefik"></a> [enable_traefik](#input_enable_traefik)                                                       | Whether to enable or disbale k3s traefik installation                                                                                                  | `bool`         | `true`                                                         |    no    |
+| <a name="input_use_cluster_name_in_node_name"></a> [use_cluster_name_in_node_name](#input_use_cluster_name_in_node_name)             | Whether to use the cluster name in the node name                                                                                                       | `bool`         | `true`                                                         |    no    |
+| <a name="input_use_control_plane_lb"></a> [use_control_plane_lb](#input_use_control_plane_lb)                                        | When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability | `bool`         | `false`                                                        |    no    |
+| <a name="input_enable_klipper_metal_lb"></a> [enable_klipper_metal_lb](#input_enable_klipper_metal_lb)                                                          | Use klipper load balancer                                                                                                                              | `bool`         | `false`                                                        |    no    |
 
 ### Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_agents_public_ipv4"></a> [agents\_public\_ipv4](#output\_agents\_public\_ipv4) | The public IPv4 addresses of the agent server. |
-| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Shared suffix for all resources belonging to this cluster. |
-| <a name="output_control_planes_public_ipv4"></a> [control\_planes\_public\_ipv4](#output\_control\_planes\_public\_ipv4) | The public IPv4 addresses of the controlplane server. |
-| <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Structured kubeconfig data to supply to other providers |
-| <a name="output_kubeconfig_file"></a> [kubeconfig\_file](#output\_kubeconfig\_file) | Kubeconfig file content with external IP address |
-| <a name="output_load_balancer_public_ipv4"></a> [load\_balancer\_public\_ipv4](#output\_load\_balancer\_public\_ipv4) | The public IPv4 address of the Hetzner load balancer |
+| Name                                                                                                              | Description                                                |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| <a name="output_agents_public_ipv4"></a> [agents_public_ipv4](#output_agents_public_ipv4)                         | The public IPv4 addresses of the agent server.             |
+| <a name="output_cluster_name"></a> [cluster_name](#output_cluster_name)                                           | Shared suffix for all resources belonging to this cluster. |
+| <a name="output_control_planes_public_ipv4"></a> [control_planes_public_ipv4](#output_control_planes_public_ipv4) | The public IPv4 addresses of the controlplane server.      |
+| <a name="output_kubeconfig"></a> [kubeconfig](#output_kubeconfig)                                                 | Structured kubeconfig data to supply to other providers    |
+| <a name="output_kubeconfig_file"></a> [kubeconfig_file](#output_kubeconfig_file)                                  | Kubeconfig file content with external IP address           |
+| <a name="output_load_balancer_public_ipv4"></a> [load_balancer_public_ipv4](#output_load_balancer_public_ipv4)    | The public IPv4 address of the Hetzner load balancer       |
+
 <!-- END_TF_DOCS -->

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -148,9 +148,9 @@ module "kube-hetzner" {
   # longhorn_replica_count = 1
 
   # When you enable Longhorn, you can go with the default settings and just modify the above two variables OR you can copy the longhorn_values.yaml.example
-  # file to longhorn_value.yaml and put it at the base of your own module, next to your kube.tf, this is Longhorn's own helm values file, 
-  # all possible values can be found here https://github.com/longhorn/longhorn/blob/master/chart/values.yaml. If that file is present, the system will use it
-  # during the deploy, if not it will use the default values with the two variable above that can be customized.
+  # file to longhorn_value.yaml and put it at the base of your own module, next to your kube.tf, this is Longhorn's own helm values file. 
+  # If that file is present, the system will use it during the deploy, if not it will use the default values with the two variable above that can be customized.
+  # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
 
   # Also, you choose to create a hetzner volume to be used with Longhorn. By default, it will use the nodes own storage space, BUT if you an attribute of
   # longhorn_volume_size with a value of 10 to 10000 GB to your agent nodepool definition, it will create and use the volume in question.
@@ -163,8 +163,24 @@ module "kube-hetzner" {
   # hetzner_ccm_version = ""
   # hetzner_csi_version = ""
 
-  # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available
+  # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available.
   # kured_version = ""
+
+  # If you want to enable the Nginx ingress controller instead of Traefik, you can set this to "true". Default is "false". 
+  # FOR THIS TO NOT BE IGNORED, you also need to set "enable_traefik = false".
+  # By the default we load an optimal Nginx ingress controller config for Hetzner, however you may need to tweak it to your needs, so to do,
+  # we allow you to add a nginx_values.yaml file to the root of your module, next to the kube.tf file, it is simply a helm values config file.
+  # See the nginx_values.yaml.example located at the root of this project.
+  # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
+  # enable_nginx = true
+
+  # If you want to disable the Traefik ingress controller, to use the Nginx ingress controller for instance, you can can set this to "false". Default is "true".
+  # enable_traefik = false
+  
+  # Use the klipper LB, instead of the default Hetzner one, that has an advantage of dropping the cost of the setup,
+  # Automatically "true" in the case of single node cluster.
+  # It can work with any ingress controller that you choose to deploy.
+  # enable_klipper_metal_lb = "true"
 
   # We give you the possibility to use letsencrypt directly with Traefik because it's an easy setup, however it's not optimal,
   # as the free version of Traefik causes a little bit of downtime when when the certificates get renewed. For proper SSL management,
@@ -172,11 +188,13 @@ module "kube-hetzner" {
   # traefik_acme_tls = true
   # traefik_acme_email = "mail@example.com"
 
-  # If you want to disable the Traefik ingress controller, you can can set this to "false". Default is "true".
-  # traefik_enabled = false
+  # If you want to configure additional Arguments for traefik, enter them here as a list and in the form of traefik CLI arguments; see https://doc.traefik.io/traefik/reference/static-configuration/cli/
+  # They are the options that go into the additionalArguments section of the Traefik helm values file.
+  # Example: traefik_additional_options = ["--log.level=DEBUG", "--tracing=true"]
+  # traefik_additional_options = []
 
   # If you want to disable the metric server, you can! Default is "true".
-  # metrics_server_enabled = false
+  # enable_metrics_server = false
 
   # If you want to allow non-control-plane workloads to run on the control-plane nodes, set "true" below. The default is "false".
   # True by default for single node clusters.
@@ -216,18 +234,9 @@ module "kube-hetzner" {
   #   }
   # ]
 
-  # If you want to configure additional Arguments for traefik, enter them here as a list and in the form of traefik CLI arguments; see https://doc.traefik.io/traefik/reference/static-configuration/cli/
-  # Example: traefik_additional_options = ["--log.level=DEBUG", "--tracing=true"]
-  # traefik_additional_options = []
-
-  # Use the klipper LB, instead of the default Hetzner one, that has an advantage of dropping the cost of the setup,
-  # but you would need to point your DNS to every schedulable IPs in your cluster (usually agents). The default is "false".
-  # Automatically "true" in the case of single node cluster.
-  # use_klipper_lb = "true"
-
   # If you want to configure a different CNI for k3s, use this flag
   # possible values: flannel (Default), calico, and cilium
-  # CAVEATS: Calico is not supported when not using the Hetzner LB (like when use_klipper_lb is set to true or when using a single node cluster),
+  # CAVEATS: Calico is not supported when not using the Hetzner LB (like when enable_klipper_metal_lb is set to true or when using a single node cluster),
   # because of the following issue https://github.com/k3s-io/klipper-lb/issues/6.
   # As for Cilium, we allow infinite configurations, please check the CNI section of the readme over at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/#cni.
   # cni_plugin = "cilium"
@@ -258,21 +267,21 @@ module "kube-hetzner" {
   # When Rancher is enabled, it automatically installs cert-manager too, and it uses rancher's own self-signed certificates.
   # See for options https://rancher.com/docs/rancher/v2.0-v2.4/en/installation/resources/advanced/helm2/helm-rancher/#choose-your-ssl-configuration
   # The easiest thing is to leave everything as is (using the default rancher self-signed certificate) and put Cloudflare in front of it.
-  # As for the number of replicas, it is set to the numbe of control plane nodes.
-  # You can customized all of the above by creating and applying a HelmChartConfig to pass the helm chart values of your choice.
-  # See https://rancher.com/docs/k3s/latest/en/helm/ 
-  # and https://rancher.com/docs/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/
+  # As for the number of replicas, by default it is set to the numbe of control plane nodes.
+  # You can customized all of the above by adding a rancher_values.yaml file at the root of your module, which is just a helm values file. 
+  # See the rancher_values.yaml.example file located at the root of the project.
+  # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
   # IMPORTANT: Rancher's install is quite memory intensive, you will require at least 4GB if RAM, meaning cx21 server type (for your control plane).
+  # ALSO, in order for Rancher to successfully deploy, you have to set the "rancher_hostname".
   # enable_rancher = true
+
+  # If using Rancher you can set the Rancher hostname, it must be unique hostname even if you do not use it.
+  # If not pointing the DNS, you can just port-forward locally via kubectl to get access to the dashboard.
+  # rancher_hostname = "rancher.xyz.dev"
 
   # When Rancher is deployed, by default is uses the "latest" channel. But this can be customized.
   # The allowed values are "stable" or "latest".
   # rancher_install_channel = "stable"
-
-  # Here you can set the Rancher hostname, the default is "rancher.example.com".
-  # It is a required value when using rancher, but up to you to point the DNS to it or not. 
-  # You can also not point the DNS, and just port-forward locally via kubectl to get access to the dashboard.
-  # rancher_hostname = "rancher.xyz.dev"
 
   # Finally, you can specify a bootstrap-password for your rancher instance. Minimum 48 characters long!
   # If you leave empty, one will be generated for you.

--- a/main.tf
+++ b/main.tf
@@ -60,13 +60,6 @@ resource "hcloud_placement_group" "agent" {
   type  = "spread"
 }
 
-data "hcloud_load_balancer" "cluster" {
-  count = local.using_klipper_lb ? 0 : var.traefik_enabled == false ? 0 : 1
-  name  = "${var.cluster_name}-lb"
-
-  depends_on = [null_resource.kustomization]
-}
-
 resource "null_resource" "destroy_cluster_loadbalancer" {
 
   # this only gets triggered before total destruction of the cluster, but when the necessary elements to run the commands are still available

--- a/nginx_ingress_values.yaml.example
+++ b/nginx_ingress_values.yaml.example
@@ -1,0 +1,18 @@
+# All Nginx Ingress helm values can be found at https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+
+controller:
+  # These options can be found here https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+  config:
+    "use-forwarded-headers": "true"
+    "compute-full-forwarded-for": "true"
+    "use-proxy-protocol": "true"
+  service:
+    annotations:
+      "load-balancer.hetzner.cloud/name": "k3s"
+      # make hetzners load-balancer connect to our nodes via our private k3s
+      "load-balancer.hetzner.cloud/use-private-ip": "true"
+      # keep hetzner-ccm from exposing our private ingress ip, which in general isn't routeable from the public internet
+      "load-balancer.hetzner.cloud/disable-private-ingress": "true"
+      "load-balancer.hetzner.cloud/location": "nbg1"
+      "load-balancer.hetzner.cloud/type": "lb11"
+      "load-balancer.hetzner.cloud/uses-proxyprotocol": "true"

--- a/output.tf
+++ b/output.tf
@@ -19,7 +19,7 @@ output "agents_public_ipv4" {
 
 output "load_balancer_public_ipv4" {
   description = "The public IPv4 address of the Hetzner load balancer"
-  value       = (local.using_klipper_lb == true || var.traefik_enabled == false) ? null : data.hcloud_load_balancer.cluster[0].ipv4
+  value       = local.using_klipper_lb || local.ingress_controller == "none" ? null : data.hcloud_load_balancer.cluster[0].ipv4
 }
 
 output "kubeconfig_file" {

--- a/rancher_values.yaml.example
+++ b/rancher_values.yaml.example
@@ -1,0 +1,8 @@
+# All Rancher helm values can be found at https://rancher.com/docs/rancher/v2.5/en/installation/install-rancher-on-k8s/chart-options/
+
+ingress:
+  tls:
+    source: "rancher"
+hostname: "rancher.example.com"
+replicas: 1
+bootstrapPassword: "supermario"

--- a/templates/nginx_ingress.yaml.tpl
+++ b/templates/nginx_ingress.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: ngx
+  namespace: kube-system
+spec:
+  chart: nginx-ingress
+  repo: https://helm.nginx.com/stable
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    ${values}

--- a/templates/rancher.yaml.tpl
+++ b/templates/rancher.yaml.tpl
@@ -14,9 +14,4 @@ spec:
   repo: https://releases.rancher.com/server-charts/${rancher_install_channel}
   targetNamespace: cattle-system
   valuesContent: |-
-    ingress:
-      tls:
-        source: rancher
-    hostname: ${rancher_hostname}
-    replicas: ${number_control_plane_nodes}
-    bootstrapPassword: ${rancher_bootstrap_password}
+    ${values}

--- a/templates/traefik_config.yaml.tpl
+++ b/templates/traefik_config.yaml.tpl
@@ -24,10 +24,12 @@ spec:
         "load-balancer.hetzner.cloud/uses-proxyprotocol": "true"
 %{ endif ~}
     additionalArguments:
+%{ if using_hetzner_lb ~}
       - "--entryPoints.web.proxyProtocol.trustedIPs=127.0.0.1/32,10.0.0.0/8"
       - "--entryPoints.websecure.proxyProtocol.trustedIPs=127.0.0.1/32,10.0.0.0/8"
       - "--entryPoints.web.forwardedHeaders.trustedIPs=127.0.0.1/32,10.0.0.0/8"
       - "--entryPoints.websecure.forwardedHeaders.trustedIPs=127.0.0.1/32,10.0.0.0/8"
+%{ endif ~}
 %{ for option in traefik_additional_options ~}
       - "${option}"
 %{ endfor ~}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "hcloud_token" {
-  description = "Hetzner Cloud API Token"
+  description = "Hetzner Cloud API Token."
   type        = string
   sensitive   = true
 }
 
 variable "ssh_port" {
-  description = "SSH port."
+  description = "The main SSH port to connect to the nodes."
   type        = number
   default     = 22
 
@@ -27,7 +27,7 @@ variable "ssh_private_key" {
 }
 
 variable "ssh_additional_public_keys" {
-  description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes"
+  description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes."
   type        = list(string)
   default     = []
 }
@@ -39,25 +39,25 @@ variable "hcloud_ssh_key_id" {
 }
 
 variable "network_region" {
-  description = "Default region for network"
+  description = "Default region for network."
   type        = string
   default     = "eu-central"
 }
 
 variable "load_balancer_location" {
-  description = "Default load balancer location"
+  description = "Default load balancer location."
   type        = string
   default     = "fsn1"
 }
 
 variable "load_balancer_type" {
-  description = "Default load balancer server type"
+  description = "Default load balancer server type."
   type        = string
   default     = "lb11"
 }
 
 variable "load_balancer_disable_ipv6" {
-  description = "Disable ipv6 for the load balancer"
+  description = "Disable ipv6 for the load balancer."
   type        = bool
   default     = false
 }
@@ -77,13 +77,13 @@ variable "agent_nodepools" {
 variable "hetzner_ccm_version" {
   type        = string
   default     = null
-  description = "Version of Kubernetes Cloud Controller Manager for Hetzner Cloud"
+  description = "Version of Kubernetes Cloud Controller Manager for Hetzner Cloud."
 }
 
 variable "hetzner_csi_version" {
   type        = string
   default     = null
-  description = "Version of Container Storage Interface driver for Hetzner Cloud"
+  description = "Version of Container Storage Interface driver for Hetzner Cloud."
 }
 
 variable "kured_version" {
@@ -92,40 +92,58 @@ variable "kured_version" {
   description = "Version of Kured"
 }
 
-variable "traefik_enabled" {
+variable "enable_nginx" {
+  type        = bool
+  default     = false
+  description = "Whether to enable or disbale the installation of the Nginx Ingress Controller."
+}
+
+variable "enable_klipper_metal_lb" {
+  type        = bool
+  default     = false
+  description = "Use klipper load balancer."
+}
+
+variable "enable_traefik" {
   type        = bool
   default     = true
-  description = "Whether to enable or disbale k3s traefik installation"
+  description = "Whether to enable or disable the installation of the Traefik Ingress Controller."
 }
 
 variable "traefik_acme_tls" {
   type        = bool
   default     = false
-  description = "Whether to include the TLS configuration with the Traefik configuration"
+  description = "Whether to include the TLS configuration with the Traefik configuration."
 }
 
 variable "traefik_acme_email" {
   type        = string
-  default     = false
-  description = "Email used to recieved expiration notice for certificate"
+  default     = ""
+  description = "Email used to recieved expiration notice for certificate."
+}
+
+variable "traefik_additional_options" {
+  type        = list(string)
+  default     = []
+  description = "Additional options to pass to Traefik as a list of strings. These are the ones that go into the additionalArguments section of the Traefik helm values file."
 }
 
 variable "allow_scheduling_on_control_plane" {
   type        = bool
   default     = false
-  description = "Whether to allow non-control-plane workloads to run on the control-plane nodes"
+  description = "Whether to allow non-control-plane workloads to run on the control-plane nodes."
 }
 
-variable "metrics_server_enabled" {
+variable "enable_metrics_server" {
   type        = bool
   default     = true
-  description = "Whether to enable or disbale k3s mertric server"
+  description = "Whether to enable or disbale k3s mertric server."
 }
 
 variable "initial_k3s_channel" {
   type        = string
   default     = "stable"
-  description = "Allows you to specify an initial k3s channel"
+  description = "Allows you to specify an initial k3s channel."
 
   validation {
     condition     = contains(["stable", "latest", "testing", "v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25"], var.initial_k3s_channel)
@@ -136,25 +154,25 @@ variable "initial_k3s_channel" {
 variable "automatically_upgrade_k3s" {
   type        = bool
   default     = true
-  description = "Whether to automatically upgrade k3s based on the selected channel"
+  description = "Whether to automatically upgrade k3s based on the selected channel."
 }
 
 variable "extra_firewall_rules" {
   type        = list(any)
   default     = []
-  description = "Additional firewall rules to apply to the cluster"
+  description = "Additional firewall rules to apply to the cluster."
 }
 
 variable "use_cluster_name_in_node_name" {
   type        = bool
   default     = true
-  description = "Whether to use the cluster name in the node name"
+  description = "Whether to use the cluster name in the node name."
 }
 
 variable "cluster_name" {
   type        = string
   default     = "k3s"
-  description = "Name of the cluster"
+  description = "Name of the cluster."
 
   validation {
     condition     = can(regex("^[a-z1-9\\-]+$", var.cluster_name))
@@ -165,7 +183,7 @@ variable "cluster_name" {
 variable "base_domain" {
   type        = string
   default     = ""
-  description = "Base domain of the cluster, used for reserve dns"
+  description = "Base domain of the cluster, used for reserve dns."
 
   validation {
     condition     = can(regex("^(?:(?:(?:[A-Za-z0-9])|(?:[A-Za-z0-9](?:[A-Za-z0-9\\-]+)?[A-Za-z0-9]))+(\\.))+([A-Za-z]{2,})([\\/?])?([\\/?][A-Za-z0-9\\-%._~:\\/?#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]+)?$", var.base_domain)) || var.base_domain == ""
@@ -173,44 +191,39 @@ variable "base_domain" {
   }
 }
 
-variable "traefik_additional_options" {
-  type    = list(string)
-  default = []
-}
-
 variable "placement_group_disable" {
   type        = bool
   default     = false
-  description = "Whether to disable placement groups"
+  description = "Whether to disable placement groups."
 }
 
 variable "disable_network_policy" {
   type        = bool
   default     = false
-  description = "Disable k3s default network policy controller (default false, automatically true for calico and cilium)"
+  description = "Disable k3s default network policy controller (default false, automatically true for calico and cilium)."
 }
 
 variable "cni_plugin" {
   type        = string
   default     = "flannel"
-  description = "CNI plugin for k3s"
+  description = "CNI plugin for k3s."
 
   validation {
     condition     = contains(["flannel", "calico", "cilium"], var.cni_plugin)
-    error_message = "cni_plugin must be one of \"flannel\", \"calico\", or \"cilium\""
+    error_message = "The cni_plugin must be one of \"flannel\", \"calico\", or \"cilium\"."
   }
 }
 
 variable "enable_longhorn" {
   type        = bool
   default     = false
-  description = "Enable Longhorn"
+  description = "Whether of not to enable Longhorn."
 }
 
 variable "longhorn_fstype" {
   type        = string
   default     = "ext4"
-  description = "The longhorn fstype"
+  description = "The longhorn fstype."
 
   validation {
     condition     = contains(["ext4", "xfs"], var.longhorn_fstype)
@@ -222,31 +235,31 @@ variable "longhorn_fstype" {
 variable "longhorn_replica_count" {
   type        = number
   default     = 3
-  description = "Number of replicas per longhorn volume"
+  description = "Number of replicas per longhorn volume."
 }
 
 variable "disable_hetzner_csi" {
   type        = bool
   default     = false
-  description = "Disable hetzner csi driver"
+  description = "Disable hetzner csi driver."
 }
 
 variable "enable_cert_manager" {
   type        = bool
   default     = false
-  description = "Enable cert manager"
+  description = "Enable cert manager."
 }
 
 variable "enable_rancher" {
   type        = bool
   default     = false
-  description = "Enable rancher"
+  description = "Enable rancher."
 }
 
 variable "rancher_install_channel" {
   type        = string
-  default     = "latest"
-  description = "Rancher install channel"
+  default     = "stable"
+  description = "The rancher installation channel."
 
   validation {
     condition     = contains(["stable", "latest"], var.rancher_install_channel)
@@ -256,13 +269,18 @@ variable "rancher_install_channel" {
 
 variable "rancher_hostname" {
   type        = string
-  default     = "rancher.example.com"
-  description = "Enable rancher"
+  default     = ""
+  description = "The rancher hostname."
+
+  validation {
+    condition     = can(regex("^(?:(?:(?:[A-Za-z0-9])|(?:[A-Za-z0-9](?:[A-Za-z0-9\\-]+)?[A-Za-z0-9]))+(\\.))+([A-Za-z]{2,})([\\/?])?([\\/?][A-Za-z0-9\\-%._~:\\/?#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]+)?$", var.rancher_hostname)) || var.rancher_hostname == ""
+    error_message = "It must be a valid domain name (FQDN)."
+  }
 }
 
 variable "rancher_registration_manifest_url" {
   type        = string
-  description = "The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)"
+  description = "The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)."
   default     = ""
   sensitive   = true
 }
@@ -270,7 +288,7 @@ variable "rancher_registration_manifest_url" {
 variable "rancher_bootstrap_password" {
   type        = string
   default     = ""
-  description = "Rancher bootstrap password"
+  description = "Rancher bootstrap password."
   sensitive   = true
 
   validation {
@@ -279,32 +297,26 @@ variable "rancher_bootstrap_password" {
   }
 }
 
-variable "use_klipper_lb" {
-  type        = bool
-  default     = false
-  description = "Use klipper load balancer"
-}
-
 variable "block_icmp_ping_in" {
   type        = bool
   default     = false
-  description = "Block ICMP ping in"
+  description = "Block entering ICMP ping."
 }
 
 variable "use_control_plane_lb" {
   type        = bool
   default     = false
-  description = "When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability"
+  description = "When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability."
 }
 
 variable "dns_servers" {
   type        = list(string)
   default     = ["1.1.1.1", " 1.0.0.1", "8.8.8.8"]
-  description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner"
+  description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner."
 }
 
 variable "extra_packages_to_install" {
   type        = list(string)
   default     = []
-  description = "A list of additional packages to install on nodes"
+  description = "A list of additional packages to install on nodes."
 }


### PR DESCRIPTION
This PR adds the Nginx ingress controller and the possibility to use a helm `_values.yaml` file for both it and Rancher. It also tweaks the variable names to make them more consistent.

Last but not least, a lot of the logic related to load-balancers, including Klipper, has been tweaked and cleaned up!

This fixes #293.