### PR TITLE
Support custom configuration options for control planes

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -31,7 +31,8 @@ resource "null_resource" "first_control_plane" {
           } : {
           tls-san = [module.control_planes[keys(module.control_planes)[0]].ipv4_address]
         },
-        local.etcd_s3_snapshots
+        local.etcd_s3_snapshots,
+        var.control_planes_custom_config
       )
     )
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -144,9 +144,9 @@ module "kube-hetzner" {
   # kube-controller-manager-arg = "- bind-address=0.0.0.0",
   # kube-proxy-arg = "- metrics-bind-address=0.0.0.0",
   # kube-scheduler-arg = "- bind-address=0.0.0.0",
-  control_planes_custom_config = {
-
-  }
+  # control_planes_custom_config = {
+  #  
+  # }
 
   # * LB location and type, the latter will depend on how much load you want it to handle, see https://www.hetzner.com/cloud/load-balancer
   load_balancer_type     = "lb11"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -139,11 +139,11 @@ module "kube-hetzner" {
     }
   ]
   # Add custom control plane configuration options here.
-  # E.g:
-  # etcd-expose-metrics = true,
-  # kube-controller-manager-arg = "- bind-address=0.0.0.0",
-  # kube-proxy-arg = "- metrics-bind-address=0.0.0.0",
-  # kube-scheduler-arg = "- bind-address=0.0.0.0",
+  # E.g to enable monitoring for etcd, proxy etc:
+  # "etcd-expose-metrics": "true"
+  # "kube-controller-manager-arg": "bind-address=0.0.0.0"
+  # "kube-proxy-arg": "metrics-bind-address=0.0.0.0"
+  # "kube-scheduler-arg": "bind-address=0.0.0.0"
   # control_planes_custom_config = {
   #  
   # }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -138,6 +138,15 @@ module "kube-hetzner" {
       # longhorn_volume_size = 20
     }
   ]
+  # Add custom control plane configuration options here.
+  # E.g:
+  # etcd-expose-metrics = true,
+  # kube-controller-manager-arg = "- bind-address=0.0.0.0",
+  # kube-proxy-arg = "- metrics-bind-address=0.0.0.0",
+  # kube-scheduler-arg = "- bind-address=0.0.0.0",
+  control_planes_custom_config = {
+
+  }
 
   # * LB location and type, the latter will depend on how much load you want it to handle, see https://www.hetzner.com/cloud/load-balancer
   load_balancer_type     = "lb11"

--- a/variables.tf
+++ b/variables.tf
@@ -416,3 +416,9 @@ variable "create_kustomization" {
   default     = true
   description = "Create the kustomization backup as a local file resource. Should be disabled for automatic runs."
 }
+
+variable "control_planes_custom_config" {
+  type = map
+  default = {}
+  description = "Custom control plane configuration e.g to allow etcd monitoring."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -418,7 +418,7 @@ variable "create_kustomization" {
 }
 
 variable "control_planes_custom_config" {
-  type = map
-  default = {}
+  type        = map(any)
+  default     = {}
   description = "Custom control plane configuration e.g to allow etcd monitoring."
 }


### PR DESCRIPTION
Closes #408 
Adds ability to have to custom config.yaml entries for the control planes, I'm not exactly sure if everything works.
`terraform validate` returns no errors, so please correct me if I made something wrong! I haven't actually tested it yet though