### PR TITLE
Introduce ssh_max_auth_tries variable

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -218,6 +218,9 @@ module "kube-hetzner" {
   # You can refine a base domain name to be use in this form of nodename.base_domain for setting the reserve dns inside Hetzner
   # base_domain = "mycluster.example.com"
 
+  # If you have issues with SSH connection to your nodes, you can increase the number of auth tries here
+  # ssh_max_auth_tries = 2
+
   # Cluster Autoscaler
   # Providing at least one map for the array enables the cluster autoscaler feature, default is disabled
   # By default we set a compatible version with the default initial_k3s_channel, to set another one,

--- a/locals.tf
+++ b/locals.tf
@@ -537,7 +537,7 @@ EOF
     Port ${var.ssh_port}
     PasswordAuthentication no
     X11Forwarding no
-    MaxAuthTries 2
+    MaxAuthTries ${var.ssh_max_auth_tries}
     AllowTcpForwarding no
     AllowAgentForwarding no
     AuthorizedKeysFile .ssh/authorized_keys

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "hcloud_ssh_key_id" {
   default     = null
 }
 
+variable "ssh_max_auth_tries" {
+  description = "The maximum number of authentication attempts permitted per connection."
+  type        = number
+  default     = 2
+}
+
 variable "network_region" {
   description = "Default region for network."
   type        = string


### PR DESCRIPTION
The default value of 2 may be too strict if there's many SSH keys in the ssh-agent. Some parts of this project don't support specific key selection in the ssh-agent, such as `data "remote_file" "kubeconfig"`