### PR TITLE
longhorn_volume_size and selinux proper activation for k3s

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -98,7 +98,7 @@ resource "null_resource" "agents" {
 }
 
 resource "hcloud_volume" "longhorn_volume" {
-  for_each = { for k, v in local.agent_nodes : k => v if((lookup(v, "longhorn_volume_size", 0) >= 10) && (lookup(v, "longhorn_volume_size", 0) <= 10000) && var.enable_longhorn) }
+  for_each = { for k, v in local.agent_nodes : k => v if((v.longhorn_volume_size >= 10) && (v.longhorn_volume_size <= 10000) && var.enable_longhorn) }
 
   labels = {
     provisioner = "terraform"
@@ -106,14 +106,14 @@ resource "hcloud_volume" "longhorn_volume" {
     scope       = "longhorn"
   }
   name      = "${var.cluster_name}-longhorn-${module.agents[each.key].name}"
-  size      = lookup(local.agent_nodes[each.key], "longhorn_volume_size", 0)
+  size      = local.agent_nodes[each.key].longhorn_volume_size
   server_id = module.agents[each.key].id
   automount = true
   format    = var.longhorn_fstype
 }
 
 resource "null_resource" "configure_longhorn_volume" {
-  for_each = { for k, v in local.agent_nodes : k => v if((lookup(v, "longhorn_volume_size", 0) >= 10) && (lookup(v, "longhorn_volume_size", 0) <= 10000) && var.enable_longhorn) }
+  for_each = { for k, v in local.agent_nodes : k => v if((v.longhorn_volume_size >= 10) && (v.longhorn_volume_size <= 10000) && var.enable_longhorn) }
 
   triggers = {
     agent_id = module.agents[each.key].id

--- a/agents.tf
+++ b/agents.tf
@@ -65,6 +65,7 @@ resource "null_resource" "agents" {
       node-ip       = module.agents[each.key].private_ipv4_address
       node-label    = each.value.labels
       node-taint    = each.value.taints
+      selinux       = true
     })
     destination = "/tmp/config.yaml"
   }

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -78,6 +78,7 @@ data "cloudinit_config" "autoscaler-config" {
           flannel-iface = local.flannel_iface
           node-label    = local.default_agent_labels
           node-taint    = local.default_agent_taints
+          selinux       = true
         })
         install_k3s_agent_script     = join("\n", concat(local.install_k3s_agent, ["systemctl start k3s-agent"]))
         cloudinit_write_files_common = local.cloudinit_write_files_common

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -112,6 +112,7 @@ resource "null_resource" "control_planes" {
           advertise-address           = module.control_planes[each.key].private_ipv4_address
           node-label                  = each.value.labels
           node-taint                  = each.value.taints
+          selinux                     = true
           write-kubeconfig-mode       = "0644" # needed for import into rancher
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),

--- a/init.tf
+++ b/init.tf
@@ -24,6 +24,7 @@ resource "null_resource" "first_control_plane" {
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels
+          selinux                     = true
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {

--- a/variables.tf
+++ b/variables.tf
@@ -104,14 +104,15 @@ variable "control_plane_nodepools" {
 variable "agent_nodepools" {
   description = "Number of agent nodes."
   type = list(object({
-    name        = string
-    server_type = string
-    location    = string
-    backups     = optional(bool)
-    floating_ip = optional(bool)
-    labels      = list(string)
-    taints      = list(string)
-    count       = number
+    name                 = string
+    server_type          = string
+    location             = string
+    backups              = optional(bool)
+    floating_ip          = optional(bool)
+    labels               = list(string)
+    taints               = list(string)
+    count                = number
+    longhorn_volume_size = optional(number)
   }))
   default = []
 }


### PR DESCRIPTION
Fixes #682 and also brings proper k3s selinux support, before it was not activated properly, we missed it before. It needed a flag in the config, see https://docs.k3s.io/advanced#enabling-selinux-enforcement.

Because of that new rules were needed for the system upgrade controller and cluster autoscaler to be able to access, read and open certificates on the OS.