### PR TITLE
Multiple fixes

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -7,21 +7,22 @@ module "agents" {
 
   for_each = local.agent_nodes
 
-  name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  base_domain                = var.base_domain
-  ssh_keys                   = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
-  ssh_port                   = var.ssh_port
-  ssh_public_key             = var.ssh_public_key
-  ssh_private_key            = var.ssh_private_key
-  ssh_additional_public_keys = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
-  firewall_ids               = [hcloud_firewall.k3s.id]
-  placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.agent[floor(each.value.index / 10)].id
-  location                   = each.value.location
-  server_type                = each.value.server_type
-  ipv4_subnet_id             = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install        = local.packages_to_install
-  dns_servers                = var.dns_servers
-  k3s_registries             = var.k3s_registries
+  name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  base_domain                  = var.base_domain
+  ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
+  ssh_port                     = var.ssh_port
+  ssh_public_key               = var.ssh_public_key
+  ssh_private_key              = var.ssh_private_key
+  ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  firewall_ids                 = [hcloud_firewall.k3s.id]
+  placement_group_id           = var.placement_group_disable ? 0 : hcloud_placement_group.agent[floor(each.value.index / 10)].id
+  location                     = each.value.location
+  server_type                  = each.value.server_type
+  ipv4_subnet_id               = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  packages_to_install          = local.packages_to_install
+  dns_servers                  = var.dns_servers
+  k3s_registries               = var.k3s_registries
+  opensuse_microos_mirror_link = var.opensuse_microos_mirror_link
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -131,6 +131,7 @@ resource "null_resource" "autoscaled_nodes_registries" {
       echo "No reboot required"
     else
       echo "Update registries.yaml, reboot required"
+      mkdir -p /etc/rancher/k3s
       cp /tmp/registries.yaml /etc/rancher/k3s/registries.yaml
       touch /var/run/reboot-required
     fi

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -112,11 +112,11 @@ resource "null_resource" "control_planes" {
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {
-          tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
+          tls-san = concat([hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]], var.additional_tls_sans)
           } : {
-          tls-san = [
+          tls-san = concat([
             module.control_planes[each.key].ipv4_address
-          ]
+          ], var.additional_tls_sans)
         },
         local.etcd_s3_snapshots,
         var.control_planes_custom_config

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -7,21 +7,22 @@ module "control_planes" {
 
   for_each = local.control_plane_nodes
 
-  name                       = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  base_domain                = var.base_domain
-  ssh_keys                   = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
-  ssh_port                   = var.ssh_port
-  ssh_public_key             = var.ssh_public_key
-  ssh_private_key            = var.ssh_private_key
-  ssh_additional_public_keys = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
-  firewall_ids               = [hcloud_firewall.k3s.id]
-  placement_group_id         = var.placement_group_disable ? 0 : hcloud_placement_group.control_plane[floor(each.value.index / 10)].id
-  location                   = each.value.location
-  server_type                = each.value.server_type
-  ipv4_subnet_id             = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  packages_to_install        = local.packages_to_install
-  dns_servers                = var.dns_servers
-  k3s_registries             = var.k3s_registries
+  name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  base_domain                  = var.base_domain
+  ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
+  ssh_port                     = var.ssh_port
+  ssh_public_key               = var.ssh_public_key
+  ssh_private_key              = var.ssh_private_key
+  ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  firewall_ids                 = [hcloud_firewall.k3s.id]
+  placement_group_id           = var.placement_group_disable ? 0 : hcloud_placement_group.control_plane[floor(each.value.index / 10)].id
+  location                     = each.value.location
+  server_type                  = each.value.server_type
+  ipv4_subnet_id               = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  packages_to_install          = local.packages_to_install
+  dns_servers                  = var.dns_servers
+  k3s_registries               = var.k3s_registries
+  opensuse_microos_mirror_link = var.opensuse_microos_mirror_link
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.

--- a/init.tf
+++ b/init.tf
@@ -27,9 +27,9 @@ resource "null_resource" "first_control_plane" {
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {
-          tls-san = [hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]]
+          tls-san = concat([hcloud_load_balancer.control_plane.*.ipv4[0], hcloud_load_balancer_network.control_plane.*.ip[0]], var.additional_tls_sans)
           } : {
-          tls-san = [module.control_planes[keys(module.control_planes)[0]].ipv4_address]
+          tls-san = concat([module.control_planes[keys(module.control_planes)[0]].ipv4_address], var.additional_tls_sans)
         },
         local.etcd_s3_snapshots,
         var.control_planes_custom_config

--- a/init.tf
+++ b/init.tf
@@ -106,7 +106,7 @@ resource "null_resource" "kustomization" {
           "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml",
         ],
         var.disable_hetzner_csi ? [] : [
-          "https://raw.githubusercontent.com/hetznercloud/csi-driver/${local.csi_version}/deploy/kubernetes/hcloud-csi.yml"
+          "hcloud-csi.yml"
         ],
         lookup(local.ingress_controller_install_resources, local.ingress_controller, []),
         lookup(local.cni_install_resources, var.cni_plugin, []),
@@ -227,6 +227,7 @@ resource "null_resource" "kustomization" {
       "set -ex",
       "kubectl -n kube-system create secret generic hcloud --from-literal=token=${var.hcloud_token} --from-literal=network=${hcloud_network.k3s.name} --dry-run=client -o yaml | kubectl apply -f -",
       "kubectl -n kube-system create secret generic hcloud-csi --from-literal=token=${var.hcloud_token} --dry-run=client -o yaml | kubectl apply -f -",
+      "curl https://raw.githubusercontent.com/hetznercloud/csi-driver/${local.csi_version}/deploy/kubernetes/hcloud-csi.yml | sed -e 's|k8s.gcr.io|registry.k8s.io|g' > /var/post_install/hcloud-csi.yml"
     ]
   }
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -332,6 +332,12 @@ module "kube-hetzner" {
   # The default is false.
   # use_control_plane_lb = true
 
+  # Oftentimes, you need to communicate to the cluster from inside the cluster itself, in which case it is important to set this value, as it will configure the hostname
+  # at the load balancer level, and will save you from many slows downs when initiating communications from inside. Later on, you can point your DNS to the IP given
+  # to the LB. And if you have other services pointing to it, you are also free to create CNAMES to point to it, or whatever you see fit.
+  # If set, it will apply to either ingress controllers, Traefik or Ingress-Nginx.
+  # lb_hostname = ""
+
   # You can enable Rancher (installed by Helm behind the scenes) with the following flag, the default is "false".
   # When Rancher is enabled, it automatically installs cert-manager too, and it uses rancher's own self-signed certificates.
   # See for options https://rancher.com/docs/rancher/v2.0-v2.4/en/installation/resources/advanced/helm2/helm-rancher/#choose-your-ssl-configuration
@@ -345,6 +351,8 @@ module "kube-hetzner" {
 
   # If using Rancher you can set the Rancher hostname, it must be unique hostname even if you do not use it.
   # If not pointing the DNS, you can just port-forward locally via kubectl to get access to the dashboard.
+  # If you already set the lb_hostname above and are using a Hetzner LB, you do not need to set this one, as it will be used by default.
+  # But if you set this one explicitly, it will have preference over the lb_hostname in rancher settings.
   # rancher_hostname = "rancher.xyz.dev"
 
   # When Rancher is deployed, by default is uses the "latest" channel. But this can be customized.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -324,6 +324,11 @@ module "kube-hetzner" {
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "false".
   # enable_cert_manager = true
 
+  # By default we use a known good mirror to download the needed OpenSUSE, but for instance, it may not be available in US-East location, in which case,
+  # you can find a working mirror for you at https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist,
+  # Or use the value below to automatically select an optimal mirror (by default we have it fixed to one german mirror that we know works for most locations)
+  # opensuse_microos_mirror_link = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+
   # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", " 1.0.0.1", "8.8.8.8"].
   # For rancher installs, best to leave it as default.
   # dns_servers = []

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -337,6 +337,11 @@ module "kube-hetzner" {
   # The default is false.
   # use_control_plane_lb = true
 
+  # Let's say you are not using the control plane LB solution above, and still want to have one hostname point to all your control-plane nodes.
+  # You could create multiple A records of to let's say cp.cluster.my.org pointing to all of your control-plane nodes ips.
+  # In which case, you need to define that hostname in the k3s TLS-SANs config to allow connection through it. It can be hostnames or IP addresses.
+  # additional_tls_sans = ["cp.cluster.my.org"]
+
   # Oftentimes, you need to communicate to the cluster from inside the cluster itself, in which case it is important to set this value, as it will configure the hostname
   # at the load balancer level, and will save you from many slows downs when initiating communications from inside. Later on, you can point your DNS to the IP given
   # to the LB. And if you have other services pointing to it, you are also free to create CNAMES to point to it, or whatever you see fit.

--- a/kustomize/kured.yaml
+++ b/kustomize/kured.yaml
@@ -19,3 +19,4 @@ spec:
             - /usr/bin/kured
             - --reboot-command=/usr/bin/systemctl reboot
             - --pre-reboot-node-labels=kured=rebooting
+            - --post-reboot-node-labels=kured=done

--- a/locals.tf
+++ b/locals.tf
@@ -347,6 +347,9 @@ controller:
       "load-balancer.hetzner.cloud/location": "${var.load_balancer_location}"
       "load-balancer.hetzner.cloud/type": "${var.load_balancer_type}"
       "load-balancer.hetzner.cloud/uses-proxyprotocol": "true"
+%{if var.lb_hostname != ""~}
+      "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
+%{endif~}
 %{endif~}
   EOT
 
@@ -364,6 +367,9 @@ service:
     "load-balancer.hetzner.cloud/location": "${var.load_balancer_location}"
     "load-balancer.hetzner.cloud/type": "${var.load_balancer_type}"
     "load-balancer.hetzner.cloud/uses-proxyprotocol": "true"
+%{if var.lb_hostname != ""~}
+      "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
+%{endif~}
 %{endif~}
 additionalArguments:
 %{if !local.using_klipper_lb~}
@@ -383,7 +389,7 @@ additionalArguments:
   EOT
 
   rancher_values = var.rancher_values != "" ? var.rancher_values : <<EOT
-hostname: "${var.rancher_hostname}"
+hostname: "${var.rancher_hostname} ? ${var.rancher_hostname} : ${var.lb_hostname}"
 replicas: ${length(local.control_plane_nodes)}
 bootstrapPassword: "${length(var.rancher_bootstrap_password) == 0 ? resource.random_password.rancher_bootstrap[0].result : var.rancher_bootstrap_password}"
   EOT

--- a/locals.tf
+++ b/locals.tf
@@ -92,7 +92,7 @@ locals {
   default_agent_taints         = concat([], var.cni_plugin == "cilium" ? ["node.cilium.io/agent-not-ready:NoExecute"] : [])
 
 
-  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs"] : [], var.extra_packages_to_install)
+  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs", "cryptsetup"] : [], var.extra_packages_to_install)
 
   # The following IPs are important to be whitelisted because they communicate with Hetzner services and enable the CCM and CSI to work properly.
   # Source https://github.com/hetznercloud/csi-driver/issues/204#issuecomment-848625566

--- a/locals.tf
+++ b/locals.tf
@@ -83,7 +83,7 @@ locals {
 
   # Default k3s node labels
   default_agent_labels         = concat([], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
-  default_control_plane_labels = concat([], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
+  default_control_plane_labels = concat(["node.kubernetes.io/exclude-from-external-load-balancers=${local.allow_scheduling_on_control_plane ? "true" : "false"}"], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
 
   allow_scheduling_on_control_plane = (local.is_single_node_cluster || local.using_klipper_lb) ? true : var.allow_scheduling_on_control_plane
 

--- a/locals.tf
+++ b/locals.tf
@@ -123,11 +123,6 @@ locals {
       port       = "any"
       source_ips = local.whitelisted_ips
     },
-    {
-      direction  = "in"
-      protocol   = "icmp"
-      source_ips = local.whitelisted_ips
-    },
 
     # Allow all traffic to the kube api server
     {
@@ -147,7 +142,8 @@ locals {
       source_ips = [
         "0.0.0.0/0"
       ]
-    },
+    }
+    ], var.ssh_port == 22 ? [] : [
     {
       direction = "in"
       protocol  = "tcp"
@@ -156,99 +152,115 @@ locals {
         "0.0.0.0/0"
       ]
     },
+    ],
+    [
+      # Allow basic out traffic
+      # ICMP to ping outside services
+      {
+        direction = "out"
+        protocol  = "icmp"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      },
 
-    # Allow basic out traffic
-    # ICMP to ping outside services
-    {
-      direction = "out"
-      protocol  = "icmp"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    },
+      # DNS
+      {
+        direction = "out"
+        protocol  = "tcp"
+        port      = "53"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      },
+      {
+        direction = "out"
+        protocol  = "udp"
+        port      = "53"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      },
 
-    # DNS
-    {
-      direction = "out"
-      protocol  = "tcp"
-      port      = "53"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    },
-    {
-      direction = "out"
-      protocol  = "udp"
-      port      = "53"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    },
+      # HTTP(s)
+      {
+        direction = "out"
+        protocol  = "tcp"
+        port      = "80"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      },
+      {
+        direction = "out"
+        protocol  = "tcp"
+        port      = "443"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      },
 
-    # HTTP(s)
-    {
-      direction = "out"
-      protocol  = "tcp"
-      port      = "80"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    },
-    {
-      direction = "out"
-      protocol  = "tcp"
-      port      = "443"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    },
-
-    #NTP
-    {
-      direction = "out"
-      protocol  = "udp"
-      port      = "123"
-      destination_ips = [
-        "0.0.0.0/0"
-      ]
-    }
-    ], !local.using_klipper_lb ? [] : [
-    # Allow incoming web traffic for single node clusters, because we are using k3s servicelb there,
-    # not an external load-balancer.
-    {
-      direction = "in"
-      protocol  = "tcp"
-      port      = "80"
-      source_ips = [
-        "0.0.0.0/0"
-      ]
-    },
-    {
-      direction = "in"
-      protocol  = "tcp"
-      port      = "443"
-      source_ips = [
-        "0.0.0.0/0"
-      ]
-    }
-    ], var.block_icmp_ping_in ? [] : [
-    {
-      direction = "in"
-      protocol  = "icmp"
-      source_ips = [
-        "0.0.0.0/0"
-      ]
-    }
-    ], var.cni_plugin != "cilium" ? [] : [
-    {
-      direction = "in"
-      protocol  = "tcp"
-      port      = "4244-4245"
-      source_ips = [
-        "0.0.0.0/0"
-      ]
-    }
+      #NTP
+      {
+        direction = "out"
+        protocol  = "udp"
+        port      = "123"
+        destination_ips = [
+          "0.0.0.0/0"
+        ]
+      }
+      ], !local.using_klipper_lb ? [] : [
+      # Allow incoming web traffic for single node clusters, because we are using k3s servicelb there,
+      # not an external load-balancer.
+      {
+        direction = "in"
+        protocol  = "tcp"
+        port      = "80"
+        source_ips = [
+          "0.0.0.0/0"
+        ]
+      },
+      {
+        direction = "in"
+        protocol  = "tcp"
+        port      = "443"
+        source_ips = [
+          "0.0.0.0/0"
+        ]
+      }
+      ], var.block_icmp_ping_in ? [] : [
+      {
+        direction = "in"
+        protocol  = "icmp"
+        source_ips = [
+          "0.0.0.0/0"
+        ]
+      }
+      ], var.cni_plugin != "cilium" ? [] : [
+      {
+        direction = "in"
+        protocol  = "tcp"
+        port      = "4244-4245"
+        source_ips = [
+          "0.0.0.0/0"
+        ]
+      }
   ])
+
+  # create a new firewall list based on base_firewall_rules but with direction-protocol-port as key
+  # this is needed to avoid duplicate rules
+  firewall_rules = { for rule in local.base_firewall_rules : format("%s-%s-%s", lookup(rule, "direction", "null"), lookup(rule, "protocol", "null"), lookup(rule, "port", "null")) => rule }
+
+
+
+  # do the same for var.extra_firewall_rules
+  extra_firewall_rules = { for rule in var.extra_firewall_rules : format("%s-%s-%s", lookup(rule, "direction", "null"), lookup(rule, "protocol", "null"), lookup(rule, "port", "null")) => rule }
+
+  # merge the two lists
+  firewall_rules_merged = merge(local.firewall_rules, local.extra_firewall_rules)
+
+  # convert the merged list back to a list
+  firewall_rules_list = values(local.firewall_rules_merged)
 
   labels = {
     "provisioner" = "terraform",

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "hcloud_firewall" "k3s" {
   name = var.cluster_name
 
   dynamic "rule" {
-    for_each = concat(local.base_firewall_rules, var.extra_firewall_rules)
+    for_each = local.firewall_rules_list
     content {
       direction       = rule.value.direction
       protocol        = rule.value.protocol

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -75,7 +75,7 @@ resource "hcloud_server" "server" {
 
     inline = [
       "set -ex",
-      "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2",
+      "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only ${var.opensuse_microos_mirror_link}",
       "qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*qcow2$') /dev/sda",
     ]
   }

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -193,6 +193,7 @@ resource "null_resource" "registries" {
       echo "No reboot required"
     else
       echo "Update registries.yaml, reboot required"
+      mkdir -p /etc/rancher/k3s
       cp /tmp/registries.yaml /etc/rancher/k3s/registries.yaml
       touch /var/run/reboot-required
     fi

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -93,3 +93,8 @@ variable "k3s_registries" {
   default = ""
   type    = string
 }
+
+variable "opensuse_microos_mirror_link" {
+  default = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+  type    = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "lb_hostname" {
   description = "The Hetzner Load Balancer hostname, for either Traefik or Ingress-Nginx."
 
   validation {
-    condition     = can(regex("^(?:(?:(?:[A-Za-z0-9])|(?:[A-Za-z0-9](?:[A-Za-z0-9\\-]+)?[A-Za-z0-9]))+(\\.))+([A-Za-z]{2,})([\\/?])?([\\/?][A-Za-z0-9\\-%._~:\\/?#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]+)?$", var.rancher_hostname)) || var.rancher_hostname == ""
+    condition     = can(regex("^(?:(?:(?:[A-Za-z0-9])|(?:[A-Za-z0-9](?:[A-Za-z0-9\\-]+)?[A-Za-z0-9]))+(\\.))+([A-Za-z]{2,})([\\/?])?([\\/?][A-Za-z0-9\\-%._~:\\/?#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]+)?$", var.lb_hostname)) || var.lb_hostname == ""
     error_message = "It must be a valid domain name (FQDN)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -454,3 +454,9 @@ variable "opensuse_microos_mirror_link" {
     error_message = "You need to use a mirror link from https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist"
   }
 }
+
+variable "additional_tls_sans" {
+  description = "Additional TLS SANs to allow connection to control-plane through it."
+  default     = []
+  type        = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -443,3 +443,14 @@ variable "k3s_registries" {
   default     = ""
   type        = string
 }
+
+variable "opensuse_microos_mirror_link" {
+  description = "The mirror link to use for the opensuse microos image."
+  default     = "https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+  type        = string
+
+  validation {
+    condition     = can(regex("^https.*openSUSE-MicroOS\\.x86_64-OpenStack-Cloud\\.qcow2$", var.opensuse_microos_mirror_link))
+    error_message = "You need to use a mirror link from https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -354,6 +354,17 @@ variable "rancher_hostname" {
   }
 }
 
+variable "lb_hostname" {
+  type        = string
+  default     = ""
+  description = "The Hetzner Load Balancer hostname, for either Traefik or Ingress-Nginx."
+
+  validation {
+    condition     = can(regex("^(?:(?:(?:[A-Za-z0-9])|(?:[A-Za-z0-9](?:[A-Za-z0-9\\-]+)?[A-Za-z0-9]))+(\\.))+([A-Za-z]{2,})([\\/?])?([\\/?][A-Za-z0-9\\-%._~:\\/?#\\[\\]@!\\$&\\'\\(\\)\\*\\+,;=]+)?$", var.rancher_hostname)) || var.rancher_hostname == ""
+    error_message = "It must be a valid domain name (FQDN)."
+  }
+}
+
 variable "rancher_registration_manifest_url" {
   type        = string
   description = "The url of a rancher registration manifest to apply. (see https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/)."


### PR DESCRIPTION
Closes:
- #469, fixes container pull errors.
- #467, brings multiple TLS-SANs.
- #461, brings the ability to set a custom mirror link for MicroOS.
- #447, fixes control plane nodes showing up in LB as targets when scheduling is not allowed.
- #436, fixes SSH extra rules merging, now done correctly.
