### PR TITLE
Fix/destroy on correct state of failed build.

### DIFF
--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -12,7 +12,7 @@ data "remote_file" "kubeconfig" {
 }
 
 locals {
-  kubeconfig_external = replace(replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : (length(keys(module.control_planes)) > 0 ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : "unknown")), "default", var.cluster_name)
+  kubeconfig_external = replace(replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : (can(module.control_planes[keys(module.control_planes)[0]].ipv4_address) ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : "unknown")), "default", var.cluster_name)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
     host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -12,7 +12,10 @@ data "remote_file" "kubeconfig" {
 }
 
 locals {
-  kubeconfig_external = replace(replace(data.remote_file.kubeconfig.content, "127.0.0.1", var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : (can(module.control_planes[keys(module.control_planes)[0]].ipv4_address) ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : "unknown")), "default", var.cluster_name)
+  kubeconfig_server_address = var.use_control_plane_lb ? hcloud_load_balancer.control_plane.*.ipv4[0] : (
+    can(module.control_planes[keys(module.control_planes)[0]].ipv4_address) ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : "unknown"
+  )
+  kubeconfig_external = replace(replace(data.remote_file.kubeconfig.content, "127.0.0.1", local.kubeconfig_server_address), "default", var.cluster_name)
   kubeconfig_parsed   = yamldecode(local.kubeconfig_external)
   kubeconfig_data = {
     host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]


### PR DESCRIPTION
Apparently it can happen that Hetzner Cloud takes too long to setup on of the servers. In this case, terraform times out, and there is no ip in the state, even though the server exists. When terraform-destroying on that state, the ipv4 field may not exist and the destroy could fail. With this fix (building on a previous fix), that scenario now works.