### PR TITLE
fix: Rename `nginx_ingress_values` to `nginx_values` in example

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -535,7 +535,7 @@ ports:
   # Nginx, all Nginx helm values can be found at https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   # You can also have a look at https://kubernetes.github.io/ingress-nginx/, to understand how it works, and all the options at your disposal.
   # The following is an example, please note that the current indentation inside the EOT is important.
-  /*   nginx_ingress_values = <<EOT
+  /*   nginx_values = <<EOT
 controller:
   watchIngressWithoutClass: "true"
   kind: "DaemonSet"


### PR DESCRIPTION
Hi, the `nginx_ingress_values` variable was renamed to `nginx_values` in https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/commit/adbaa4b6e7428da523c19685348de8c966827ae6. I guess it was forgotten to adjust the example at the same time. 

Have a nice weekend!