### PR TITLE
Add switch to disable automatic os updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,15 @@ You can copy and modify the [one in the templates](https://github.com/kube-hetzn
 
 ### Turning Off Automatic Upgrade
 
-_If you wish to turn off automatic MicroOS upgrades (Important if you are not launching an HA setup which requires at least 3 control-plane nodes), you need to ssh into each node and issue the following command:_
+_If you wish to turn off automatic MicroOS upgrades (Important if you are not launching an HA setup which requires at least 3 control-plane nodes), you need to set:_ 
+```terraform
+automatically_upgrade_os = false
+```
+
+_Alternatively ssh into each node and issue the following command:_
 
 ```sh
 systemctl --now disable transactional-update.timer
-
 ```
 
 _To turn off k3s upgrades, you can either remove the `k3s_upgrade=true` label or set it to `false`. This needs to happen for all the nodes too! To remove it, apply:_
@@ -302,7 +306,7 @@ spec:
 <summary>Single-node cluster</summary>
 
 Running a development cluster on a single node without any high availability is also possible. You need one control plane nodepool with a count of 1 and one agent nodepool with a count of 0. Also set the variable `hetzner_ccm_version="v1.12.1"` which will ensure that workloads can be executed on the control plane and prevent some errors.
-
+Additionally `automatically_upgrade_os` should be set to `false`, especially with attached volumes the automatic reboots won't work properly.
 In this case, we don't deploy an external load-balancer but use the default [k3s service load balancer](https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer) on the host itself and open up port 80 & 443 in the firewall (done automatically).
 
 </details>

--- a/agents.tf
+++ b/agents.tf
@@ -26,6 +26,8 @@ module "agents" {
 
   labels = merge(local.labels, local.labels_agent_node)
 
+  automatically_upgrade_os = var.automatically_upgrade_os
+
   depends_on = [
     hcloud_network_subnet.agent
   ]

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -28,6 +28,8 @@ module "control_planes" {
 
   labels = merge(local.labels, local.labels_control_plane_node)
 
+  automatically_upgrade_os = var.automatically_upgrade_os
+
   depends_on = [
     hcloud_network_subnet.control_plane
   ]

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -13,7 +13,7 @@ module "kube-hetzner" {
   # could adapt them to your needs.
 
   # * For local dev, path to the git repo
-  # source = "../../kube-hetzner/" 
+  # source = "../../kube-hetzner/"
   # For normal use, this is the path to the terraform registry
   source = "kube-hetzner/kube-hetzner/hcloud"
   # you can optionally specify a version number
@@ -33,10 +33,10 @@ module "kube-hetzner" {
   ssh_private_key = file("/home/username/.ssh/id_ed25519")
   # You can add additional SSH public Keys to grant other team members root access to your cluster nodes.
   # ssh_additional_public_keys = []
-  
+
   # If you want to use an ssh key that is already registered within hetzner cloud, you can pass its id.
   # If no id is passed, a new ssh key will be registered within hetzner cloud.
-  # It is important that exactly this key is passed via `ssh_public_key` & `ssh_private_key` vars. 
+  # It is important that exactly this key is passed via `ssh_public_key` & `ssh_private_key` vars.
   # hcloud_ssh_key_id = ""
 
   # These can be customized, or left with the default values
@@ -62,7 +62,7 @@ module "kube-hetzner" {
   # The nodepool names are entirely arbitrary, you can choose whatever you want, but no special characters or underscore, and they must be unique; only alphanumeric characters and dashes are allowed.
 
   # If you want to have a single node cluster, have one control plane nodepools with a count of 1, and one agent nodepool with a count of 0.
-  
+
   # Please note that changing labels and taints after the first run will have no effect. If needed, you will need to do that through Kubernetes directly.
 
   # * Example below:
@@ -148,7 +148,7 @@ module "kube-hetzner" {
   # longhorn_replica_count = 1
 
   # When you enable Longhorn, you can go with the default settings and just modify the above two variables OR you can copy the longhorn_values.yaml.example
-  # file to longhorn_value.yaml and put it at the base of your own module, next to your kube.tf, this is Longhorn's own helm values file. 
+  # file to longhorn_value.yaml and put it at the base of your own module, next to your kube.tf, this is Longhorn's own helm values file.
   # If that file is present, the system will use it during the deploy, if not it will use the default values with the two variable above that can be customized.
   # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
 
@@ -166,7 +166,7 @@ module "kube-hetzner" {
   # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available.
   # kured_version = ""
 
-  # If you want to enable the Nginx ingress controller (https://kubernetes.github.io/ingress-nginx/) instead of Traefik, you can set this to "true". Default is "false". 
+  # If you want to enable the Nginx ingress controller (https://kubernetes.github.io/ingress-nginx/) instead of Traefik, you can set this to "true". Default is "false".
   # FOR THIS TO NOT BE IGNORED, you also need to set "enable_traefik = false".
   # By the default we load an optimal Nginx ingress controller config for Hetzner, however you may need to tweak it to your needs, so to do,
   # we allow you to add a nginx_ingress_values.yaml file to the root of your module, next to the kube.tf file, it is simply a helm values config file.
@@ -176,7 +176,7 @@ module "kube-hetzner" {
 
   # If you want to disable the Traefik ingress controller, to use the Nginx ingress controller for instance, you can can set this to "false". Default is "true".
   # enable_traefik = false
-  
+
   # Use the klipper LB, instead of the default Hetzner one, that has an advantage of dropping the cost of the setup,
   # Automatically "true" in the case of single node cluster.
   # It can work with any ingress controller that you choose to deploy.
@@ -205,6 +205,12 @@ module "kube-hetzner" {
   # If you want to disable the automatic upgrade of k3s, you can set this to false. The default is "true".
   # automatically_upgrade_k3s = false
 
+
+  # If you want to disable the automatic upgrade of MicroOS, you can set this to false. The default is "true".
+  # This is recommend for non-HA clusters, because the nodes can't be drained properly and thus the reboot will fail.
+  # IMPORTANT: This is a security risk!
+  # automatically_upgrade_os = false
+
   # Allows you to specify either stable, latest, testing or supported minor versions (defaults to stable)
   # see https://rancher.com/docs/k3s/latest/en/upgrades/basic/ and https://update.k3s.io/v1-release/channels
   # initial_k3s_channel = "latest"
@@ -224,14 +230,14 @@ module "kube-hetzner" {
   #     protocol        = "tcp"
   #     port            = "5432"
   #     source_ips      = ["0.0.0.0/0", "::/0"]
-  #     destination_ips = [] # Won't be used for this rule 
+  #     destination_ips = [] # Won't be used for this rule
   #   },
   #   # To Allow ArgoCD access to resources via SSH
   #   {
   #     direction       = "out"
   #     protocol        = "tcp"
   #     port            = "22"
-  #     source_ips      = [] # Won't be used for this rule 
+  #     source_ips      = [] # Won't be used for this rule
   #     destination_ips = ["0.0.0.0/0", "::/0"]
   #   }
   # ]
@@ -270,7 +276,7 @@ module "kube-hetzner" {
   # See for options https://rancher.com/docs/rancher/v2.0-v2.4/en/installation/resources/advanced/helm2/helm-rancher/#choose-your-ssl-configuration
   # The easiest thing is to leave everything as is (using the default rancher self-signed certificate) and put Cloudflare in front of it.
   # As for the number of replicas, by default it is set to the numbe of control plane nodes.
-  # You can customized all of the above by adding a rancher_values.yaml file at the root of your module, which is just a helm values file. 
+  # You can customized all of the above by adding a rancher_values.yaml file at the root of your module, which is just a helm values file.
   # See the rancher_values.yaml.example file located at the root of the project.
   # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
   # IMPORTANT: Rancher's install is quite memory intensive, you will require at least 4GB if RAM, meaning cx21 server type (for your control plane).

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -135,7 +135,7 @@ resource "hcloud_server" "server" {
     EOT
   }
 
-  # Cleanup ssh identity file 
+  # Cleanup ssh identity file
   provisioner "local-exec" {
     command = <<-EOT
       rm /tmp/${random_string.identity_file.id}
@@ -149,6 +149,18 @@ resource "hcloud_server" "server" {
       if [[ $(systemctl list-units --all -t service --full --no-legend "iscsid.service" | sed 's/^\s*//g' | cut -f1 -d' ') == iscsid.service ]]; then
         systemctl enable --now iscsid
       fi
+      EOT
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = var.automatically_upgrade_os ? [<<-EOT
+      echo "Automatic updates stay enabled"
+      EOT
+      ] : [
+      <<-EOT
+      echo "Automatic updates are disabled"
+      systemctl --now disable transactional-update.timer
       EOT
     ]
   }

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -83,3 +83,8 @@ variable "dns_servers" {
   type        = list(string)
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner"
 }
+
+variable "automatically_upgrade_os" {
+  type    = bool
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,12 @@ variable "automatically_upgrade_k3s" {
   description = "Whether to automatically upgrade k3s based on the selected channel."
 }
 
+variable "automatically_upgrade_os" {
+  type        = bool
+  default     = true
+  description = "Whether to enable or disable automatic os updates. Defaults to true. Should be disabled for single-node clusters"
+}
+
 variable "extra_firewall_rules" {
   type        = list(any)
   default     = []


### PR DESCRIPTION
This adds `automatically_upgrade_os` as an option to control the automatic system updates. 
As disabling them is needed for non HA clusters to work properly. This is far more convenient than the "ssh in each node" method described right now in the docs.

For convince it might be even better to set this automatically depended on the node counts, but it is contrasted by the security risk. There for I personally would tend to leaving it as user choice.