### PR TITLE
Added changes to support firewall rules' description

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -129,44 +129,50 @@ locals {
   base_firewall_rules = concat([
     # Allowing internal cluster traffic and Hetzner metadata service and cloud API IPs
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "any"
-      source_ips = local.whitelisted_ips
+      description = "Allow Internal Cluster TCP Traffic"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "any"
+      source_ips  = local.whitelisted_ips
     },
     {
-      direction  = "in"
-      protocol   = "udp"
-      port       = "any"
-      source_ips = local.whitelisted_ips
+      description = "Allow Internal Cluster UDP Traffic"
+      direction   = "in"
+      protocol    = "udp"
+      port        = "any"
+      source_ips  = local.whitelisted_ips
     },
 
     # Allow all traffic to the kube api server
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "6443"
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming Requests to Kube API Server"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "6443"
+      source_ips  = ["0.0.0.0/0", "::/0"]
     },
 
     # Allow all traffic to the ssh ports
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "22"
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming SSH Traffic"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "22"
+      source_ips  = ["0.0.0.0/0", "::/0"]
     }
     ], var.ssh_port == 22 ? [] : [
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = var.ssh_port
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming SSH Traffic"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = var.ssh_port
+      source_ips  = ["0.0.0.0/0", "::/0"]
     },
     ], !var.restrict_outbound_traffic ? [] : [
     # Allow basic out traffic
     # ICMP to ping outside services
     {
+      description     = "Allow Outbound ICMP Ping Requests"
       direction       = "out"
       protocol        = "icmp"
       port            = ""
@@ -175,12 +181,14 @@ locals {
 
     # DNS
     {
+      description     = "Allow Outbound TCP DNS Requests"
       direction       = "out"
       protocol        = "tcp"
       port            = "53"
       destination_ips = ["0.0.0.0/0", "::/0"]
     },
     {
+      description     = "Allow Outbound UDP DNS Requests"
       direction       = "out"
       protocol        = "udp"
       port            = "53"
@@ -189,12 +197,14 @@ locals {
 
     # HTTP(s)
     {
+      description     = "Allow Outbound HTTP Requests"
       direction       = "out"
       protocol        = "tcp"
       port            = "80"
       destination_ips = ["0.0.0.0/0", "::/0"]
     },
     {
+      description     = "Allow Outbound HTTPS Requests"
       direction       = "out"
       protocol        = "tcp"
       port            = "443"
@@ -203,6 +213,7 @@ locals {
 
     #NTP
     {
+      description     = "Allow Outbound UDP NTP Requests"
       direction       = "out"
       protocol        = "udp"
       port            = "123"
@@ -212,30 +223,34 @@ locals {
     # Allow incoming web traffic for single node clusters, because we are using k3s servicelb there,
     # not an external load-balancer.
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "80"
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming HTTP Connections"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "80"
+      source_ips  = ["0.0.0.0/0", "::/0"]
     },
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "443"
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming HTTPS Connections"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "443"
+      source_ips  = ["0.0.0.0/0", "::/0"]
     }
     ], var.block_icmp_ping_in ? [] : [
     {
-      direction  = "in"
-      protocol   = "icmp"
-      port       = ""
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming ICMP Ping Requests"
+      direction   = "in"
+      protocol    = "icmp"
+      port        = ""
+      source_ips  = ["0.0.0.0/0", "::/0"]
     }
     ], var.cni_plugin != "cilium" ? [] : [
     {
-      direction  = "in"
-      protocol   = "tcp"
-      port       = "4244-4245"
-      source_ips = ["0.0.0.0/0", "::/0"]
+      description = "Allow Incoming Requests to Hubble Server & Hubble Relay (Cilium)"
+      direction   = "in"
+      protocol    = "tcp"
+      port        = "4244-4245"
+      source_ips  = ["0.0.0.0/0", "::/0"]
     }
   ])
 

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "hcloud_firewall" "k3s" {
   dynamic "rule" {
     for_each = local.firewall_rules_list
     content {
+      description     = rule.value.description
       direction       = rule.value.direction
       protocol        = rule.value.protocol
       port            = lookup(rule.value, "port", null)


### PR DESCRIPTION
Updates main.tf and locals.tf file to add description attribute, which will add support for adding or making changes in the description of firewall rules, instead of empty description of rules on the Hetzner Cloud Firewalls section for the Kubernetes Cluster deployed with terraform.