### PR TITLE
Ignore ingress config for ip outputs

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -18,7 +18,7 @@ data "github_release" "kured" {
 }
 
 data "hcloud_load_balancer" "cluster" {
-  count = local.using_klipper_lb ? 0 : local.ingress_controller == "none" ? 0 : 1
+  count = local.has_external_load_balancer ? 0 : 1
   name  = var.cluster_name
 
   depends_on = [null_resource.kustomization]

--- a/init.tf
+++ b/init.tf
@@ -269,7 +269,7 @@ resource "null_resource" "kustomization" {
         "sleep 5", # important as the system upgrade controller CRDs sometimes don't get ready right away, especially with Cilium.
         "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml"
       ],
-      local.using_klipper_lb || local.ingress_controller == "none" ? [] : [
+      local.has_external_load_balancer ? [] : [
         <<-EOT
       timeout 180 bash <<EOF
       until [ -n "\$(kubectl get -n kube-system service/${lookup(local.ingress_controller_service_names, local.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2> /dev/null)" ]; do

--- a/locals.tf
+++ b/locals.tf
@@ -73,6 +73,8 @@ locals {
 
   using_klipper_lb = var.enable_klipper_metal_lb || local.is_single_node_cluster
 
+  has_external_load_balancer = local.using_klipper_lb || local.ingress_controller == "none"
+
   # disable k3s extras
   disable_extras = concat(["local-storage"], local.using_klipper_lb ? [] : ["servicelb"], var.enable_traefik ? [] : [
     "traefik"

--- a/output.tf
+++ b/output.tf
@@ -41,12 +41,11 @@ output "kubeconfig" {
 
 
 output "ingress_public_ipv4" {
-  description = "The public ingress IPv4 of the cluster (external/internal loadbalancer)"
-  value       = (local.ingress_controller == "none" ? null : (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : data.hcloud_load_balancer.cluster[0].ipv4))
+  description = "The public ingress IPv4 of the cluster (external/internal load balancer)"
+  value       = (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : data.hcloud_load_balancer.cluster[0].ipv4)
 }
 
-
 output "ingress_public_ipv6" {
-  description = "The public ingress IPv6 of the cluster (external/internal loadbalancer)"
-  value       = (local.ingress_controller == "none" || var.load_balancer_disable_ipv6 ? null : (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : data.hcloud_load_balancer.cluster[0].ipv6))
+  description = "The public ingress IPv6 of the cluster (external/internal load balancer). Only supported with external load balancer"
+  value       = (local.using_klipper_lb ? null : (var.load_balancer_disable_ipv6 ? null : data.hcloud_load_balancer.cluster[0].ipv6))
 }

--- a/output.tf
+++ b/output.tf
@@ -19,12 +19,12 @@ output "agents_public_ipv4" {
 
 output "load_balancer_public_ipv4" {
   description = "The public IPv4 address of the Hetzner load balancer"
-  value       = (local.using_klipper_lb || local.ingress_controller == "none") ? null : data.hcloud_load_balancer.cluster[0].ipv4
+  value       = local.has_external_load_balancer ? null : data.hcloud_load_balancer.cluster[0].ipv4
 }
 
 output "load_balancer_public_ipv6" {
   description = "The public IPv6 address of the Hetzner load balancer"
-  value       = (local.using_klipper_lb || local.ingress_controller == "none" || var.load_balancer_disable_ipv6) ? null : data.hcloud_load_balancer.cluster[0].ipv6
+  value       = (local.has_external_load_balancer || var.load_balancer_disable_ipv6) ? null : data.hcloud_load_balancer.cluster[0].ipv6
 }
 
 output "kubeconfig_file" {
@@ -42,10 +42,10 @@ output "kubeconfig" {
 
 output "ingress_public_ipv4" {
   description = "The public ingress IPv4 of the cluster (external/internal load balancer)"
-  value       = (local.using_klipper_lb ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : data.hcloud_load_balancer.cluster[0].ipv4)
+  value       = local.has_external_load_balancer ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : data.hcloud_load_balancer.cluster[0].ipv4
 }
 
 output "ingress_public_ipv6" {
   description = "The public ingress IPv6 of the cluster (external/internal load balancer). Only supported with external load balancer"
-  value       = (local.using_klipper_lb ? null : (var.load_balancer_disable_ipv6 ? null : data.hcloud_load_balancer.cluster[0].ipv6))
+  value       = local.has_external_load_balancer ? null : data.hcloud_load_balancer.cluster[0].ipv6
 }


### PR DESCRIPTION
Followup to #336

And this should be the final one!
- `ingress_public_ipv4` is now always populated, either with the lb ip or with the ip of the first control plane.
- `ingress_public_ipv6 ` is only populated when a load balancer is used and IPv6 is not disabled

This should clear #284! 