### PR TITLE
Add use_arm option to packer template

### DIFF
--- a/packer-template/hcloud-microos-snapshot.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshot.pkr.hcl
@@ -22,7 +22,7 @@ variable "opensuse_microos_mirror_link_x86_64" {
 
 variable "opensuse_microos_mirror_link_arm64" {
   type    = string
-  default = "https://ftp.gwdg.de/pub/opensuse/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-16.0.0-OpenStack-Cloud-Snapshot20230403.qcow2"
+  default = "https://ftp.gwdg.de/pub/opensuse/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2"
 }
 
 # If you need to add other packages to the OS, do it here in the default value, like ["vim", "curl", "wget"]


### PR DESCRIPTION
This adds another variable to the packer template, so that users can easily enable an arm packer build.
closes #716 