### PR TITLE
Nginx-ingress to ingess-nginx

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -166,7 +166,7 @@ module "kube-hetzner" {
   # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available.
   # kured_version = ""
 
-  # If you want to enable the Nginx ingress controller instead of Traefik, you can set this to "true". Default is "false". 
+  # If you want to enable the Nginx ingress controller (https://kubernetes.github.io/ingress-nginx/) instead of Traefik, you can set this to "true". Default is "false". 
   # FOR THIS TO NOT BE IGNORED, you also need to set "enable_traefik = false".
   # By the default we load an optimal Nginx ingress controller config for Hetzner, however you may need to tweak it to your needs, so to do,
   # we allow you to add a nginx_ingress_values.yaml file to the root of your module, next to the kube.tf file, it is simply a helm values config file.

--- a/locals.tf
+++ b/locals.tf
@@ -89,7 +89,7 @@ locals {
   default_agent_taints         = concat([], var.cni_plugin == "cilium" ? ["node.cilium.io/agent-not-ready:NoExecute"] : [])
 
 
-  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client"] : [], var.extra_packages_to_install)
+  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs"] : [], var.extra_packages_to_install)
 
   # The following IPs are important to be whitelisted because they communicate with Hetzner services and enable the CCM and CSI to work properly.
   # Source https://github.com/hetznercloud/csi-driver/issues/204#issuecomment-848625566
@@ -290,7 +290,7 @@ locals {
   ingress_controller = var.enable_traefik ? "traefik" : var.enable_nginx ? "nginx" : "none"
   ingress_controller_service_names = {
     "traefik" = "traefik"
-    "nginx"   = "ngx-nginx-ingress"
+    "nginx"   = "ngx-ingress-nginx-controller"
   }
 
   ingress_controller_install_resources = {

--- a/nginx_ingress_values.yaml.example
+++ b/nginx_ingress_values.yaml.example
@@ -1,4 +1,5 @@
 # All Nginx Ingress helm values can be found at https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+# You can also have a look at https://kubernetes.github.io/ingress-nginx/, to understand how it works, and all the options at your disposal.
 
 controller:
   # These options can be found here https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/

--- a/templates/nginx_ingress.yaml.tpl
+++ b/templates/nginx_ingress.yaml.tpl
@@ -4,8 +4,8 @@ metadata:
   name: ngx
   namespace: kube-system
 spec:
-  chart: nginx-ingress
-  repo: https://helm.nginx.com/stable
+  chart: ingress-nginx
+  repo: https://kubernetes.github.io/ingress-nginx
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-


### PR DESCRIPTION
Changed from nginx-ingress to ingess-nginx, which was the intended version.

I also took the opportunity to fix a few tiny bugs in the creation of Longhorn volumes, no critical but present. Now fixed.