### PR TITLE
add k3s ver to null resource kustomization

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -100,6 +100,7 @@ resource "null_resource" "kustomization" {
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
+      coalesce(var.initial_k3s_channel, "N/A"),
       coalesce(var.cluster_autoscaler_version, "N/A"),
       coalesce(var.hetzner_ccm_version, "N/A"),
       coalesce(var.hetzner_csi_version, "N/A"),


### PR DESCRIPTION
`terraform apply` now updates the k3s ver without errors

I just had a question: is it possible to have a channel for cluster autoscaler as well? So we aren't fixated on a patch version but instead always pull latest?