### PR TITLE
Extra manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Once the Cluster is up and running, you can easily customize many components lik
 
 For other components like Calico and Kured (which uses manifests), we automatically save a `kustomization_backup.yaml` file in the root of your module during the deploy, so you can use that as a starting point. This is also useful when creating the HelmChartConfig definitions, as both HelmChart and HelmChartConfig definitions are very similar.
 
+## Kustomization
+
+If you need to install additional Helm charts or Kubernetes manifests that are not provided by default, you can easily do so by using [Kustomize](https://kustomize.io).
+This is done by creating the `extra-manifests/kustomization.yaml.tpl` directory besides your `kube.tf`. 
+This file needs to be a valid `Kustomization` manifest, but it supports terraform templating! (The templating parameters can be passed via the `extra_kustomize_parameters` variable to the module).
+All files in the `extra-manifests` directory including the rendered version of `kustomization.yaml.tpl` will be applied to k3s with `kubectl apply -k`. 
+(This will be executed after and indipendently of the basic cluster configuration).
+
 ## Examples
 
 <details>

--- a/extra-manifests/.gitkeep
+++ b/extra-manifests/.gitkeep
@@ -1,1 +1,0 @@
-This folder is needed as fallback if the `extra-manifests` feature isn't used

--- a/extra-manifests/.gitkeep
+++ b/extra-manifests/.gitkeep
@@ -1,0 +1,1 @@
+This folder is needed as fallback if the `extra-manifests` feature isn't used

--- a/init.tf
+++ b/init.tf
@@ -281,18 +281,6 @@ resource "null_resource" "kustomization" {
     ])
   }
 
-  provisioner "remote-exec" {
-      inline = [
-        "echo 'Create manifests dir'",
-        "mkdir -p /var/lib/rancher/k3s/server/manifests"
-      ]
-  }
-
-  provisioner "file" {
-    source = var.extra_manifests_directory ? "extra-manifests/" : "${path.module}/extra-manifests/"
-    destination = "/var/lib/rancher/k3s/server/manifests"
-  }
-
   depends_on = [
     null_resource.first_control_plane,
     local_sensitive_file.kubeconfig,

--- a/init.tf
+++ b/init.tf
@@ -289,7 +289,7 @@ resource "null_resource" "kustomization" {
   }
 
   provisioner "file" {
-    source = var.extra_manifests ? "extra-manifests/" : "${path.module}/extra-manifests/"
+    source = var.extra_manifests_directory ? "extra-manifests/" : "${path.module}/extra-manifests/"
     destination = "/var/lib/rancher/k3s/server/manifests"
   }
 

--- a/init.tf
+++ b/init.tf
@@ -281,6 +281,18 @@ resource "null_resource" "kustomization" {
     ])
   }
 
+  provisioner "remote-exec" {
+      inline = [
+        "echo 'Create manifests dir'",
+        "mkdir -p /var/lib/rancher/k3s/server/manifests"
+      ]
+  }
+
+  provisioner "file" {
+    source = var.extra_manifests ? "extra-manifests/" : "${path.module}/extra-manifests/"
+    destination = "/var/lib/rancher/k3s/server/manifests"
+  }
+
   depends_on = [
     null_resource.first_control_plane,
     local_sensitive_file.kubeconfig,

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -298,11 +298,8 @@ module "kube-hetzner" {
   # rancher_registration_manifest_url = "https://rancher.xyz.dev/v3/import/xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz.yaml"
 
 
-  # You can provide custom manifests for k3s to be automatically installed. See https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
-  # IMPORTANT: When enabeld, a directory `extra-manifests` must exist beside the kube.tf file. 
-  # You can add any manifest files to this directory, this can be 
-  # `HelmChart`s or any other kubernetes resource. 
-  # extra_manifests_directory = true
+  # Extra values that will be passed to the `extra-manifests/kustomization.yaml.tpl` if its present.
+  # extra_kustomize_parameters={}
 }
 
 provider "hcloud" {

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -296,6 +296,13 @@ module "kube-hetzner" {
   # by Rancher in the wizard, and that would register your cluster too.
   # More information about the registration can be found here https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/
   # rancher_registration_manifest_url = "https://rancher.xyz.dev/v3/import/xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz.yaml"
+
+
+  # You can provide custom manifests for k3s to be automatically installed. See https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
+  # IMPORTANT: When enabeld, a directory `extra-manifests` must exist beside the kube.tf file. 
+  # You can add any manifest files to this directory, this can be 
+  # `HelmChart`s or any other kubernetes resource. 
+  # extra_manifests_directory = true
 }
 
 provider "hcloud" {

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -1,0 +1,44 @@
+locals {
+  user_kustomization_exists = fileexists("extra-manifests/kustomization.yaml.tpl")
+  user_kustomization_files  = toset([for p in fileset("extra-manifests", "**") : p if p != "kustomization.yaml.tpl"])
+}
+
+resource "null_resource" "kustomization_user_mkdir" {
+  count = local.user_kustomization_exists ? 1 : 0
+  connection {
+    user           = "root"
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
+    host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
+    port           = var.ssh_port
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Create kustomize dir'",
+      "mkdir -p /var/user_kustomize"
+    ]
+  }
+
+  provisioner "file" {
+    source      = "extra-manifests/"
+    destination = "/var/user_kustomize"
+  }
+
+  provisioner "file" {
+    content     = templatefile("extra-manifests/kustomization.yaml.tpl", var.extra_kustomize_parameters)
+    destination = "/var/user_kustomize/kustomization.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "rm /var/user_kustomize/kustomization.yaml.tpl",
+      "kubectl apply -k /var/user_kustomize/"
+    ]
+  }
+
+
+  depends_on = [
+    null_resource.kustomization,
+  ]
+}

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -3,7 +3,7 @@ locals {
   user_kustomization_files  = toset([for p in fileset("extra-manifests", "**") : p if p != "kustomization.yaml.tpl"])
 }
 
-resource "null_resource" "kustomization_user_mkdir" {
+resource "null_resource" "kustomization_user" {
   count = local.user_kustomization_exists ? 1 : 0
   connection {
     user           = "root"

--- a/variables.tf
+++ b/variables.tf
@@ -320,3 +320,9 @@ variable "extra_packages_to_install" {
   default     = []
   description = "A list of additional packages to install on nodes."
 }
+
+variable "extra_manifests" {
+  type = bool
+  default = false
+  description = "When this is enabled, all files from the `extra-manifests` directory will be auto-deployed via k3s"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -321,8 +321,8 @@ variable "extra_packages_to_install" {
   description = "A list of additional packages to install on nodes."
 }
 
-variable "extra_manifests_directory" {
-  type = bool
-  default = false
-  description = "When this is enabled, all files from the `extra-manifests` directory will be auto-deployed via k3s"
+variable "extra_kustomize_parameters" {
+  type = map
+  default = {}
+  description = "All values will be passed to the `kustomization.tmp.yml` template."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -322,7 +322,7 @@ variable "extra_packages_to_install" {
 }
 
 variable "extra_kustomize_parameters" {
-  type = map
-  default = {}
+  type        = map(any)
+  default     = {}
   description = "All values will be passed to the `kustomization.tmp.yml` template."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -321,7 +321,7 @@ variable "extra_packages_to_install" {
   description = "A list of additional packages to install on nodes."
 }
 
-variable "extra_manifests" {
+variable "extra_manifests_directory" {
   type = bool
   default = false
   description = "When this is enabled, all files from the `extra-manifests` directory will be auto-deployed via k3s"


### PR DESCRIPTION
Following up to #328 this PR implements support for a user defined kustomization.

The extra step is triggered if `extra-manifests/kustomization.yaml.tpl` exists. 
It will be executed after `kustomization` was successful, so it can't break the cluster build.
If this step fails (e.g. `kubectl -k apply) the manifest can be fixed and run again, without rebuilding the cluster!