### PR TITLE
Added k3s_exec_server_args variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,41 @@ For more details, see [Longhorn's documentation](https://longhorn.io/docs/1.4.0/
 
 </details>
 
+<details>
+<summary>Default nodeSelectors let you assign namespaces to arm64/amd64 nodes</summary>
+
+To enable the [PodNodeSelector and optionally the PodTolerationRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podnodeselector) api modules, set the following value:
+```terraform
+k3s_exec_server_args = "--kube-apiserver-arg enable-admission-plugins=PodTolerationRestriction,PodNodeSelector"
+```
+
+Next, you can set default nodeSelector values per namespace. This lets you assign namespaces to specific nodes. Note though, that this is the default only, so if a pod sets its own nodeSelector value, that will take precedence.
+
+Then set the according annotations on your namespaces:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: kubernetes.io/arch=amd64
+  name: this-runs-on-amd64
+```
+or with taints and tolerations:
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: kubernetes.io/arch=arm64
+    scheduler.alpha.kubernetes.io/defaultTolerations: [{ "operator" : "Equal", "effect" : "NoSchedule", "key" : "workload-type", "value" : "machine-learning" }])
+  name: this-runs-on-arm64
+```
+
+This can be helpful when you setup a mixed-architecture cluster, and there are many other use cases.
+
+
+</details>
+
 ## Debugging
 
 First and foremost, it depends, but it's always good to have a quick look into Hetzner quickly without logging in to the UI. That is where the `hcloud` cli comes in.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -385,6 +385,9 @@ module "kube-hetzner" {
   #   "trust anchor --store /root/ca.crt",
   # ]
 
+  # Additional flags to pass to the k3s server command (the control plane).
+  # k3s_exec_server_args = "--kube-apiserver-arg enable-admission-plugins=PodTolerationRestriction,PodNodeSelector"
+
   # If you want to allow all outbound traffic you can set this to "false". Default is "true".
   # restrict_outbound_traffic = false
 

--- a/locals.tf
+++ b/locals.tf
@@ -49,7 +49,7 @@ locals {
   apply_k3s_selinux = ["/sbin/semodule -v -i /usr/share/selinux/packages/k3s.pp"]
 
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
-    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC=server sh -"
+    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
   ], local.apply_k3s_selinux)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC=agent sh -"

--- a/variables.tf
+++ b/variables.tf
@@ -561,3 +561,9 @@ variable "calico_version" {
   default     = null
   description = "Version of Calico."
 }
+
+variable "k3s_exec_server_args" {
+  type        = string
+  default     = ""
+  description = "The control plane is started with `k3s server {k3s_exec_server_args}`. Use this to add kube-apiserver-arg for example."
+}


### PR DESCRIPTION
This adds k3s_exec_server_args, which lets you pass arguments to `k3s server` like so:
```
k3s_exec_server_args = "--kube-apiserver-arg enable-admission-plugins=PodTolerationRestriction,PodNodeSelector"
```

See the updated README with and example of a currently very relevant use-case with mixed arm64/amd64 clusters.