### PR TITLE
Tweaked server reboot process to avoid occasional errors

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -120,7 +120,7 @@ resource "hcloud_server" "server" {
   # Issue a reboot command.
   provisioner "local-exec" {
     command = <<-EOT
-      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -p ${var.ssh_port} root@${self.ipv4_address} '(sleep 2; reboot)&'; sleep 3
+      ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -p ${var.ssh_port} root@${self.ipv4_address} '(sleep 3; reboot)&'; sleep 3
     EOT
   }
 


### PR DESCRIPTION
This does a minor tweak to the waiting times to allow the snapshot to be considered before rebooting during the node base install process. It avoids an error where the new snapshot was not considered if the reboot came in too early.