### PR TITLE
Fix/auto assign ips

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -24,8 +24,6 @@ module "agents" {
   k3s_registries               = var.k3s_registries
   opensuse_microos_mirror_link = var.opensuse_microos_mirror_link
 
-  private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
-
   labels = merge(local.labels, local.labels_agent_node)
 
   automatically_upgrade_os = var.automatically_upgrade_os

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -24,10 +24,6 @@ module "control_planes" {
   k3s_registries               = var.k3s_registries
   opensuse_microos_mirror_link = var.opensuse_microos_mirror_link
 
-  # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
-  # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
-  private_ipv4 = cidrhost(hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
-
   labels = merge(local.labels, local.labels_control_plane_node)
 
   automatically_upgrade_os = var.automatically_upgrade_os

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -212,7 +212,7 @@ resource "hcloud_rdns" "server" {
 }
 
 resource "hcloud_server_network" "server" {
-  ip        = var.private_ipv4
+  # auto-assign the ip.
   server_id = hcloud_server.server.id
   subnet_id = var.ipv4_subnet_id
 }

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -63,10 +63,6 @@ variable "ipv4_subnet_id" {
   type        = string
 }
 
-variable "private_ipv4" {
-  description = "Private IP for the server"
-  type        = string
-}
 
 variable "server_type" {
   description = "The server type"


### PR DESCRIPTION
No need to compute the ips, have them be auto-assigned. The benefit is:
- less code to maintain,
- no worries when adding things to the network later which have not been imagined yet.