### PR TITLE
fix: avoid querying repos for latest version if versions are fixed.

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,10 +1,12 @@
 data "github_release" "hetzner_ccm" {
+  count       = var.hetzner_ccm_version == null ? 1 : 0
   repository  = "hcloud-cloud-controller-manager"
   owner       = "hetznercloud"
   retrieve_by = "latest"
 }
 
 data "github_release" "hetzner_csi" {
+  count       = var.hetzner_csi_version == null ? 1 : 0
   repository  = "csi-driver"
   owner       = "hetznercloud"
   retrieve_by = "latest"
@@ -12,6 +14,7 @@ data "github_release" "hetzner_csi" {
 
 // github_release for kured
 data "github_release" "kured" {
+  count       = var.kured_version == null ? 1 : 0
   repository  = "kured"
   owner       = "weaveworks"
   retrieve_by = "latest"

--- a/locals.tf
+++ b/locals.tf
@@ -7,9 +7,9 @@ locals {
   # Otherwise, a new one will be created by the module.
   hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
 
-  ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm.release_tag
-  csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi.release_tag
-  kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured.release_tag
+  ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
+  csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
+  kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
 
   common_commands_install_k3s = [
     "set -ex",


### PR DESCRIPTION
A minor modification, but it seems that github can have issues which make this change useful: if versions of packages are fixed in user input (hetzner_ccm, hetzner_csi and kured), there is no need to ping github to retrieve the latest release numbers. This pull request implements the conditionality of the github_release calls.