### PR TITLE
Feat/custom env

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report any vulnerability findings privately via email to the top three contributors to the projects. You can find our emails by grepping the git logs.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -123,7 +123,7 @@
 | <a name="input_longhorn_values"></a> [longhorn\_values](#input\_longhorn\_values) | Additional helm values file to pass to longhorn as 'valuesContent' at the HelmChart. | `string` | `""` | no |
 | <a name="input_network_region"></a> [network\_region](#input\_network\_region) | Default region for network. | `string` | `"eu-central"` | no |
 | <a name="input_nginx_values"></a> [nginx\_values](#input\_nginx\_values) | Additional helm values file to pass to nginx as 'valuesContent' at the HelmChart. | `string` | `""` | no |
-| <a name="input_opensuse_microos_mirror_link"></a> [opensuse\_microos\_mirror\_link](#input\_opensuse\_microos\_mirror\_link) | The mirror link to use for the opensuse microos image. | `string` | `"https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"` | no |
+| <a name="input_opensuse_microos_mirror_link"></a> [opensuse\_microos\_mirror\_link](#input\_opensuse\_microos\_mirror\_link) | The mirror link to use for the opensuse microos image. | `string` | `"https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"` | no |
 | <a name="input_placement_group_disable"></a> [placement\_group\_disable](#input\_placement\_group\_disable) | Whether to disable placement groups. | `bool` | `false` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Rancher bootstrap password. | `string` | `""` | no |
 | <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | The rancher hostname. | `string` | `""` | no |

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -305,6 +305,19 @@ module "kube-hetzner" {
           password: password
   EOT */
 
+  # Additional environment variables for the host OS on which k3s runs. See for example https://docs.k3s.io/advanced#configuring-an-http-proxy . 
+  # additional_k3s_environment = {
+  #   "CONTAINERD_HTTP_PROXY" : "http://your.proxy:port",
+  #   "CONTAINERD_HTTPS_PROXY" : "http://your.proxy:port",
+  #   "NO_PROXY" : "127.0.0.0/8,10.0.0.0/8,",
+  # }
+
+  # Additional commands to execute on the host OS before the install calls, for example fetching and installing certs.
+  # preinstall_exec = [
+  #   "curl https://somewhere.over.the.rainbow/ca.crt > /root/ca.crt",
+  #   "trust anchor --store /root/ca.crt",
+  # ]
+
   # If you want to allow all outbound traffic you can set this to "false". Default is "true".
   # restrict_outbound_traffic = false
 

--- a/variables.tf
+++ b/variables.tf
@@ -433,6 +433,19 @@ variable "dns_servers" {
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner."
 }
 
+variable "additional_k3s_environment" {
+  type        = map(any)
+  default     = {}
+  description = "Additional environment variables for the k3s binary. See for example https://docs.k3s.io/advanced#configuring-an-http-proxy ."
+}
+
+variable "preinstall_exec" {
+  type        = list(string)
+  default     = []
+  description = "Additional to execute before the install calls, for example fetching and installing certs."
+}
+
+
 variable "extra_packages_to_install" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
Commits related to this comment https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions#discussioncomment-4779692

These changes allow you to set environment variables on the host nodes. Notably, HTTP(S)_PROXY which lets you route all the outbound traffic. Use this to work around the fact that some Hetzner IPs are blocked by various different container registries.