### PR TITLE
Allow `0` in cluster name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "cluster_name" {
   description = "Name of the cluster."
 
   validation {
-    condition     = can(regex("^[a-z1-9\\-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9\\-]+$", var.cluster_name))
     error_message = "The cluster name must be in the form of lowercase alphanumeric characters and/or dashes."
   }
 }


### PR DESCRIPTION
Just a minor problem: the cluster name isn't allowed to contain a `0` which may cause problems with auto-generated names. 
It don't see any reason why the `0` should be excluded (correct me if im wrong)