### PR TITLE
feat: variable for the INSTALL_K3S_EXEC k3s server var

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,7 +45,7 @@ locals {
   apply_k3s_selinux = ["/sbin/semodule -v -i /usr/share/selinux/packages/k3s.pp"]
 
   install_k3s_server = concat(local.common_commands_install_k3s, [
-    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC=server sh -"
+    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='${var.install_k3s_exec_server}' sh -"
   ], local.apply_k3s_selinux)
   install_k3s_agent = concat(local.common_commands_install_k3s, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC=agent sh -"

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "initial_k3s_channel" {
   }
 }
 
+variable "install_k3s_exec_server" {
+  type        = string
+  default     = "server"
+  description = "The command which is set as ExecStart of the k3s server systemd service"
+}
+
 variable "automatically_upgrade_k3s" {
   type        = bool
   default     = true


### PR DESCRIPTION
This adds the possibility to customize the INSTALL_K3S_EXEC environment variable for the k3s server daemon.
This can be useful to pass additional arguments, for example api server arguments, to enable oidc or other stuff.