### PR TITLE
fix: output kubeconfig renamed to kubeconfig_file

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -437,7 +437,7 @@ terraform {
   }
 }
 
-output "kubeconfig" {
+output "kubeconfig_file" {
   value     = module.kube-hetzner.kubeconfig_file
   sensitive = true
 }


### PR DESCRIPTION
Align output name in kube.tf.example with existing Documentation

fixes issue https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/421