### PR TITLE
Added option to configure private registries.

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -21,6 +21,7 @@ module "agents" {
   ipv4_subnet_id             = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
   packages_to_install        = local.packages_to_install
   dns_servers                = var.dns_servers
+  k3s_registries             = var.k3s_registries
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -21,6 +21,7 @@ module "control_planes" {
   ipv4_subnet_id             = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
   packages_to_install        = local.packages_to_install
   dns_servers                = var.dns_servers
+  k3s_registries             = var.k3s_registries
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -109,6 +109,7 @@
 | <a name="input_kured_version"></a> [kured\_version](#input\_kured\_version) | Version of Kured | `string` | `null` | no |
 | <a name="input_load_balancer_disable_ipv6"></a> [load\_balancer\_disable\_ipv6](#input\_load\_balancer\_disable\_ipv6) | Disable ipv6 for the load balancer. | `bool` | `false` | no |
 | <a name="input_load_balancer_location"></a> [load\_balancer\_location](#input\_load\_balancer\_location) | Default load balancer location. | `string` | `"fsn1"` | no |
+| <a name="k3s_registries"></a> [k3s\_registries](#k3s\_registries) | Allows you to specify custom config for private registries. | `string` | `""` | no |
 | <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Default load balancer server type. | `string` | `"lb11"` | no |
 | <a name="input_longhorn_fstype"></a> [longhorn\_fstype](#input\_longhorn\_fstype) | The longhorn fstype. | `string` | `"ext4"` | no |
 | <a name="input_longhorn_replica_count"></a> [longhorn\_replica\_count](#input\_longhorn\_replica\_count) | Number of replicas per longhorn volume. | `number` | `3` | no |

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -266,6 +266,21 @@ module "kube-hetzner" {
   # Whether to use the cluster name in the node name, in the form of {cluster_name}-{nodepool_name}, the default is "true".
   # use_cluster_name_in_node_name = false
 
+  # Extra k3s registries. This is useful if you have private registries and you
+  # want to pull images without additional secrets. 
+  # registries.yaml file docs: https://docs.k3s.io/installation/private-registry
+  /* k3s_registries = <<-EOT
+    mirrors:
+      hub.my_registry.com:
+        endpoint:
+          - "hub.my_registry.com"
+    configs:
+      hub.my_registry.com:
+        auth:
+          username: username
+          password: password
+  EOT */
+
   # Adding extra firewall rules, like opening a port
   # More info on the format here https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall
   # extra_firewall_rules = [

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -194,6 +194,7 @@ data "cloudinit_config" "config" {
         sshPort           = var.ssh_port
         sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
         dnsServers        = var.dns_servers
+        k3sRegistries     = var.k3s_registries
       }
     )
   }

--- a/modules/host/templates/userdata.yaml.tpl
+++ b/modules/host/templates/userdata.yaml.tpl
@@ -66,6 +66,12 @@ write_files:
     X3QBAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   path: /etc/selinux/sshd_t.pp
 
+%{ if k3sRegistries != "" }
+# Create k3s registries file
+- content: ${base64encode(k3sRegistries)}
+  encoding: base64
+  path: /etc/rancher/k3s/registries.yaml
+%{ endif }
 
 # Add ssh authorized keys
 ssh_authorized_keys:

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -88,3 +88,8 @@ variable "automatically_upgrade_os" {
   type    = bool
   default = true
 }
+
+variable "k3s_registries" {
+  default = ""
+  type    = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -422,3 +422,9 @@ variable "control_planes_custom_config" {
   default     = {}
   description = "Custom control plane configuration e.g to allow etcd monitoring."
 }
+
+variable "k3s_registries" {
+  description = "K3S registries.yml contents. It used to access private docker registries."
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
Hi and thanks for amazing project. 

I needed to connect my cluster to existing registries, but I couldn't find an option to do so. 
This is my attempt to create such option.

## Q&A
> Why don't you create this file on node startup?

Because if you change registries.yaml contents later we need to reload all k3s services on all nodes.

> Why do new resources depend on kustomization resource?

Because otherwise, when we create cluster for the first time and you provide custom registry config, the error may occur.
Since we need to restart k3s services after updating the config, it may create a conflict where kustomization target and new targets try to interact with k3s service at the same time.

I would really appreciate a feedback for this PR.

Signed-off-by: Pavel Kirilin <win10@list.ru>