### PR TITLE
Hcloud token env

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1,6 +1,6 @@
 locals {
-  # First and foremost set your Hetzner API token here. It can be found in your Project > Security > API Token (Read & Write is required).
-  hcloud_token = "xxxxxxxxxxxxxxxxYYYYYYYYYYzzzzzzzzzzzzzzzzz"
+  # set your Hetzner API token here or define the HCLOUD_TOKEN env within your shell for security purpose. It can be found in your Project > Security > API Token (Read & Write is required).
+  hcloud_token = ""
 }
 
 module "kube-hetzner" {

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,8 @@ resource "hcloud_network" "k3s" {
   labels   = local.labels
 }
 
-# We start from the end of the subnets cird array,
-# as we would have fewer control plane nodepools, than angent ones.
+# We start from the end of the subnets cidr array,
+# as we would have fewer control plane nodepools, than agent ones.
 resource "hcloud_network_subnet" "control_plane" {
   count        = length(var.control_plane_nodepools)
   network_id   = hcloud_network.k3s.id
@@ -26,7 +26,7 @@ resource "hcloud_network_subnet" "control_plane" {
   ip_range     = local.network_ipv4_subnets[255 - count.index]
 }
 
-# Here we start at the beginning of the subnets cird array
+# Here we start at the beginning of the subnets cidr array
 resource "hcloud_network_subnet" "agent" {
   count        = length(var.agent_nodepools)
   network_id   = hcloud_network.k3s.id

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ variable "hcloud_token" {
   description = "Hetzner Cloud API Token."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "ssh_port" {


### PR DESCRIPTION
Make token usage optional to use `HCLOUD_TOKEN` environment variable instead. This helps in avoiding unintentional versioning the token within git and to use it within a pipeline.