### PR TITLE
Opt out of local files and add kubeconfig as an output to the kube.tf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ It will take around 5 minutes to complete, and then you should see a green outpu
 
 When your brand new cluster is up and running, the sky is your limit! 🎉
 
-You can immediately kubectl into it (using the `clustername_kubeconfig.yaml` saved to the project's directory after the installation). By doing `kubectl --kubeconfig clustername_kubeconfig.yaml`, but for more convenience, either create a symlink from `~/.kube/config` to `clustername_kubeconfig.yaml` or add an export statement to your `~/.bashrc` or `~/.zshrc` file, as follows (you can get the path of `clustername_kubeconfig.yaml` by running `pwd`):
+You can immediately kubectl into it (by exporting the kubeconfig to a file via `terraform output --raw kubeconfig > clustername_kubeconfig.yaml` after the installation). By doing `kubectl --kubeconfig clustername_kubeconfig.yaml`, but for more convenience, either create a symlink from `~/.kube/config` to `clustername_kubeconfig.yaml` or add an export statement to your `~/.bashrc` or `~/.zshrc` file, as follows (you can get the path of `clustername_kubeconfig.yaml` by running `pwd`):
 
 ```sh
 export KUBECONFIG=/<path-to>/clustername_kubeconfig.yaml

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -74,6 +74,8 @@
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster. | `string` | `"k3s"` | no |
 | <a name="input_cni_plugin"></a> [cni\_plugin](#input\_cni\_plugin) | CNI plugin for k3s. | `string` | `"flannel"` | no |
 | <a name="input_control_plane_nodepools"></a> [control\_plane\_nodepools](#input\_control\_plane\_nodepools) | Number of control plane nodes. | `list(any)` | `[]` | no |
+| <a name="input_create_kubeconfig"></a> [create\_kubeconfig](#input\_create\_kubeconfig) | Create the kubeconfig as a local file resource. Should be disabled for automatic runs. | `bool` | `true` | no |
+| <a name="input_create_kustomization"></a> [create\_kustomization](#input\_create\_kustomization) | Create the kustomization backup as a local file resource. Should be disabled for automatic runs. | `bool` | `true` | no |
 | <a name="input_disable_hetzner_csi"></a> [disable\_hetzner\_csi](#input\_disable\_hetzner\_csi) | Disable hetzner csi driver. | `bool` | `false` | no |
 | <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico and cilium). | `bool` | `false` | no |
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner. | `list(string)` | <pre>[<br>  "1.1.1.1",<br>  " 1.0.0.1",<br>  "8.8.8.8"<br>]</pre> | no |

--- a/init.tf
+++ b/init.tf
@@ -282,7 +282,6 @@ resource "null_resource" "kustomization" {
 
   depends_on = [
     null_resource.first_control_plane,
-    local_sensitive_file.kubeconfig,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume
   ]

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -304,6 +304,16 @@ module "kube-hetzner" {
 
   # Extra values that will be passed to the `extra-manifests/kustomization.yaml.tpl` if its present.
   # extra_kustomize_parameters={}
+
+  # Don't create a local kubeconfig file. For backwards compatibility this is set to true by default in the module but for automatic runs this can cause issues.
+  # See https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/349
+  # The kubeconfig file can instead be created by executing: "terraform output --raw kubeconfig > cluster_kubeconfig.yaml"
+  # Be careful to not commit this file!
+  create_kubeconfig = false
+
+
+  # Don't create the kustomize backup. This can be helpful for automation.
+  # create_kustomization = false
 }
 
 provider "hcloud" {
@@ -318,4 +328,9 @@ terraform {
       version = ">= 1.35.1"
     }
   }
+}
+
+output "kubeconfig" {
+    value = module.kube-hetzner.kubeconfig_file
+    sensitive = true
 }

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -15,7 +15,7 @@ locals {
   kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
-    host                   = var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
+    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])
@@ -23,6 +23,7 @@ locals {
 }
 
 resource "local_sensitive_file" "kubeconfig" {
+  count           = var.create_kubeconfig ? 1 : 0
   content         = local.kubeconfig_external
   filename        = "${var.cluster_name}_kubeconfig.yaml"
   file_permission = "600"

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -12,6 +12,7 @@ data "remote_file" "kustomization_backup" {
 }
 
 resource "local_file" "kustomization_backup" {
+  count           = var.create_kustomization ? 1 : 0
   content         = data.remote_file.kustomization_backup.content
   filename        = "${var.cluster_name}_kustomization_backup.yaml"
   file_permission = "600"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,6 @@ resource "null_resource" "destroy_cluster_loadbalancer" {
   }
 
   depends_on = [
-    local_sensitive_file.kubeconfig,
     null_resource.control_planes[0],
     hcloud_network_subnet.control_plane,
     hcloud_network_subnet.agent,

--- a/variables.tf
+++ b/variables.tf
@@ -332,3 +332,15 @@ variable "extra_kustomize_parameters" {
   default     = {}
   description = "All values will be passed to the `kustomization.tmp.yml` template."
 }
+
+variable "create_kubeconfig" {
+  type        = bool
+  default     = true
+  description = "Create the kubeconfig as a local file resource. Should be disabled for automatic runs."
+}
+
+variable "create_kustomization" {
+  type        = bool
+  default     = true
+  description = "Create the kustomization backup as a local file resource. Should be disabled for automatic runs."
+}


### PR DESCRIPTION
Fixes #349 by removing the local kubeconfig file and documented how to export it from the terraform output