### PR TITLE
Outputted `kubeconfig`: Abide to the `cluster_name` module input var

### DIFF
--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -20,6 +20,7 @@ locals {
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])
+    cluster_name           = var.cluster_name
   }
 }
 

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -14,9 +14,9 @@ data "remote_file" "kubeconfig" {
 locals {
   kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
   kubeconfig_final    = replace(local.kubeconfig_external, "default", var.cluster_name)
-  kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
+  kubeconfig_parsed   = yamldecode(local.kubeconfig_final)
   kubeconfig_data = {
-    host                   = var.cluster_name
+    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -15,7 +15,7 @@ locals {
   kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
-    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
+    host                   = var.cluster_name
     client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
     client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
     cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -13,6 +13,7 @@ data "remote_file" "kubeconfig" {
 
 locals {
   kubeconfig_external = replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : module.control_planes[keys(module.control_planes)[0]].ipv4_address)
+  kubeconfig_final    = replace(local.kubeconfig_external, "default", var.cluster_name)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
     host                   = var.cluster_name
@@ -24,7 +25,7 @@ locals {
 
 resource "local_sensitive_file" "kubeconfig" {
   count           = var.create_kubeconfig ? 1 : 0
-  content         = local.kubeconfig_external
+  content         = local.kubeconfig_final
   filename        = "${var.cluster_name}_kubeconfig.yaml"
   file_permission = "600"
 }


### PR DESCRIPTION
closes: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/357