### PR TITLE
fix: no loadbalancer exclusion on control planes

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -108,7 +108,7 @@ locals {
 
   # Default k3s node labels
   default_agent_labels         = concat([], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
-  default_control_plane_labels = concat(["node.kubernetes.io/exclude-from-external-load-balancers=${local.allow_loadbalancer_target_on_control_plane ? "false" : "true"}"], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
+  default_control_plane_labels = concat(local.allow_loadbalancer_target_on_control_plane ? [] : ["node.kubernetes.io/exclude-from-external-load-balancers=true"], var.automatically_upgrade_k3s ? ["k3s_upgrade=true"] : [])
 
   # Default k3s node taints
   default_control_plane_taints = concat([], local.allow_scheduling_on_control_plane ? [] : ["node-role.kubernetes.io/control-plane:NoSchedule"])

--- a/variables.tf
+++ b/variables.tf
@@ -220,7 +220,7 @@ variable "allow_scheduling_on_control_plane" {
 variable "enable_metrics_server" {
   type        = bool
   default     = true
-  description = "Whether to enable or disbale k3s mertric server."
+  description = "Whether to enable or disable k3s metric server."
 }
 
 variable "initial_k3s_channel" {


### PR DESCRIPTION
As discussed in https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/667 the label `node.kubernetes.io/exclude-from-external-load-balancers` must not be set at all instead of setting it to false for the control planes to be set as targets of the load-balancer.