### PR TITLE
fix: validation regex for var.opensuse_microos_mirror_link , because …

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -450,7 +450,7 @@ variable "opensuse_microos_mirror_link" {
   type        = string
 
   validation {
-    condition     = can(regex("^https.*openSUSE-MicroOS\\.x86_64-OpenStack-Cloud\\.qcow2$", var.opensuse_microos_mirror_link))
+    condition     = can(regex("^https.*openSUSE-MicroOS\\.x86_64[\\-0-9\\.]*-OpenStack-Cloud.*\\.qcow2$", var.opensuse_microos_mirror_link))
     error_message = "You need to use a mirror link from https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist"
   }
 }


### PR DESCRIPTION
…the urls listed at the mirror list now include version info.