### PR TITLE
Update `registries.yaml` on existing nodes

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -1,4 +1,5 @@
 locals {
+  cluster_prefix = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""
   autoscaler_yaml = length(var.autoscaler_nodepools) == 0 ? "" : templatefile(
     "${path.module}/templates/autoscaler.yaml.tpl",
     {
@@ -6,12 +7,20 @@ locals {
       ca_image         = var.cluster_autoscaler_image
       ca_version       = var.cluster_autoscaler_version
       ssh_key          = local.hcloud_ssh_key_id
-      ipv4_subnet_id   = hcloud_network.k3s.id # for now we use the k3s network, as we cannot reference subnet-ids in autoscaler
-      snapshot_id      = hcloud_snapshot.autoscaler_image[0].id
-      firewall_id      = hcloud_firewall.k3s.id
-      cluster_name     = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""
-      node_pools       = var.autoscaler_nodepools
+      ipv4_subnet_id   = hcloud_network.k3s.id
+      # for now we use the k3s network, as we cannot reference subnet-ids in autoscaler
+      snapshot_id  = hcloud_snapshot.autoscaler_image[0].id
+      firewall_id  = hcloud_firewall.k3s.id
+      cluster_name = local.cluster_prefix
+      node_pools   = var.autoscaler_nodepools
   })
+  # A concatenated list of all autoscaled nodes
+  autoscaled_nodes = {
+    for v in concat([
+      for k, v in data.
+      hcloud_servers.autoscaled_nodes : [for v in v.servers : v]
+    ]...) : v.name => v
+  }
 }
 
 resource "hcloud_snapshot" "autoscaler_image" {
@@ -85,8 +94,40 @@ data "cloudinit_config" "autoscaler-config" {
           node-label    = local.default_agent_labels
           node-taint    = local.default_agent_taints
         })
-        k3s_registries  = var.k3s_registries
+        k3s_registries = var.k3s_registries
       }
     )
+  }
+}
+
+data "hcloud_servers" "autoscaled_nodes" {
+  for_each      = toset(var.autoscaler_nodepools[*].name)
+  with_selector = "hcloud/node-group=${local.cluster_prefix}${each.value}"
+}
+
+resource "null_resource" "autoscaled_nodes_registries" {
+  depends_on = [data.hcloud_servers.autoscaled_nodes]
+  for_each   = local.autoscaled_nodes
+  triggers = {
+    registries = var.k3s_registries
+  }
+
+  connection {
+    user           = "root"
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
+    host           = each.value.ipv4_address
+    port           = var.ssh_port
+  }
+
+  provisioner "file" {
+    content     = var.k3s_registries
+    destination = "/etc/rancher/k3s/registries.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "touch /var/run/reboot-required"
+    ]
   }
 }

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -85,6 +85,7 @@ data "cloudinit_config" "autoscaler-config" {
           node-label    = local.default_agent_labels
           node-taint    = local.default_agent_taints
         })
+        k3s_registries  = var.k3s_registries
       }
     )
   }

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -122,12 +122,19 @@ resource "null_resource" "autoscaled_nodes_registries" {
 
   provisioner "file" {
     content     = var.k3s_registries
-    destination = "/etc/rancher/k3s/registries.yaml"
+    destination = "/tmp/registries.yaml"
   }
 
   provisioner "remote-exec" {
-    inline = [
-      "touch /var/run/reboot-required"
+    inline = [<<-EOT
+    if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml; then
+      echo "No reboot required"
+    else
+      echo "Update registries.yaml, reboot required"
+      cp /tmp/registries.yaml /etc/rancher/k3s/registries.yaml
+      touch /var/run/reboot-required
+    fi
+    EOT
     ]
   }
 }

--- a/kustomize/kured.yaml
+++ b/kustomize/kured.yaml
@@ -19,3 +19,4 @@ spec:
             - /usr/bin/kured
             - --reboot-command=/usr/bin/systemctl reboot
             - --pre-reboot-node-labels=kured=rebooting
+            - --period=5m

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -182,7 +182,7 @@ resource "null_resource" "registries" {
   }
 
   provisioner "file" {
-    content = var.k3s_registries
+    content     = var.k3s_registries
     destination = "/etc/rancher/k3s/registries.yaml"
   }
 

--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -67,6 +67,11 @@ write_files:
   content: ${base64encode(k3s_config)}
 
 - owner: root:root
+  path: /etc/rancher/k3s/registries.yaml
+  encoding: base64
+  content: ${base64encode(k3s_registries)}
+
+- owner: root:root
   path: /root/install-k3s-agent.sh
   permissions: '0600'
   content: |
@@ -74,9 +79,9 @@ write_files:
       set -e
 
       # old k3s is deleted with bootcmd
-      
+
       # run installer. Not the best way to serve directly from a public server, but works for now
-      curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${k3s_channel} INSTALL_K3S_EXEC=agent sh - 
+      curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${k3s_channel} INSTALL_K3S_EXEC=agent sh -
 
       # install selinux module
       /sbin/semodule -v -i /usr/share/selinux/packages/k3s.pp


### PR DESCRIPTION
Issue: #460 

- [x] Deploy `registries.yaml` as `null_resource`
- [x] Add `registries.yaml` to cloud-init for new autoscaled instances
- [x] Update autoscaler on update
- [x] Prevent reboot on first creation
- [x] Find a way to handle autoscaled nodes
