### PR TITLE
Adds crowdsec agent selinux config

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -570,7 +570,7 @@ EOF
       class sock_file { write create unlink };
       class unix_dgram_socket create;
       class unix_stream_socket { connectto read write };
-      class dir { add_name create getattr link lock read rename remove_name reparent rmdir setattr unlink search write };
+      class dir { add_name create getattr link lock read rename remove_name reparent rmdir setattr unlink search write watch };
       class lnk_file { read create };
       class system module_request;
       class filesystem associate;
@@ -616,7 +616,7 @@ EOF
     allow container_t container_runtime_exec_t:file { read execute execute_no_trans open };
     allow container_t container_runtime_t:unix_stream_socket { connectto read write };
     allow container_t kernel_t:system module_request;
-    allow container_t container_log_t:dir read;
+    allow container_t container_log_t:dir { read watch };
     allow container_t container_log_t:file { open read watch };
     allow container_t container_log_t:lnk_file read;
     allow container_t var_log_t:dir { add_name write };


### PR DESCRIPTION
I deployed https://artifacthub.io/packages/helm/crowdsec/crowdsec and started to get errors in agent pods:

`Could not create watch on directory /var/log/containers : permission denied" type=file`

After reading this issue #697 and reading https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/697#issuecomment-1496607924 I created policy.

`.te` file looks like this:

```
module crowdsec_agent 1.0;

require {
        type container_t;
        type container_log_t;
        class dir watch;
}

#============= container_t ==============
allow container_t container_log_t:dir watch;
```

Than I tested it using `.pp` file and it works OK:

```
level=info msg="Adding file /var/log/containers/traefik-6c77f68ddf-jh65p_traefik_traefik-ea4ad12fa05199b8db9d5acfbe19bc2804de8dc95fe7a03b44bd3105775e1275.log to datasources" type=file
```

To test if my fix is OK I destroyed cluster, edited `.terraform/modules/kube-hetzner/locals.tf` as in this pull request and recreated cluster with new settings.
Pods could read logs from `/var/log`:

```
level=info msg="Adding file /var/log/containers/traefik-6c77f68ddf-qbxb8_traefik_traefik-d5c9c1fb7ff5200e1db6d73e3286dccfe67997d2c6f5247867cee20fde99049d.log to datasources" type=file
```
