### PR TITLE
fix: use same datatype for default tf example

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -107,7 +107,10 @@ module "kube-hetzner" {
       server_type = "cpx11",
       location    = "fsn1",
       labels      = [],
-      taints      = [],
+      # To exclude from Longhorn if that is used for instance. Completely optional.
+      taints = [
+        "server-usage=storage:NoSchedule"
+      ],
       count       = 1
     },
     {
@@ -129,6 +132,7 @@ module "kube-hetzner" {
       labels = [
         "node.kubernetes.io/server-usage=storage"
       ],
+      taints = [],
       count = 1
       # In the case of using Longhorn, you can use Hetzner volumes instead of using the node's own storage by specifying a value from 10 to 10000 (in GB)
       # It will create one volume per node in the nodepool, and configure Longhorn to use them.


### PR DESCRIPTION
fixes an issue where an initial create was not possible is the default kube.tf.example was just used