### PR TITLE
Outputted kubeconfig: Abide to the cluster_name module input var

### DIFF
--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -15,7 +15,7 @@ locals {
   kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
-    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
+    host                   = var.cluster_name
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])


### PR DESCRIPTION
closes: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/357