### PR TITLE
fix: support for labels, that are defined in `agent_nodepools`

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -24,7 +24,11 @@ module "agents" {
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = merge(local.labels, local.labels_agent_node)
+  labels = merge(
+    local.labels,
+    local.labels_agent_node,
+    tomap({ for label in each.value.labels: split("=", label)[0] => length(split("=", label)) > 1 ? split("=", label)[1] : ""})
+  )
 
   automatically_upgrade_os = var.automatically_upgrade_os
 


### PR DESCRIPTION
Previously the labels defined in `agent_nodepools` were not applied when running `terraform apply`.
Now they are properly parsed and added as labels to the nodes. (either as "label=value" or "label").

```hcl
agent_nodepools = [
  {
    name        = "agent-small",
    server_type = "cpx41",
    location    = "fsn1",
    labels      = ["label_without_value", "label=with_value"], // labels control applied firewall rules
    taints      = [],
    count       = 1
  }
]
```