### PR TITLE
feat: agent_nodepools: add floating IPs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To achieve this, we built up on the shoulders of giants by choosing [openSUSE Mi
 - [x] Possibility to toggle **Longhorn** and **Hetzner CSI**.
 - [x] Choose between **Flannel, Calico, or Cilium** as CNI.
 - [x] Optional **Wireguard** encryption of the Kube network for added security.
+- [x] Optional assign [Floating IPs](https://docs.hetzner.com/cloud/floating-ips/faq) (with default routing via Floating IP) to a selected nodepool.
+See the [examples](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner#examples) section for use case: **Cilium Egress Gateway (via Floating IP)**.
 - [x] **Flexible configuration options** via variables and an extra Kustomization option.
 
 _It uses Terraform to deploy as it's easy to use, and Hetzner has a great [Hetzner Terraform Provider](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs)._
@@ -277,6 +279,86 @@ kubectl -n kube-system exec --stdin --tty cilium-xxxx -- cilium service list
 
 _For more cilium commands, please refer to their corresponding [Documentation](https://docs.cilium.io/en/latest/cheatsheet)._
   
+</details>
+
+<details>
+<summary>Cilium Egress Gateway (via Floating IP)</summary>
+
+[Cilium Egress Gateway](https://docs.cilium.io/en/stable/network/egress-gateway/) provides the ability to control outgoing traffic from POD.
+
+Using Floating IP makes it possible to get rid of the problem of changing the primary IP when recreate (while change node type) the cluster node.
+
+To implement Cilium Egress Gateway feature, you need to define a separate nodepool (1 or more nodes) with the setting `floating_ip = true` in the nodepool configuration parameter block.
+
+Example nodepool configuration:
+```
+{
+  name        = "egress",
+  server_type = "cpx11",
+  location    = "fsn1",
+  labels = [
+    "node.kubernetes.io/role=egress"
+  ],
+  taints = [
+    "node.kubernetes.io/role=egress:NoSchedule"
+  ],
+  floating_ip = true
+  count = 1
+},
+```
+
+Configure Cilium:
+```
+locals {
+  cluster_ipv4_cidr = "10.42.0.0/16"
+}
+
+cluster_ipv4_cidr = local.cluster_ipv4_cidr
+
+cilium_values = <<EOT
+ipam:
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - ${local.cluster_ipv4_cidr}
+kubeProxyReplacement: strict
+l7Proxy: "false"
+bpf:
+  masquerade: "true"
+egressGateway:
+  enabled: "true"
+EOT
+```
+
+Deploy the K8S cluster infrastructure.
+
+See the Cilium documentation for further steps (policy writing and testing): [Writing egress gateway policies](https://docs.cilium.io/en/stable/network/egress-gateway/)
+
+CiliumEgressGatewayPolicy example:
+```
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: egress-sample
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        org: empire
+        class: mediabot
+        io.kubernetes.pod.namespace: default
+
+  destinationCIDRs:
+  - "0.0.0.0/0"
+
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        node.kubernetes.io/role: egress
+
+    # Specify the IP address used to SNAT traffic matched by the policy.
+    # It must exist as an IP associated with a network interface on the instance.
+    egressIP: {FLOATING_IP}
+```
 </details>
 
 <details>

--- a/agents.tf
+++ b/agents.tf
@@ -144,8 +144,6 @@ resource "hcloud_floating_ip" "agents" {
   type          = "ipv4"
   labels        = local.labels
   home_location = each.value.location
-
-  delete_protection = true
 }
 
 resource "hcloud_floating_ip_assignment" "agents" {

--- a/agents.tf
+++ b/agents.tf
@@ -163,11 +163,10 @@ resource "null_resource" "configure_floating_ip" {
   for_each = { for k, v in local.agent_nodes : k => v if(lookup(v, "floating_ip", false)) }
 
   triggers = {
-    agent_id = module.agents[each.key].id
+    agent_id       = module.agents[each.key].id
     floating_ip_id = hcloud_floating_ip.agents[each.key].id
   }
 
-  # Start the k3s agent and wait for it to have started
   provisioner "remote-exec" {
     inline = [
       "echo \"BOOTPROTO='static'\nSTARTMODE='auto'\nIPADDR=${hcloud_floating_ip.agents[each.key].ip_address}/32\nIPADDR_1=${module.agents[each.key].ipv4_address}/32\" > /etc/sysconfig/network/ifcfg-eth0",

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -125,6 +125,22 @@ module "kube-hetzner" {
       taints      = [],
       count       = 1
     },
+    # 'egress' nodepool with 'floating IPs' assigning to each node in pool
+    # useful for control/route egress traffic using 'Hetzner Floating IPs' (https://docs.hetzner.com/cloud/floating-ips)
+    # applied to: https://docs.cilium.io/en/stable/gettingstarted/egress-gateway/
+    {
+      name        = "egress",
+      server_type = "cpx11",
+      location    = "fsn1",
+      labels = [
+        "node.kubernetes.io/role=egress"
+      ],
+      taints = [
+        "node.kubernetes.io/role=egress:NoSchedule"
+      ],
+      floating_ip = true
+      count = 1
+    },
     {
       name        = "storage",
       server_type = "cpx21",

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -128,6 +128,7 @@ module "kube-hetzner" {
     # 'egress' nodepool with 'floating IPs' assigning to each node in pool
     # useful for control/route egress traffic using 'Hetzner Floating IPs' (https://docs.hetzner.com/cloud/floating-ips)
     # applied to: https://docs.cilium.io/en/stable/gettingstarted/egress-gateway/
+    # See the https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner#examples for use case: **Cilium Egress Gateway (via Floating IP)**.
     {
       name        = "egress",
       server_type = "cpx11",

--- a/locals.tf
+++ b/locals.tf
@@ -72,6 +72,7 @@ locals {
         nodepool_name : nodepool_obj.name,
         server_type : nodepool_obj.server_type,
         longhorn_volume_size : lookup(nodepool_obj, "longhorn_volume_size", 0),
+        floating_ip : lookup(nodepool_obj, "floating_ip", false),
         location : nodepool_obj.location,
         labels : concat(local.default_agent_labels, nodepool_obj.labels),
         taints : concat(local.default_agent_taints, nodepool_obj.taints),


### PR DESCRIPTION
This modification is primarily intended to enable the implementation of the Cilium egress gateway (https://docs.cilium.io/en/v1.12/gettingstarted/egress-gateway) and allows assigning a unique floating IP to each node in the selected node pool, as well as configuring routing through the assigned floating IP.

nodepool example:

```
{
  name        = "egress",
  server_type = "cpx11",
  location    = "fsn1",
  labels = [
    "node.kubernetes.io/role=egress"
  ],
  taints = [
    "node.kubernetes.io/role=egress:NoSchedule"
  ],
  floating_ip = true # <--
  count = 1
},
```

Brief summary of the changes made:

An optional floating_ip parameter has been added to the agent_nodes parameters (default value: false).

A floating IP is leased and assigned to each node in the selected node pool.

The following actions are performed via remote-exec on each node in the selected node pool:
A new network interface configuration is saved for ETH0 (+ routing through the floating IP).

```
 # /etc/sysconfig/network/ifcfg-eth0:
 BOOTPROTO='static'
 STARTMODE='auto'
 # its important: floating-ip should be the main IP
 IPADDR={FLOATING_IP}/32
 IPADDR_1={NODE_PRIMARY_IP}/32
```

```
# /etc/sysconfig/network/ifroute-eth0:
172.31.1.1 - 255.255.255.255 eth0
default 172.31.1.1 - eth0 src {FLOATING_IP}

```
Applied immediately to the running OS:

```
ip addr add {FLOATING_IP}/32 dev eth0
ip route replace default via 172.31.1.1 dev eth0 src {FLOATING_IP}

# its important: floating IP should be first on the interface IP list, move main IP to the second position
ip addr del {NODE_PRIMARY_IP}/32 dev eth0
ip addr add {NODE_PRIMARY_IP}/32 dev eth0
```

Additionally:
When leasing a floating IP, a protection flag is set to prevent accidentally losing the leased floating IP during future cluster reconfigurations (such as reassigning the floating IP to another node pool). This work is done manually using terraform state rm / terraform import.
If it is necessary to remove the configuration with the floating IP, it is necessary to manually remove the protection flag for the floating IP via the Hetzner console.