### PR TITLE
Fix/longhorn encryption at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To achieve this, we built up on the shoulders of giants by choosing [openSUSE Mi
 - [x] Can use Klipper as an **on-metal LB** or the **Hetzner LB**.
 - [x] Ability to **add nodes and nodepools** when the cluster is running.
 - [x] Possibility to toggle **Longhorn** and **Hetzner CSI**.
+- [x] Encryption at rest fully functional in both **Longhorn** and **Hetzner CSI**.
 - [x] Choose between **Flannel, Calico, or Cilium** as CNI.
 - [x] Optional **Wireguard** encryption of the Kube network for added security.
 - [x] Optional use of **Floating IPs** for use via Cilium's Egress Gateway.

--- a/locals.tf
+++ b/locals.tf
@@ -113,7 +113,7 @@ locals {
 
   packages_to_install = concat(
     var.enable_wireguard ? ["wireguard-tools"] : [],
-    var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs", "cryptsetup"] : [],
+    var.enable_longhorn ? ["open-iscsi", "nfs-client", "xfsprogs", "cryptsetup", "lvm2"] : [],
     var.extra_packages_to_install,
   )
 


### PR DESCRIPTION
This was one of the most painful debugging sessions, with an insanely small code-change to fix it. Please pad me on the back here.. 

Longhorn encryption at rest now works correctly! cryptsetup does not hang, volumes get created and encrypted and mounted. The key was installing a >10 year old package lvm2, which creates the right udev rules.

See here for some digging: https://github.com/longhorn/longhorn/discussions/5332

This solves the open question of encrypting longhorn volumes, https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/448 .
