### PR TITLE
Support adding ssh keys from hcloud by label

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -9,11 +9,11 @@ module "agents" {
 
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
-  ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_keys                   = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
-  ssh_additional_public_keys = var.ssh_additional_public_keys
+  ssh_additional_public_keys = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
   placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.agent[floor(each.value.index / 10)].id
   location                   = each.value.location

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -9,11 +9,11 @@ module "control_planes" {
 
   name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
   base_domain                = var.base_domain
-  ssh_keys                   = [local.hcloud_ssh_key_id]
+  ssh_keys                   = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                   = var.ssh_port
   ssh_public_key             = var.ssh_public_key
   ssh_private_key            = var.ssh_private_key
-  ssh_additional_public_keys = var.ssh_additional_public_keys
+  ssh_additional_public_keys = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids               = [hcloud_firewall.k3s.id]
   placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.control_plane[floor(each.value.index / 10)].id
   location                   = each.value.location

--- a/data.tf
+++ b/data.tf
@@ -23,3 +23,8 @@ data "hcloud_load_balancer" "cluster" {
 
   depends_on = [null_resource.kustomization]
 }
+
+data "hcloud_ssh_keys" "keys_by_selector" {
+  count         = length(var.ssh_hcloud_key_label) > 0 ? 1 : 0
+  with_selector = var.ssh_hcloud_key_label
+}

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -33,6 +33,10 @@ module "kube-hetzner" {
   ssh_private_key = file("/home/username/.ssh/id_ed25519")
   # You can add additional SSH public Keys to grant other team members root access to your cluster nodes.
   # ssh_additional_public_keys = []
+  
+  # You can also add additional SSH public Keys which are saved in the hetzner cloud by a label.
+  # See https://docs.hetzner.cloud/#label-selector
+  # ssh_hcloud_key_label = "role=admin"
 
   # If you want to use an ssh key that is already registered within hetzner cloud, you can pass its id.
   # If no id is passed, a new ssh key will be registered within hetzner cloud.

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "ssh_private_key" {
   sensitive   = true
 }
 
+variable "ssh_hcloud_key_label" {
+  description = "Additional SSH public Keys by hcloud label. e.g. role=admin"
+  type        = string
+  default     = ""
+}
+
 variable "ssh_additional_public_keys" {
   description = "Additional SSH public Keys. Use them to grant other team members root access to your cluster nodes."
   type        = list(string)


### PR DESCRIPTION
This allows setting a label selector to add the public ssh keys stored in the hetzner cloud to the provisioned machines.

I will update terraform docs later today.

@mysticaltech Would be great if you could take a look and maybe give it a try it if still works when no label is provided.