### PR TITLE
Fix/invert loadbalancer label on control planes

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -103,9 +103,8 @@ locals {
 
   # Default k3s node labels
   default_agent_labels         = concat([], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
-  default_control_plane_labels = concat(["node.kubernetes.io/exclude-from-external-load-balancers=${local.allow_scheduling_on_control_plane ? "true" : "false"}"], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
-
   allow_scheduling_on_control_plane = (local.is_single_node_cluster || local.using_klipper_lb) ? true : var.allow_scheduling_on_control_plane
+  default_control_plane_labels = concat(["node.kubernetes.io/exclude-from-external-load-balancers=${local.allow_scheduling_on_control_plane ? "true" : "false"}"], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
 
   # Default k3s node taints
   default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/control-plane:NoSchedule"])


### PR DESCRIPTION
Hi, I can't find the "staging" branch mentioned in the contribution section of the readme, so I'm targeting master for now?

I've had the issue of the label `node.kubernetes.io/exclude-from-external-load-balancers` being set to true with `allow_scheduling_on_control_plane=true` in my configuration. After searching for the issue it seem to me that the conditions are not being set correctly.
There are two separate concerns mixed: the loadbalancer targeting the control planes (set via an "exclude" meaning inverted label) and the scheduling of load on the control planes (set via the ":NoSchedule" taint).

The condition for the loadbalancer label seems to have been inverted. (I'm not sure how it would have been possible that this was not detected before, which makes me doubt my solution.)

I have now tested the cluster setup with 3 control planes with `allow_scheduling_on_control_plane=true` and the label was set to `node.kubernetes.io/exclude-from-external-load-balancers: "false"` which should be correct. However, the LoadBalancer still did not target the servers. Maybe there are additional issues?