### PR TITLE
Output the cp ip when using klipper

### DIFF
--- a/modules/host/out.tf
+++ b/modules/host/out.tf
@@ -2,6 +2,10 @@ output "ipv4_address" {
   value = hcloud_server.server.ipv4_address
 }
 
+output "ipv6_address" {
+  value = hcloud_server.server.ipv6_address
+}
+
 output "private_ipv4_address" {
   value = hcloud_server_network.server.ip
 }

--- a/output.tf
+++ b/output.tf
@@ -7,14 +7,14 @@ output "control_planes_public_ipv4" {
   value = [
     for obj in module.control_planes : obj.ipv4_address
   ]
-  description = "The public IPv4 addresses of the controlplane server."
+  description = "The public IPv4 addresses of the controlplane servers."
 }
 
 output "agents_public_ipv4" {
   value = [
     for obj in module.agents : obj.ipv4_address
   ]
-  description = "The public IPv4 addresses of the agent server."
+  description = "The public IPv4 addresses of the agent servers."
 }
 
 output "load_balancer_public_ipv4" {
@@ -37,4 +37,16 @@ output "kubeconfig" {
   description = "Structured kubeconfig data to supply to other providers"
   value       = local.kubeconfig_data
   sensitive   = true
+}
+
+
+output "ingress_public_ipv4" {
+  description = "The public ingress IPv4 of the cluster (external/internal loadbalancer)"
+  value       = (local.ingress_controller == "none" ? null : (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : data.hcloud_load_balancer.cluster[0].ipv4))
+}
+
+
+output "ingress_public_ipv6" {
+  description = "The public ingress IPv6 of the cluster (external/internal loadbalancer)"
+  value       = (local.ingress_controller == "none" || var.load_balancer_disable_ipv6 ? null : (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : data.hcloud_load_balancer.cluster[0].ipv6))
 }


### PR DESCRIPTION
Follow up to #332.

This adds 2 new outputs `ingress_public_ipv4` and `ingress_public_ipv6`.
They support `hetzner_lb` and `klipper` and are more consistent to use between single-node clusters with `klipper` and full blown clusters.

To be conservative I added them as new outputs instead of extending the existing `load_balancer_public_ipv4|6`.

Since I haven't experience with klipper setups a few questions remain: 
How to handle setups besides single-node clusters where it is save to assume the first control-plane accepts the traffic?

My best guess would be something like this: (just some rough code for understanding)
```
if(!local.using_kilpper_lb){
   return  data.hcloud_load_balancer.cluster[0].ipv4
}

if(local.is_single_node_cluster){
  return module.control_planes[keys(module.control_planes)[0]].ipv4_address
}

return module.agents[keys(module.agents)[0]].ipv4_address 
```

In addition there is still #284 open. To solve this in one go, I would drop `local.ingress_controller == "none"` completely and make this output solely rely on the load balancing config and not the ingress controller itself.
