### PR TITLE
Feat/private ip during microos install

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -183,7 +183,10 @@ resource "null_resource" "server_setup" {
 }
 
 resource "null_resource" "registries" {
-  depends_on = [hcloud_server.server]
+  depends_on = [
+    hcloud_server.server,
+    null_resource.server_setup,
+  ]
 
   triggers = {
     registries = var.k3s_registries


### PR DESCRIPTION
refactor: moving the shell scripting of the server installation outside of the hcloud_server block.
    
All the remote-exec blocks are now in a null-resource, instead of immediately in the hcloud_server block. The benefit is that now the private ip can be assigned (in the subnet) before microos is installed. With the current code base that has zero impact, but it opens up the possibility to ho to communicate safely in the private network at the installation stage already.

