### PR TITLE
feat: add wireguard option

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -127,7 +127,7 @@ resource "null_resource" "autoscaled_nodes_registries" {
 
   provisioner "remote-exec" {
     inline = [<<-EOT
-    if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml; then
+    if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml || [ ! -f /etc/rancher/k3s/registries.yaml ]; then
       echo "No reboot required"
     else
       echo "Update registries.yaml, reboot required"

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -104,6 +104,7 @@ resource "null_resource" "control_planes" {
           kubelet-arg                 = local.kubelet_arg
           kube-controller-manager-arg = local.kube_controller_manager_arg
           flannel-iface               = local.flannel_iface
+          flannel-backend             = "wireguard-native"
           node-ip                     = module.control_planes[each.key].private_ipv4_address
           advertise-address           = module.control_planes[each.key].private_ipv4_address
           node-label                  = each.value.labels

--- a/init.tf
+++ b/init.tf
@@ -20,6 +20,7 @@ resource "null_resource" "first_control_plane" {
           kubelet-arg                 = local.kubelet_arg
           kube-controller-manager-arg = local.kube_controller_manager_arg
           flannel-iface               = local.flannel_iface
+          flannel-backend             = "wireguard-native"
           node-ip                     = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints

--- a/locals.tf
+++ b/locals.tf
@@ -91,7 +91,11 @@ locals {
   default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/control-plane:NoSchedule"])
   default_agent_taints         = concat([], var.cni_plugin == "cilium" ? ["node.cilium.io/agent-not-ready:NoExecute"] : [])
 
-  packages_to_install = concat(var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs", "cryptsetup"] : [], var.extra_packages_to_install)
+  packages_to_install = concat(
+    ["wireguard-tools"],
+    var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs", "cryptsetup"] : [],
+    var.extra_packages_to_install,
+  )
 
   # The following IPs are important to be whitelisted because they communicate with Hetzner services and enable the CCM and CSI to work properly.
   # Source https://github.com/hetznercloud/csi-driver/issues/204#issuecomment-848625566

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -189,7 +189,7 @@ resource "null_resource" "registries" {
 
   provisioner "remote-exec" {
     inline = [<<-EOT
-    if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml; then
+    if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml || [ ! -f /etc/rancher/k3s/registries.yaml ]; then
       echo "No reboot required"
     else
       echo "Update registries.yaml, reboot required"


### PR DESCRIPTION
I chose not to make this an optional thing, avoiding adding variables. Only merge this branch if tests show that it is a good idea. Otherwise modify the code to make wireguard optional. See https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/527

I do not know all the arguments for and against making this standard, so I am marking this MR as draft and hope to see some discussion about it.