### PR TITLE
Set tls-san to external ip for control planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ brew install hcloud
 
 _A complete reference of all inputs, outputs, modules etc. can be found in the [terraform.md](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/docs/terraform.md) file._
 
-_It's important to realize that you do not even need to clone this git repo, as the module by default will be fetched from the Terraform registry. All you need, is to use the [kube.tf.example](https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example) file to make sure you get the format of your `kube.tf` file right._
+_It's important to realize that your kube.tf needs to reside in a NEW folder, not a clone of this git repo (the module by default will be fetched from the Terraform registry). All you need, is to re-use the [kube.tf.example](https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example) file to make sure you get the format right._
 
 ### 🎯 Installation
 

--- a/cilium_values.yaml.example
+++ b/cilium_values.yaml.example
@@ -11,13 +11,6 @@ ipam:
 # program. When not specified, probing will automatically detect devices.
 devices: "eth1"
 
-# -- Configure the encapsulation configuration for communication between nodes.
-# Possible values:
-#   - disabled (native routing works, however it feels that geneve is more stable, but we may be wrong)
-#   - vxlan
-#   - geneve (it's basically a better version of vxlan)
-tunnel: geneve
-
 # -- Configure Kubernetes specific configuration
 k8s:
   # -- requireIPv4PodCIDR enables waiting for Kubernetes to provide the PodCIDR

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -106,12 +106,12 @@ resource "null_resource" "control_planes" {
           node-label                  = each.value.labels
           node-taint                  = each.value.taints
           write-kubeconfig-mode       = "0644" # needed for import into rancher
-          tls-san = []
+          tls-san                     = []
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {
           tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
-        } : {
+          } : {
           tls-san = [
             module.control_planes[each.key].ipv4_address
           ]

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -86,32 +86,39 @@ resource "null_resource" "control_planes" {
 
   # Generating k3s server config file
   provisioner "file" {
-    content = yamlencode(merge({
-      node-name = module.control_planes[each.key].name
-      server = length(module.control_planes) == 1 ? null : "https://${
-        var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] :
-        module.control_planes[each.key].private_ipv4_address == module.control_planes[keys(module.control_planes)[0]].private_ipv4_address ?
-        module.control_planes[keys(module.control_planes)[1]].private_ipv4_address :
-      module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
-      token                       = random_password.k3s_token.result
-      disable-cloud-controller    = true
-      disable                     = local.disable_extras
-      kubelet-arg                 = ["cloud-provider=external", "volume-plugin-dir=/var/lib/kubelet/volumeplugins"]
-      kube-controller-manager-arg = "flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins"
-      flannel-iface               = "eth1"
-      node-ip                     = module.control_planes[each.key].private_ipv4_address
-      advertise-address           = module.control_planes[each.key].private_ipv4_address
-      node-label                  = each.value.labels
-      node-taint                  = each.value.taints
-      write-kubeconfig-mode       = "0644" # needed for import into rancher
-      },
-      lookup(local.cni_k3s_settings, var.cni_plugin, {}),
-      var.use_control_plane_lb ? {
-        tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
-      } : {}
-    ))
+    content = yamlencode(
+      merge(
+        {
+          node-name = module.control_planes[each.key].name
+          server = length(module.control_planes) == 1 ? null : "https://${
+            var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] :
+            module.control_planes[each.key].private_ipv4_address == module.control_planes[keys(module.control_planes)[0]].private_ipv4_address ?
+            module.control_planes[keys(module.control_planes)[1]].private_ipv4_address :
+          module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+          token                       = random_password.k3s_token.result
+          disable-cloud-controller    = true
+          disable                     = local.disable_extras
+          kubelet-arg                 = ["cloud-provider=external", "volume-plugin-dir=/var/lib/kubelet/volumeplugins"]
+          kube-controller-manager-arg = "flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins"
+          flannel-iface               = "eth1"
+          node-ip                     = module.control_planes[each.key].private_ipv4_address
+          advertise-address           = module.control_planes[each.key].private_ipv4_address
+          node-label                  = each.value.labels
+          node-taint                  = each.value.taints
+          write-kubeconfig-mode       = "0644" # needed for import into rancher
+          tls-san = []
+        },
+        lookup(local.cni_k3s_settings, var.cni_plugin, {}),
+        var.use_control_plane_lb ? {
+          tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
+        } : {
+          tls-san = [
+            module.control_planes[each.key].ipv4_address
+          ]
+        }
+      )
+    )
 
-    destination = "/tmp/config.yaml"
   }
 
   # Install k3s server

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -119,6 +119,7 @@ resource "null_resource" "control_planes" {
       )
     )
 
+    destination = "/tmp/config.yaml"
   }
 
   # Install k3s server

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -4,7 +4,7 @@ Kube-Hetzner requires you to have a recent version of OpenSSH (>=6.5) installed 
 - rsa-sha2-512
 - rsa-sha2-256
 
-If your key-pair is of the `ssh-ed25519` sort, and without of passphrase, you do not need to do anything else. Just set `public_key` and `private_key` to their respective path values in your terraform.tfvars.
+If your key-pair is of the `ssh-ed25519` sort, and without of passphrase, you do not need to do anything else. Just set `public_key` and `private_key` to their respective path values in your kube.tf file.
 
 ---
 
@@ -21,4 +21,4 @@ Verify it is loaded with:
 ssh-add -l
 ```
 
-Then set `private_key = null` in your terraform.tfvars, as it will be read from the ssh-agent automatically.
+Then set `private_key = null` in your kube.tf file, as it will be read from the ssh-agent automatically.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -121,4 +121,5 @@
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Structured kubeconfig data to supply to other providers |
 | <a name="output_kubeconfig_file"></a> [kubeconfig\_file](#output\_kubeconfig\_file) | Kubeconfig file content with external IP address |
 | <a name="output_load_balancer_public_ipv4"></a> [load\_balancer\_public\_ipv4](#output\_load\_balancer\_public\_ipv4) | The public IPv4 address of the Hetzner load balancer |
+| <a name="output_load_balancer_public_ipv6"></a> [load\_balancer\_public\_ipv6](#output\_load\_balancer\_public\_ipv6) | The public IPv6 address of the Hetzner load balancer |
 <!-- END_TF_DOCS -->

--- a/init.tf
+++ b/init.tf
@@ -28,7 +28,7 @@ resource "null_resource" "first_control_plane" {
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {
           tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
-        } : {
+          } : {
           tls-san = [module.control_planes[keys(module.control_planes)[0]].ipv4_address]
         }
       )

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -198,6 +198,8 @@ module "kube-hetzner" {
 
   # If you want to allow non-control-plane workloads to run on the control-plane nodes, set "true" below. The default is "false".
   # True by default for single node clusters.
+  # IMPORTANT: For the time being, this requires you to also set hetzner_ccm_version="v1.12.1", see issue #311
+  # Hopefully it's just a temporary measure, as we are seeking solutions at the source.
   # allow_scheduling_on_control_plane = true
 
   # If you want to disable the automatic upgrade of k3s, you can set this to false. The default is "true".

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -136,7 +136,7 @@ module "kube-hetzner" {
   ### The following values are entirely optional (and can be removed from this if unused)
 
   # You can refine a base domain name to be use in this form of nodename.base_domain for setting the reserve dns inside Hetzner
-  # base_domain = mycluster.example.com
+  # base_domain = "mycluster.example.com"
 
   # To use local storage on the nodes, you can enable Longhorn, default is "false".
   # enable_longhorn = true

--- a/locals.tf
+++ b/locals.tf
@@ -317,6 +317,9 @@ persistence:
 
   default_nginx_ingress_values = <<EOT
 controller:
+  watchIngressWithoutClass: "true"
+  kind: "Deployment"
+  replicaCount: ${(local.agent_count > 2) ? 3 : (local.agent_count == 2) ? 2 : 1}
   config:
     "use-forwarded-headers": "true"
     "compute-full-forwarded-for": "true"

--- a/nginx_ingress_values.yaml.example
+++ b/nginx_ingress_values.yaml.example
@@ -3,6 +3,8 @@
 
 controller:
   # These options can be found here https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+  watchIngressWithoutClass: "true"
+  kind: "DaemonSet"
   config:
     "use-forwarded-headers": "true"
     "compute-full-forwarded-for": "true"

--- a/output.tf
+++ b/output.tf
@@ -19,7 +19,12 @@ output "agents_public_ipv4" {
 
 output "load_balancer_public_ipv4" {
   description = "The public IPv4 address of the Hetzner load balancer"
-  value       = local.using_klipper_lb || local.ingress_controller == "none" ? null : data.hcloud_load_balancer.cluster[0].ipv4
+  value       = (local.using_klipper_lb || local.ingress_controller == "none") ? null : data.hcloud_load_balancer.cluster[0].ipv4
+}
+
+output "load_balancer_public_ipv6" {
+  description = "The public IPv6 address of the Hetzner load balancer"
+  value       = (local.using_klipper_lb || local.ingress_controller == "none" || var.load_balancer_disable_ipv6) ? null : data.hcloud_load_balancer.cluster[0].ipv6
 }
 
 output "kubeconfig_file" {


### PR DESCRIPTION
In response to #325 

This PR sets the external IP of the control planes to the `tis-san` for the certificate to prevent certificate errors on the first request to the Kubernetes API.
When the control plane load balancer is used, nothing should change. I tested it with 1 and 3 control planes and the connection to each cp works properly.
I'm still a bit unsure about `tls-san` in `control-planes.tf`, should it include only the IP of the current server or the list of all CP IPs?