### PR TITLE
Emergency downgrade of the container-selinux package + tiny improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ kubectl delete plan k3s-agent -n system-upgrade
 kubectl delete plan k3s-server -n system-upgrade
 ```
 
+Also, note that after turning off nodes upgrades, you will need to manually upgrade the nodes when needed. You can do so by SSH'ing into each node and running the following commands (and don't forget to drain the node before with `kubectl drain <node-name>`):
+
+```sh
+transactional-update
+reboot
+```
+
 ### Individual Components Upgrade
 
 Rarely needed, but can be handy in the long run. During the installation, we automatically download a backup of the kustomization to a `kustomization_backup.yaml` file. You will find it next to your `clustername_kubeconfig.yaml` at the root of your project.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -349,9 +349,9 @@ module "kube-hetzner" {
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "false".
   # enable_cert_manager = true
 
-  # By default we use a a mirror is automatically chosen for you, but if somehow you get a bad one, you can set the one you want manually.
-  # You can find a working mirror for you at https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist,
-  # Or use the one in the example below, that has proven to be solid from most locations.
+  # By default a mirror is automatically chosen for you, but if you get a bad one (it rarely happens), you can set the one you want manually.
+  # You can find a working mirror at https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist,
+  # Or just use the one in the example below, that has proven to be a solid one from most locations.
   # opensuse_microos_mirror_link = "https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
 
   # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", " 1.0.0.1", "8.8.8.8"].

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -349,10 +349,10 @@ module "kube-hetzner" {
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "false".
   # enable_cert_manager = true
 
-  # By default we use a known good mirror to download the needed OpenSUSE, but for instance, it may not be available in US-East location, in which case,
-  # you can find a working mirror for you at https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist,
-  # Or use the value below to automatically select an optimal mirror (by default we have it fixed to one german mirror that we know works for most locations)
-  # opensuse_microos_mirror_link = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+  # By default we use a a mirror is automatically chosen for you, but if somehow you get a bad one, you can set the one you want manually.
+  # You can find a working mirror for you at https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.mirrorlist,
+  # Or use the one in the example below, that has proven to be solid from most locations.
+  # opensuse_microos_mirror_link = "https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
 
   # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", " 1.0.0.1", "8.8.8.8"].
   # For rancher installs, best to leave it as default.

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -10,7 +10,7 @@ locals {
   ssh_client_identity = var.ssh_private_key == null ? var.ssh_public_key : var.ssh_private_key
 
   # Final list of packages to install
-  needed_packages = join(" ", concat(["k3s-selinux"], var.packages_to_install))
+  needed_packages = join(" ", concat(["k3s-selinux restorecond policycoreutils setools-console"], var.packages_to_install))
 
   # the hosts name with its unique suffix attached
   name = "${var.name}-${random_string.server.id}"

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -110,7 +110,8 @@ resource "hcloud_server" "server" {
 
     inline = [<<-EOT
       set -ex
-      transactional-update shell <<< "zypper --gpg-auto-import-keys install -y ${local.needed_packages}"
+      transactional-update shell <<< "zypper install -y --oldpackage https://download.opensuse.org/tumbleweed/repo/oss/noarch/container-selinux-2.188.0-2.1.noarch.rpm && zypper addlock container-selinux"
+      transactional-update --continue shell <<< "zypper --gpg-auto-import-keys install -y ${local.needed_packages}"
       sleep 1 && udevadm settle
       EOT
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -471,7 +471,7 @@ variable "k3s_registries" {
 
 variable "opensuse_microos_mirror_link" {
   description = "The mirror link to use for the opensuse microos image."
-  default     = "https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+  default     = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
   type        = string
 
   validation {


### PR DESCRIPTION
This fixes #528, by temporarily downgrading the `container-selinux` package, while we wait for the fix, most probably coming in the next version of `k3s-selinux`. See https://github.com/k3s-io/k3s-selinux/issues/36

Also, I lock the `container-selinux` package, so that an automatic upgrade, so not break the system.

![ksnip_20230125-042006](https://user-images.githubusercontent.com/518555/214473533-eb606100-58c0-4e8d-92b2-e5edb46a6e56.png)

Last but not least, this PR does small improvements, like switching back to the automatic mirror OpenSUSE MicroOS link, as previously suggested by @aleksasiriski, while preserving the known-working mirror link in the `kube.tf.example`.