### PR TITLE
moved uninstall of k3s to runcmd section

### DIFF
--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -4,10 +4,6 @@ instance-id: iid-abcde001
 
 debug: True
 
-bootcmd:
-# uninstall k3s if it exists already in the snaphshot
-- [/bin/sh, -c, '[ -f /usr/local/bin/k3s-uninstall.sh ] && /usr/local/bin/k3s-uninstall.sh']
-
 write_files:
 
 # Configure the private network interface
@@ -78,8 +74,6 @@ write_files:
       #!/bin/sh
       set -e
 
-      # old k3s is deleted with bootcmd
-
       # run installer. Not the best way to serve directly from a public server, but works for now
       curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${k3s_channel} INSTALL_K3S_EXEC=agent sh -
 
@@ -103,6 +97,8 @@ hostname: ${hostname}
 preserve_hostname: true
 
 runcmd:
+# uninstall k3s if it exists already in the snaphshot
+- [/bin/sh, -c, '[ -f /usr/local/bin/k3s-uninstall.sh ] && /usr/local/bin/k3s-uninstall.sh']
 
 # ensure that /var uses full available disk size, thanks to btrfs this is easy
 - [btrfs, 'filesystem', 'resize', 'max', '/var']


### PR DESCRIPTION
This fixes https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/537#issuecomment-1405448035

Uninstall was wrongly placed in bootcmd section.

