### PR TITLE
Apply hcloud token as var in module call

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1,13 +1,18 @@
 locals {
-  # set your Hetzner API token here or define the TF_VAR_hcloud_token env within your shell for security purpose. It can be found in your Project > Security > API Token (Read & Write is required).
   hcloud_token = ""
+}
+variable "hcloud_token" {
+  description = "Sets your Hetzner API token here or define the TF_VAR_hcloud_token env within your shell for security purpose. It can be found in your Project > Security > API Token (Read & Write is required)."
+  type        = string
+  sensitive   = true
+  default = ""
 }
 
 module "kube-hetzner" {
   providers = {
     hcloud = hcloud
   }
-  hcloud_token = local.hcloud_token
+  hcloud_token = var.hcloud_token
 
   # Then fill or edit the below values. Only the first values starting with a * are obligatory; the rest can remain with their default values, or you
   # could adapt them to your needs.
@@ -563,7 +568,7 @@ bootstrapPassword: "supermario"
 }
 
 provider "hcloud" {
-  token = local.hcloud_token
+  token = var.hcloud_token
 }
 
 terraform {


### PR DESCRIPTION
This PR makes the hcloud token available as variable that can be injected via envvar. This is the solution proposed by @mysticaltech in #601.