### PR TITLE
Changed the image server location to a fixed DE server

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -75,7 +75,7 @@ resource "hcloud_server" "server" {
 
     inline = [
       "set -ex",
-      "wget --timeout=5 --waitretry=0 --tries=10 --retry-connrefused --inet4-only https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2",
+      "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2",
       "qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*qcow2$') /dev/sda",
     ]
   }


### PR DESCRIPTION
This to deal with the fact that automatic location selection has become unreliable, as some sources have either blacklisted hetzner servers IPs or have corrupt images.