### PR TITLE
Calico fix (with optional version variable)

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -20,6 +20,14 @@ data "github_release" "kured" {
   retrieve_by = "latest"
 }
 
+// github_release for kured
+data "github_release" "calico" {
+  count       = var.calico_version == null ? 1 : 0
+  repository  = "calico"
+  owner       = "projectcalico"
+  retrieve_by = "latest"
+}
+
 data "hcloud_load_balancer" "cluster" {
   count = local.has_external_load_balancer ? 0 : 1
   name  = var.cluster_name

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -349,6 +349,11 @@ module "kube-hetzner" {
   # Also, see the cilium_values at towards the end of this file, in the advanced section.
   # cni_plugin = "cilium"
 
+  # You can choose the version of Calico that you want. By default, the latest is used.
+  # More info on available versions can be found at https://github.com/projectcalico/calico/releases
+  # Please note that if you are getting 403s from Github, it's also useful to set the version manually. However there is rarely a need for that!
+  # calico_version = "v3.25.0"
+
   # If you want to disable the k3s default network policy controller, use this flag!
   # Both Calico and Ciliun cni_plugin values override this value to true automatically, the default is "false".
   # disable_network_policy = true

--- a/locals.tf
+++ b/locals.tf
@@ -7,9 +7,10 @@ locals {
   # Otherwise, a new one will be created by the module.
   hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
 
-  ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
-  csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
-  kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
+  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
+  csi_version    = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
+  kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
+  calico_version = var.calico_version != null ? var.calico_version : data.github_release.calico[0].release_tag
 
   additional_k3s_environment = join("\n",
     [
@@ -275,7 +276,7 @@ locals {
   }
 
   cni_install_resources = {
-    "calico" = ["https://projectcalico.docs.tigera.io/manifests/calico.yaml"]
+    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${local.calico_version}/manifests/calico.yaml"]
     "cilium" = ["cilium.yaml"]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -510,3 +510,9 @@ variable "additional_tls_sans" {
   default     = []
   type        = list(string)
 }
+
+variable "calico_version" {
+  type        = string
+  default     = null
+  description = "Version of Calico."
+}


### PR DESCRIPTION
Fixes #574 

@captnCC FYI, for Calico I propose we stick to the manifest, as the helm is cumbersome and requires configuring its operator.