### PR TITLE
Adds option to modify longhorn namespace upon deployment

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -113,6 +113,7 @@
 | <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Default load balancer server type. | `string` | `"lb11"` | no |
 | <a name="input_longhorn_fstype"></a> [longhorn\_fstype](#input\_longhorn\_fstype) | The longhorn fstype. | `string` | `"ext4"` | no |
 | <a name="input_longhorn_replica_count"></a> [longhorn\_replica\_count](#input\_longhorn\_replica\_count) | Number of replicas per longhorn volume. | `number` | `3` | no |
+| <a name="input_longhorn_namespace"></a> [longhorn\_namespace](#input\_longhorn\_namespace) | The namespace for longhorn deployment.  | `string` | `longhorn-system`                                                 |    no    |
 | <a name="input_longhorn_values"></a> [longhorn\_values](#input\_longhorn\_values) | Additional helm values file to pass to longhorn as 'valuesContent' at the HelmChart. | `string` | `""` | no |
 | <a name="input_network_region"></a> [network\_region](#input\_network\_region) | Default region for network. | `string` | `"eu-central"` | no |
 | <a name="input_nginx_ingress_values"></a> [nginx\_ingress\_values](#input\_nginx\_ingress\_values) | Additional helm values file to pass to nginx as 'valuesContent' at the HelmChart. | `string` | `""` | no |

--- a/init.tf
+++ b/init.tf
@@ -195,7 +195,7 @@ resource "null_resource" "kustomization" {
       "${path.module}/templates/longhorn.yaml.tpl",
       {
         longhorn_namespace = var.longhorn_namespace
-        values = indent(4, trimspace(local.longhorn_values))
+        values             = indent(4, trimspace(local.longhorn_values))
     })
     destination = "/var/post_install/longhorn.yaml"
   }

--- a/init.tf
+++ b/init.tf
@@ -194,6 +194,7 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/longhorn.yaml.tpl",
       {
+        longhorn_namespace = var.longhorn_namespace
         values = indent(4, trimspace(local.longhorn_values))
     })
     destination = "/var/post_install/longhorn.yaml"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -182,6 +182,9 @@ module "kube-hetzner" {
   # See a full recap on how to configure agent nodepools for longhorn here https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/373#discussioncomment-3983159
   # enable_longhorn = true
 
+  # The namespace for longhorn deployment, default is "longhorn-system"
+  # longhorn_namespace = "longhorn-system"
+
   # The file system type for Longhorn, if enabled (ext4 is the default, otherwise you can choose xfs)
   # longhorn_fstype = "xfs"
 

--- a/templates/longhorn.yaml.tpl
+++ b/templates/longhorn.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: longhorn-system
+  name: system-longhorn
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -13,7 +13,7 @@ spec:
   chart: longhorn-crd
   # Using this repo makes it compatible with Rancher
   repo: https://charts.rancher.io
-  targetNamespace: longhorn-system
+  targetNamespace: system-longhorn
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -24,6 +24,6 @@ spec:
   chart: longhorn
   # Using this repo makes it compatible with Rancher
   repo: https://charts.rancher.io
-  targetNamespace: longhorn-system
+  targetNamespace: system-longhorn
   valuesContent: |-
     ${values}

--- a/templates/longhorn.yaml.tpl
+++ b/templates/longhorn.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: system-longhorn
+  name: ${longhorn_namespace}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -13,7 +13,7 @@ spec:
   chart: longhorn-crd
   # Using this repo makes it compatible with Rancher
   repo: https://charts.rancher.io
-  targetNamespace: system-longhorn
+  targetNamespace: ${longhorn_namespace}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -24,6 +24,6 @@ spec:
   chart: longhorn
   # Using this repo makes it compatible with Rancher
   repo: https://charts.rancher.io
-  targetNamespace: system-longhorn
+  targetNamespace: ${longhorn_namespace}
   valuesContent: |-
     ${values}

--- a/variables.tf
+++ b/variables.tf
@@ -280,7 +280,11 @@ variable "enable_longhorn" {
   default     = false
   description = "Whether of not to enable Longhorn."
 }
-
+variable "longhorn_namespace" {
+  type        = string
+  default     = "longhorn-system"
+  description = "Namespace for longhorn deployment, defaults to 'longhorn-system'"
+}
 variable "longhorn_fstype" {
   type        = string
   default     = "ext4"


### PR DESCRIPTION
Hi and thanks for the great project.
Due to some tooling constraints I had to modify the namespace longhorn is deployed into.
Initially, this namespace is hardcoded in the deployment.yaml, so this is my attempt to make it configurable via kube.tf
I thought I ask if you might find this useful, but feel free to dismiss if such additions are not considered relevant.
Thanks,
morphine
