### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -472,7 +472,7 @@ variable "use_control_plane_lb" {
 
 variable "dns_servers" {
   type        = list(string)
-  default     = ["8.8.8.8", "8.8.4.4", "1.1.1.1", "1.0.0.1"]
+  default     = ["8.8.8.8", "8.8.4.4", "1.1.1.1"]
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner."
 }
 


### PR DESCRIPTION
Apparently k8s only support 3 entries for DNS servers. 

To avoid these warning "Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 8.8.8.8 8.8.4.4 1.1.1.1"

randomly removed the last entry ;)