### PR TITLE
fix: control_planes_custom_config must be applied to all control-plan…

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -117,7 +117,8 @@ resource "null_resource" "control_planes" {
             module.control_planes[each.key].ipv4_address
           ]
         },
-        local.etcd_s3_snapshots
+        local.etcd_s3_snapshots,
+        var.control_planes_custom_config
       )
     )
 


### PR DESCRIPTION
The user variable `control_planes_custom_config` was only applied on the first control plane node, but with this fix it gets applied on all control plane nodes. Without this fix, a config like this:
```
  control_planes_custom_config = {
    "secrets-encryption" : "true",
  }
```

will hang, as the additional control-plane nodes will never come online. With this fix, they do come online without problems.

Is secrets-encryption=true perhaps a good default to consider?