### PR TITLE
Fix placement groups

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -15,7 +15,7 @@ module "agents" {
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
-  placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.agent.*.id, ceil(each.value.index / 10))
+  placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.agent[floor(each.value.index / 10)].id
   location                   = each.value.location
   server_type                = each.value.server_type
   ipv4_subnet_id             = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -15,7 +15,7 @@ module "control_planes" {
   ssh_private_key            = var.ssh_private_key
   ssh_additional_public_keys = var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
-  placement_group_id         = var.placement_group_disable ? 0 : element(hcloud_placement_group.control_plane.*.id, ceil(each.value.index / 10))
+  placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.control_plane[floor(each.value.index / 10)].id
   location                   = each.value.location
   server_type                = each.value.server_type
   ipv4_subnet_id             = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id


### PR DESCRIPTION
I'm working with ~20-22 nodes and everytime, I re-created the whole cluster, it failed because of wrong placement_group mappings (it tried to map >10 nodes at one placement_group)

As far as I could calculate, the placement_group logic is starting one ID above 0 (1) and accidentally used the terraform overflow-logic (if n+1 is longer than the array-size, start from 0)

I think I solved it by slightly replace the calculation :-)