### PR TITLE
Add "PubkeyAuthentication=yes" to ssh_args

### DIFF
--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -3,7 +3,7 @@ locals {
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
   ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
   # shared flags for ssh to ignore host keys for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'IdentitiesOnly yes'"
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'IdentitiesOnly yes' -o PubkeyAuthentication=yes"
 
   # ssh_client_identity is used for ssh "-i" flag, its the private key if that is set, or a public key
   # if an ssh agent is used.


### PR DESCRIPTION
If your local SSH environment is configured to disable authentication by public/private keys, SSH connections fail due to no other authentication means remaining.

This small modification adds `PubkeyAuthentication=yes` to the `ssh_args` variable, thus always enabling public key authentication when running Kube-Hetzner.