### PR TITLE
Microos snapshot stage 2

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -8,6 +8,7 @@ module "agents" {
   for_each = local.agent_nodes
 
   name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  microos_image_id             = data.hcloud_image.microos_image.id
   base_domain                  = var.base_domain
   ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                     = var.ssh_port

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -9,7 +9,7 @@ locals {
       ssh_key          = local.hcloud_ssh_key_id
       ipv4_subnet_id   = hcloud_network.k3s.id
       # for now we use the k3s network, as we cannot reference subnet-ids in autoscaler
-      snapshot_id  = hcloud_snapshot.autoscaler_image[0].id
+      snapshot_id  = data.hcloud_image.microos_image.id
       firewall_id  = hcloud_firewall.k3s.id
       cluster_name = local.cluster_prefix
       node_pools   = var.autoscaler_nodepools
@@ -22,18 +22,6 @@ locals {
     ]...) : v.name => v
   }
 }
-
-resource "hcloud_snapshot" "autoscaler_image" {
-  count = length(var.autoscaler_nodepools) > 0 ? 1 : 0
-
-  # using control_plane here as this one is always available
-  server_id   = values(module.control_planes)[0].id
-  description = "Initial snapshot used for autoscaler"
-  labels = merge(local.labels, {
-    autoscaler = "true"
-  })
-}
-
 resource "null_resource" "configure_autoscaler" {
   count = length(var.autoscaler_nodepools) > 0 ? 1 : 0
 
@@ -64,7 +52,7 @@ resource "null_resource" "configure_autoscaler" {
 
   depends_on = [
     null_resource.first_control_plane,
-    hcloud_snapshot.autoscaler_image
+    data.hcloud_image.microos_image
   ]
 }
 
@@ -85,7 +73,6 @@ data "cloudinit_config" "autoscaler-config" {
         sshPort           = var.ssh_port
         sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
         dnsServers        = var.dns_servers
-        k3s_channel       = var.initial_k3s_channel
         k3s_config = yamlencode({
           server        = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
           token         = random_password.k3s_token.result
@@ -95,6 +82,7 @@ data "cloudinit_config" "autoscaler-config" {
           node-taint    = local.default_agent_taints
         })
         k3s_registries = var.k3s_registries
+        install_k3s    = local.install_k3s_agent
       }
     )
   }

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -8,6 +8,7 @@ module "control_planes" {
   for_each = local.control_plane_nodes
 
   name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  microos_image_id             = data.hcloud_image.microos_image.id
   base_domain                  = var.base_domain
   ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                     = var.ssh_port

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -56,12 +56,14 @@
 | [null_resource.first_control_plane](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.kustomization](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.kustomization_user](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.packer](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_password.k3s_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.rancher_bootstrap](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [cloudinit_config.autoscaler-config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [github_release.hetzner_ccm](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
 | [github_release.hetzner_csi](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
 | [github_release.kured](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
+| [hcloud_image.microos_image](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/image) | data source |
 | [hcloud_load_balancer.cluster](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/load_balancer) | data source |
 | [hcloud_servers.autoscaled_nodes](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/servers) | data source |
 | [hcloud_ssh_keys.keys_by_selector](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/ssh_keys) | data source |

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,8 @@ locals {
   # Otherwise, a new one will be created by the module.
   hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
 
+  microos_image_name = join("-", ["microos-snapshot", formatdate("YYYYMMDDhhmmss", timestamp())])
+
   ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
   kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag

--- a/locals.tf
+++ b/locals.tf
@@ -7,9 +7,9 @@ locals {
   # Otherwise, a new one will be created by the module.
   hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
 
-  ccm_version   = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
-  csi_version   = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
-  kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
+  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
+  csi_version    = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
+  kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
   calico_version = var.calico_version != null ? var.calico_version : data.github_release.calico[0].release_tag
 
   additional_k3s_environment = join("\n",

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -13,5 +13,5 @@ locals {
   needed_packages = join(" ", concat(["restorecond policycoreutils setools-console"], var.packages_to_install))
 
   # the hosts name with its unique suffix attached
-  name = "${var.name}-${random_string.server.id}"
+  name = "${var.name}-${random_id.server_id.hex}"
 }

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -138,13 +138,6 @@ resource "hcloud_server" "server" {
     ]
   }
 }
-
-resource "null_resource" "create_snapshot" {
-  count = startswith(var.microos_image_id, "ubuntu") ? 1 : 0
-
-  depends_on = [hcloud_server.server]
-}
-
 resource "null_resource" "registries" {
   triggers = {
     registries = var.k3s_registries
@@ -167,7 +160,7 @@ resource "null_resource" "registries" {
     inline = [var.k3s_registries_update_script]
   }
 
-  depends_on = [null_resource.create_snapshot]
+  depends_on = [hcloud_server.server]
 }
 
 resource "hcloud_rdns" "server" {

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -2,7 +2,10 @@ variable "name" {
   description = "Host name"
   type        = string
 }
-
+variable "microos_image_id" {
+  description = "MicroOS image ID to be used "
+  type        = string
+}
 variable "base_domain" {
   description = "Base domain used for reverse dns"
   type        = string

--- a/packer.tf
+++ b/packer.tf
@@ -9,7 +9,10 @@ resource "null_resource" "packer" {
   }
 
   provisioner "local-exec" {
-    # working_dir = "./packer"
+    environment = {
+      HCLOUD_TOKEN = nonsensitive(var.hcloud_token)
+    }
+
     # credits for packer integration to https://austincloud.guru/2020/02/27/building-packer-image-with-terraform/
     command = <<EOF
 RED='\033[0;31m'   # Red Text
@@ -18,7 +21,6 @@ BLUE='\033[0;34m'  # Blue Text
 NC='\033[0m'       # No Color
 
 packer build -force \
-  -var hcloud_token=${var.hcloud_token} \
   -var opensuse_microos_mirror_link=${var.opensuse_microos_mirror_link} \
   -var creator_id=${self.id} \
   ${path.module}/packer/hcloud-microos-snapshot.pkr.hcl

--- a/packer.tf
+++ b/packer.tf
@@ -1,5 +1,5 @@
 locals {
-    packages = length(local.packages_to_install) > 0 ? "-var packages_to_install=${local.packages_to_install}"  : ""
+  packages = length(local.packages_to_install) > 0 ? "-var packages_to_install=${local.packages_to_install}" : ""
 }
 data "hcloud_image" "microos_image" {
   with_selector = "microos-snapshot=yes,creator_id=${null_resource.packer.id}"

--- a/packer.tf
+++ b/packer.tf
@@ -1,3 +1,6 @@
+locals {
+    packages = length(local.packages_to_install) > 0 ? "-var packages_to_install=${local.packages_to_install}"  : ""
+}
 data "hcloud_image" "microos_image" {
   with_selector = "microos-snapshot=yes,creator_id=${null_resource.packer.id}"
   most_recent   = true
@@ -22,7 +25,7 @@ NC='\033[0m'       # No Color
 
 packer build -force \
   -var opensuse_microos_mirror_link=${var.opensuse_microos_mirror_link} \
-  -var creator_id=${self.id} \
+  -var creator_id=${self.id} ${local.packages} \
   ${path.module}/packer/hcloud-microos-snapshot.pkr.hcl
 
 if [ $? -eq 0 ]; then

--- a/packer.tf
+++ b/packer.tf
@@ -1,0 +1,39 @@
+data "hcloud_image" "microos_image" {
+  with_selector = "microos-snapshot=yes,creator_id=${null_resource.packer.id}"
+  most_recent   = true
+}
+
+resource "null_resource" "packer" {
+  triggers = {
+    file_changed = md5(file("${path.module}/packer/hcloud-microos-snapshot.pkr.hcl"))
+  }
+
+  provisioner "local-exec" {
+    # working_dir = "./packer"
+    # credits for packer integration to https://austincloud.guru/2020/02/27/building-packer-image-with-terraform/
+    command = <<EOF
+RED='\033[0;31m'   # Red Text
+GREEN='\033[0;32m' # Green Text
+BLUE='\033[0;34m'  # Blue Text
+NC='\033[0m'       # No Color
+
+packer build -force \
+  -var hcloud_token=${var.hcloud_token} \
+  -var opensuse_microos_mirror_link=${var.opensuse_microos_mirror_link} \
+  -var creator_id=${self.id} \
+  ${path.module}/packer/hcloud-microos-snapshot.pkr.hcl
+
+if [ $? -eq 0 ]; then
+  printf "\n $GREEN Packer Succeeded $NC \n"
+else
+  printf "\n $RED Packer Failed $NC \n" >&2
+  exit 1
+fi
+EOF
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "echo 'Packer image will not be destroyed yet...'"
+  }
+}

--- a/packer/hcloud-microos-snapshot.pkr.hcl
+++ b/packer/hcloud-microos-snapshot.pkr.hcl
@@ -1,0 +1,58 @@
+/*
+ * Creates a MicroOS snapshot for Hetzner Cloud
+ */
+
+variable "hcloud_token" {
+  type      = string
+  default   = env("HCLOUD_TOKEN")
+  sensitive = true
+}
+
+variable "opensuse_microos_mirror_link" {
+  type    = string
+  default = "https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/images/openSUSE_Tumbleweed/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2"
+}
+
+variable "creator_id" {
+  type    = string
+  default = "123456789"
+}
+
+source "hcloud" "microos-snapshot" {
+  image       = "ubuntu-20.04"
+  rescue      = "linux64"
+  location    = "nbg1"
+  server_type = "cx21" # at least a disk size of >= 40GiB is needed to install MicroOS image
+  snapshot_labels = {
+    microos-snapshot = "yes"
+    creator          = "kube-hetzner"
+    creator_id       = var.creator_id
+  }
+  snapshot_name = "MicroOS snapshot created by kube-hetzner"
+  ssh_username  = "root"
+  token         = var.hcloud_token
+}
+
+build {
+  sources = ["source.hcloud.microos-snapshot"]
+
+  # Download the MicroOS image and write it to disk
+  provisioner "shell" {
+    inline = [
+      "sleep 5",
+      "wget --timeout=5 ${var.opensuse_microos_mirror_link}",
+      "qemu-img convert -p -f qcow2 -O host_device $(ls -a | grep -ie '^opensuse.*microos.*qcow2$') /dev/sda",
+      "sleep 2; reboot"
+    ]
+    expect_disconnect = true
+  }
+
+  # Ensure connection to MicroOS and do house-keeping
+  provisioner "shell" {
+    pause_before = "5s"
+    inline = [
+      "echo Reboot successful, installing basic packages and cleaning-up....",
+      "rm -rf /var/log/*"
+    ]
+  }
+}


### PR DESCRIPTION
Hi, I don't know why but the last pull request has vanished..

Anyway, this know removes the initial snapshot and just uses the packer based snapshot for all created servers now, including the cluster autoscaler nodes. 
Please have a look and test it, hadn't hat much time for it yet. 

But as recently came the request, to make this work also in terraform cloud, I see the following alternatives:

1.  fall back to have the `packer` step outside of the terraform script (initial idea). Needs some additional "glue" scripting
2. avoid packer, do the snapshot with terraform - either by a separate script or include it here. Needs some additional "glue" scripting
3. Include the snapshot creation in the "host" module. Should be possible (when no `image_id`given, create first a snapshot, otherwise use the image_id. But Increases the complexity of the script

For me, using packer/ or a separate terraform script  to create the snapshot and assume the image_id in the terraform script would be the simpliest, cleanest way, as we can get rid of a lot of code in the main script. 

What do you think? 