### PR TITLE
fix: systemctl restart k3s instead of rebooting the machine.

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -130,10 +130,14 @@ resource "null_resource" "autoscaled_nodes_registries" {
     if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml || [ ! -f /etc/rancher/k3s/registries.yaml ]; then
       echo "No reboot required"
     else
-      echo "Update registries.yaml, reboot required"
+      echo "Update registries.yaml, restart of k3s required"
       mkdir -p /etc/rancher/k3s
       cp /tmp/registries.yaml /etc/rancher/k3s/registries.yaml
-      touch /var/run/reboot-required
+      if systemctl status k3s > /dev/null; then 
+        systemctl restart k3s; 
+      elif systemctl status k3s-agent > /dev/null; then 
+        systemctl restart k3s-agent; 
+      fi  
     fi
     EOT
     ]

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -193,10 +193,14 @@ resource "null_resource" "registries" {
     if cmp -s /tmp/registries.yaml /etc/rancher/k3s/registries.yaml || [ ! -f /etc/rancher/k3s/registries.yaml ]; then
       echo "No reboot required"
     else
-      echo "Update registries.yaml, reboot required"
+      echo "Update registries.yaml, restart of k3s required"
       mkdir -p /etc/rancher/k3s
       cp /tmp/registries.yaml /etc/rancher/k3s/registries.yaml
-      touch /var/run/reboot-required
+      if systemctl status k3s > /dev/null; then 
+        systemctl restart k3s; 
+      elif systemctl status k3s-agent > /dev/null; then 
+        systemctl restart k3s-agent; 
+      fi  
     fi
     EOT
     ]


### PR DESCRIPTION
This addresses the question in https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/548 , and after discussion we concluded that this restart is safe and immediate.