### PR TITLE
Trigger recreation of kustomization when helm values change

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -85,6 +85,22 @@ resource "random_password" "rancher_bootstrap" {
 
 # This is where all the setup of Kubernetes components happen
 resource "null_resource" "kustomization" {
+
+  # Redeploy helm charts when the underlying values change
+  triggers = {
+    values_yaml = join(",",
+      [
+        local.traefik_values,
+        local.nginx_values,
+        local.calico_values,
+        local.cilium_values,
+        local.longhorn_values,
+        local.cert_manager_values,
+        local.rancher_values,
+      ]
+    )
+  }
+
   connection {
     user           = "root"
     private_key    = var.ssh_private_key
@@ -95,6 +111,7 @@ resource "null_resource" "kustomization" {
 
   # Upload kustomization.yaml, containing Hetzner CSI & CSM, as well as kured.
   provisioner "file" {
+
     content = yamlencode({
       apiVersion = "kustomize.config.k8s.io/v1beta1"
       kind       = "Kustomization"

--- a/init.tf
+++ b/init.tf
@@ -95,8 +95,7 @@ resource "null_resource" "kustomization" {
       local.cilium_values,
       local.longhorn_values,
       local.cert_manager_values,
-      local.rancher_values,
-      var.kured_options
+      local.rancher_values
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
@@ -104,6 +103,7 @@ resource "null_resource" "kustomization" {
       var.hetzner_ccm_version,
       var.hetzner_csi_version,
       var.kured_version,
+      var.kured_options,
       var.calico_version
     ])
   }

--- a/init.tf
+++ b/init.tf
@@ -87,7 +87,7 @@ resource "random_password" "rancher_bootstrap" {
 resource "null_resource" "kustomization" {
   triggers = {
     # Redeploy helm charts when the underlying values change
-    helm_values_yaml = join("---\n",[
+    helm_values_yaml = join("---\n", [
       local.traefik_values,
       local.nginx_values,
       local.calico_values,
@@ -97,7 +97,7 @@ resource "null_resource" "kustomization" {
       local.rancher_values,
     ])
     # Redeploy when versions of addons need to be updated
-    versions = join("\n",[
+    versions = join("\n", [
       var.cluster_autoscaler_version,
       var.hetzner_ccm_version,
       var.hetzner_csi_version,

--- a/init.tf
+++ b/init.tf
@@ -85,20 +85,25 @@ resource "random_password" "rancher_bootstrap" {
 
 # This is where all the setup of Kubernetes components happen
 resource "null_resource" "kustomization" {
-
-  # Redeploy helm charts when the underlying values change
   triggers = {
-    values_yaml = join(",",
-      [
-        local.traefik_values,
-        local.nginx_values,
-        local.calico_values,
-        local.cilium_values,
-        local.longhorn_values,
-        local.cert_manager_values,
-        local.rancher_values,
-      ]
-    )
+    # Redeploy helm charts when the underlying values change
+    helm_values_yaml = [
+      local.traefik_values,
+      local.nginx_values,
+      local.calico_values,
+      local.cilium_values,
+      local.longhorn_values,
+      local.cert_manager_values,
+      local.rancher_values,
+    ]
+    # Redeploy when versions of addons need to be updated
+    versions = [
+      var.cluster_autoscaler_version,
+      var.hetzner_ccm_version,
+      var.hetzner_csi_version,
+      var.kured_version,
+      var.calico_version
+    ]
   }
 
   connection {

--- a/init.tf
+++ b/init.tf
@@ -96,6 +96,7 @@ resource "null_resource" "kustomization" {
       local.longhorn_values,
       local.cert_manager_values,
       local.rancher_values,
+      var.kured_options
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [

--- a/init.tf
+++ b/init.tf
@@ -87,7 +87,7 @@ resource "random_password" "rancher_bootstrap" {
 resource "null_resource" "kustomization" {
   triggers = {
     # Redeploy helm charts when the underlying values change
-    helm_values_yaml = [
+    helm_values_yaml = join("---\n",[
       local.traefik_values,
       local.nginx_values,
       local.calico_values,
@@ -95,15 +95,15 @@ resource "null_resource" "kustomization" {
       local.longhorn_values,
       local.cert_manager_values,
       local.rancher_values,
-    ]
+    ])
     # Redeploy when versions of addons need to be updated
-    versions = [
+    versions = join("\n",[
       var.cluster_autoscaler_version,
       var.hetzner_ccm_version,
       var.hetzner_csi_version,
       var.kured_version,
       var.calico_version
-    ]
+    ])
   }
 
   connection {

--- a/init.tf
+++ b/init.tf
@@ -99,12 +99,14 @@ resource "null_resource" "kustomization" {
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
-      var.cluster_autoscaler_version,
-      var.hetzner_ccm_version,
-      var.hetzner_csi_version,
-      var.kured_version,
-      var.kured_options,
-      var.calico_version
+      coalesce(var.cluster_autoscaler_version, "N/A"),
+      coalesce(var.hetzner_ccm_version, "N/A"),
+      coalesce(var.hetzner_csi_version, "N/A"),
+      coalesce(var.kured_version, "N/A"),
+      coalesce(var.calico_version, "N/A"),
+    ])
+    options = join("\n", [
+      for option, value in var.kured_options : "${option}=${value}"
     ])
   }
 

--- a/init.tf
+++ b/init.tf
@@ -111,7 +111,6 @@ resource "null_resource" "kustomization" {
 
   # Upload kustomization.yaml, containing Hetzner CSI & CSM, as well as kured.
   provisioner "file" {
-
     content = yamlencode({
       apiVersion = "kustomize.config.k8s.io/v1beta1"
       kind       = "Kustomization"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -336,16 +336,16 @@ module "kube-hetzner" {
   # Adding extra firewall rules, like opening a port
   # More info on the format here https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall
   # extra_firewall_rules = [
-  #   # For Postgres
   #   {
+  #     description = "For Postgres"
   #     direction       = "in"
   #     protocol        = "tcp"
   #     port            = "5432"
   #     source_ips      = ["0.0.0.0/0", "::/0"]
   #     destination_ips = [] # Won't be used for this rule
   #   },
-  #   # To Allow ArgoCD access to resources via SSH
   #   {
+  #     description = "To Allow ArgoCD access to resources via SSH"
   #     direction       = "out"
   #     protocol        = "tcp"
   #     port            = "22"


### PR DESCRIPTION
Per https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/607, any changes in the values.yaml will cause the `kustomization` null_resource block to be tainted and recreated.

I'm not sure if there are other spots where the module level variables impact the values.yaml, but am happy to add those in (if there are any)!