### PR TITLE
feat: added variable for choosing repository for longhorn helm chart.

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -194,8 +194,9 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/longhorn.yaml.tpl",
       {
-        longhorn_namespace = var.longhorn_namespace
-        values             = indent(4, trimspace(local.longhorn_values))
+        longhorn_namespace  = var.longhorn_namespace
+        longhorn_repository = var.longhorn_repository
+        values              = indent(4, trimspace(local.longhorn_values))
     })
     destination = "/var/post_install/longhorn.yaml"
   }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -182,6 +182,10 @@ module "kube-hetzner" {
   # See a full recap on how to configure agent nodepools for longhorn here https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/373#discussioncomment-3983159
   # enable_longhorn = true
 
+  # By default, longhorn is pulled from https://charts.rancher.io which assures compatibility with rancher.
+  # If you need a newer version of longhorn you can set this variable to https://charts.longhorn.io. 
+  # longhorn_repository = "https://charts.rancher.io"
+
   # The namespace for longhorn deployment, default is "longhorn-system"
   # longhorn_namespace = "longhorn-system"
 

--- a/templates/longhorn.yaml.tpl
+++ b/templates/longhorn.yaml.tpl
@@ -11,8 +11,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: longhorn-crd
-  # Using this repo makes it compatible with Rancher
-  repo: https://charts.rancher.io
+  repo: ${longhorn_repository}
   targetNamespace: ${longhorn_namespace}
 ---
 apiVersion: helm.cattle.io/v1
@@ -22,8 +21,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: longhorn
-  # Using this repo makes it compatible with Rancher
-  repo: https://charts.rancher.io
+  repo: ${longhorn_repository}
   targetNamespace: ${longhorn_namespace}
   valuesContent: |-
     ${values}

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,11 @@ variable "enable_longhorn" {
   default     = false
   description = "Whether of not to enable Longhorn."
 }
+variable "longhorn_repository" {
+  type        = string
+  default     = "https://charts.rancher.io"
+  description = "By default a forked chart which is compatible with rancher is used, but if that version is behind on what you need, switch to https://charts.longhorn.io."
+}
 variable "longhorn_namespace" {
   type        = string
   default     = "longhorn-system"


### PR DESCRIPTION
The default repository from which longhorn is pullen, is a mirror from rancher. This assures compatibility with rancher. However, as it is a modified mirror, it can be behind in version compared to the upstream source longhorn.io. This PR adds an optional variable so you can point to longhorn.io.

Use case today: k3s v1.25 with longhorn 1.4 run perfectly fine together when you use the longhorn.io helm repository.