### PR TITLE
added ssh_connection_timeout to resources

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -15,6 +15,7 @@ module "agents" {
   ssh_public_key               = var.ssh_public_key
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  ssh_connection_timeout       = var.ssh_connection_timeout
   firewall_ids                 = [hcloud_firewall.k3s.id]
   placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.agent[floor(index(keys(local.agent_nodes), each.key) / 10)].id
   location                     = each.value.location
@@ -52,6 +53,7 @@ resource "null_resource" "agents" {
     agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Generating k3s agent config file
@@ -135,6 +137,7 @@ resource "null_resource" "configure_longhorn_volume" {
     agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   depends_on = [
@@ -190,6 +193,7 @@ resource "null_resource" "configure_floating_ip" {
     agent_identity = local.ssh_agent_identity
     host           = module.agents[each.key].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   depends_on = [

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -37,6 +37,7 @@ resource "null_resource" "configure_autoscaler" {
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Upload the autoscaler resource defintion
@@ -108,6 +109,7 @@ resource "null_resource" "autoscaled_nodes_registries" {
     agent_identity = local.ssh_agent_identity
     host           = each.value.ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   provisioner "file" {

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -95,6 +95,9 @@ resource "null_resource" "control_planes" {
 
   # Generating k3s server config file
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = yamlencode(
       merge(
         {
@@ -135,11 +138,17 @@ resource "null_resource" "control_planes" {
 
   # Install k3s server
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = local.install_k3s_server
   }
 
   # Start the k3s server and wait for it to have started correctly
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = [
       "systemctl start k3s 2> /dev/null",
       <<-EOT

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -15,6 +15,7 @@ module "control_planes" {
   ssh_public_key               = var.ssh_public_key
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  ssh_connection_timeout       = var.ssh_connection_timeout
   firewall_ids                 = [hcloud_firewall.k3s.id]
   placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.control_plane[floor(index(keys(local.control_plane_nodes), each.key) / 10)].id
   location                     = each.value.location
@@ -89,6 +90,7 @@ resource "null_resource" "control_planes" {
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[each.key].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Generating k3s server config file

--- a/init.tf
+++ b/init.tf
@@ -5,6 +5,7 @@ resource "null_resource" "first_control_plane" {
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Generating k3s master config file
@@ -118,10 +119,14 @@ resource "null_resource" "kustomization" {
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Upload kustomization.yaml, containing Hetzner CSI & CSM, as well as kured.
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = yamlencode({
       apiVersion = "kustomize.config.k8s.io/v1beta1"
       kind       = "Kustomization"
@@ -157,6 +162,9 @@ resource "null_resource" "kustomization" {
 
   # Upload traefik ingress controller config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/traefik_ingress.yaml.tpl",
       {
@@ -167,6 +175,9 @@ resource "null_resource" "kustomization" {
 
   # Upload nginx ingress controller config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/nginx_ingress.yaml.tpl",
       {
@@ -177,6 +188,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the CCM patch config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/ccm.yaml.tpl",
       {
@@ -190,6 +204,9 @@ resource "null_resource" "kustomization" {
   # Upload the calico patch config, for the kustomization of the calico manifest
   # This method is a stub which could be replaced by a more practical helm implementation
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/calico.yaml.tpl",
       {
@@ -200,6 +217,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the cilium install file
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/cilium.yaml.tpl",
       {
@@ -210,6 +230,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the system upgrade controller plans config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/plans.yaml.tpl",
       {
@@ -220,6 +243,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the Longhorn config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/longhorn.yaml.tpl",
       {
@@ -232,6 +258,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the csi-driver-smb config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/csi-driver-smb.yaml.tpl",
       {
@@ -242,6 +271,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the cert-manager config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/cert_manager.yaml.tpl",
       {
@@ -252,6 +284,9 @@ resource "null_resource" "kustomization" {
 
   # Upload the Rancher config
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/rancher.yaml.tpl",
       {
@@ -262,6 +297,9 @@ resource "null_resource" "kustomization" {
   }
 
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content = templatefile(
       "${path.module}/templates/kured.yaml.tpl",
       {
@@ -273,6 +311,9 @@ resource "null_resource" "kustomization" {
 
   # Deploy secrets, logging is automatically disabled due to sensitive variables
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = [
       "set -ex",
       "kubectl -n kube-system create secret generic hcloud --from-literal=token=${var.hcloud_token} --from-literal=network=${hcloud_network.k3s.name} --dry-run=client -o yaml | kubectl apply -f -",
@@ -283,6 +324,9 @@ resource "null_resource" "kustomization" {
 
   # Deploy our post-installation kustomization
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = concat([
       "set -ex",
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -48,6 +48,12 @@ module "kube-hetzner" {
   # If you use SSH agent and have issues with SSH connecting to your nodes, you can increase the number of auth tries (default is 2)
   # ssh_max_auth_tries = 10
 
+  # Customize the ssh-timeout (by default 10m)
+  # Note that in some regions and under some circumstances the full network-wise availability of the nodes might be delayed after a restart, which causes the installation to fail.
+  # Increasing the ssh-connection timeout gives the local ssh client used by terraform more time before aborting.
+  # ssh_connection_timeout = "60m"
+
+
   # If you want to use an ssh key that is already registered within hetzner cloud, you can pass its id.
   # If no id is passed, a new ssh key will be registered within hetzner cloud.
   # It is important that exactly this key is passed via `ssh_public_key` & `ssh_private_key` vars.

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -5,6 +5,7 @@ data "remote_file" "kubeconfig" {
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null
+    timeout     = tonumber(trim(var.ssh_connection_timeout, "m"))*1000*60
   }
   path = "/etc/rancher/k3s/k3s.yaml"
 

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -5,7 +5,7 @@ data "remote_file" "kubeconfig" {
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null
-    timeout     = tonumber(trim(var.ssh_connection_timeout, "m"))*1000*60
+    timeout     = tonumber(trim(var.ssh_connection_timeout, "m")) * 1000 * 60
   }
   path = "/etc/rancher/k3s/k3s.yaml"
 

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -5,7 +5,7 @@ data "remote_file" "kustomization_backup" {
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null
-    timeout     = tonumber(trim(var.ssh_connection_timeout, "m"))*1000*60
+    timeout     = tonumber(trim(var.ssh_connection_timeout, "m")) * 1000 * 60
   }
   path = "/var/post_install/kustomization.yaml"
 

--- a/kustomization_backup.tf
+++ b/kustomization_backup.tf
@@ -5,6 +5,7 @@ data "remote_file" "kustomization_backup" {
     user        = "root"
     private_key = var.ssh_private_key
     agent       = var.ssh_private_key == null
+    timeout     = tonumber(trim(var.ssh_connection_timeout, "m"))*1000*60
   }
   path = "/var/post_install/kustomization.yaml"
 

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -11,9 +11,13 @@ resource "null_resource" "kustomization_user" {
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = [
       "echo 'Create kustomize dir'",
       "mkdir -p /var/user_kustomize"
@@ -21,16 +25,25 @@ resource "null_resource" "kustomization_user" {
   }
 
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     source      = "extra-manifests/"
     destination = "/var/user_kustomize"
   }
 
   provisioner "file" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     content     = templatefile("extra-manifests/kustomization.yaml.tpl", var.extra_kustomize_parameters)
     destination = "/var/user_kustomize/kustomization.yaml"
   }
 
   provisioner "remote-exec" {
+    connection {
+      timeout = var.ssh_connection_timeout
+    }
     inline = [
       "rm /var/user_kustomize/kustomization.yaml.tpl",
       "kubectl apply -k /var/user_kustomize/"

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -49,6 +49,7 @@ resource "hcloud_server" "server" {
     agent_identity = local.ssh_agent_identity
     host           = self.ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   # Prepare ssh identity file
@@ -103,6 +104,7 @@ resource "null_resource" "registries" {
     agent_identity = local.ssh_agent_identity
     host           = hcloud_server.server.ipv4_address
     port           = var.ssh_port
+    timeout        = var.ssh_connection_timeout
   }
 
   provisioner "file" {

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -118,3 +118,9 @@ variable "cloudinit_runcmd_common" {
   default = ""
   type    = string
 }
+
+variable "ssh_connection_timeout" {
+  description = "SSH connection timeout"
+  type        = string
+  default     = "10m"
+}

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -28,6 +28,16 @@ variable "packages_to_install" {
   type    = list(string)
   default = []
 }
+variable "start_retry_timeout" {
+  description = "SSH connection timeout"
+  type        = string
+  default     = "20m"
+}
+variable "ssh_timeout" {
+  description = "connection timeout"
+  type        = string
+  default     = "20m"
+}
 
 locals {
   needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console bind-utils wireguard-tools open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils"], var.packages_to_install))
@@ -80,6 +90,7 @@ source "hcloud" "microos-x86-snapshot" {
   }
   snapshot_name = "OpenSUSE MicroOS x86 by Kube-Hetzner"
   ssh_username  = "root"
+  ssh_timeout   = var.ssh_timeout
   token         = var.hcloud_token
 }
 
@@ -95,6 +106,7 @@ source "hcloud" "microos-arm-snapshot" {
   }
   snapshot_name = "OpenSUSE MicroOS ARM by Kube-Hetzner"
   ssh_username  = "root"
+  ssh_timeout   = var.ssh_timeout
   token         = var.hcloud_token
 }
 
@@ -105,12 +117,16 @@ build {
   # Download the MicroOS x86 image
   provisioner "shell" {
     inline = ["${local.download_image}${var.opensuse_microos_x86_mirror_link}"]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Write the MicroOS x86 image to disk
   provisioner "shell" {
     inline            = [local.write_image]
     expect_disconnect = true
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Ensure connection to MicroOS x86 and do house-keeping
@@ -118,17 +134,23 @@ build {
     pause_before      = "5s"
     inline            = [local.install_packages]
     expect_disconnect = true
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Ensure connection to MicroOS x86 and do house-keeping
   provisioner "shell" {
     pause_before = "5s"
     inline       = [local.clean_up]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
   provisioner "shell" {
     inline = [local.cloud_init_network]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 }
 
@@ -139,12 +161,16 @@ build {
   # Download the MicroOS ARM image
   provisioner "shell" {
     inline = ["${local.download_image}${var.opensuse_microos_arm_mirror_link}"]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Write the MicroOS ARM image to disk
   provisioner "shell" {
     inline            = [local.write_image]
     expect_disconnect = true
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Ensure connection to MicroOS ARM and do house-keeping
@@ -152,16 +178,22 @@ build {
     pause_before      = "5s"
     inline            = [local.install_packages]
     expect_disconnect = true
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Ensure connection to MicroOS ARM and do house-keeping
   provisioner "shell" {
     pause_before = "5s"
     inline       = [local.clean_up]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 
   # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
   provisioner "shell" {
     inline = [local.cloud_init_network]
+    start_retry_timeout   = var.start_retry_timeout
+    timeout      = var.ssh_timeout
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -573,3 +573,9 @@ variable "k3s_exec_server_args" {
   default     = ""
   description = "The control plane is started with `k3s server {k3s_exec_server_args}`. Use this to add kube-apiserver-arg for example."
 }
+
+variable "ssh_connection_timeout" {
+  description = "SSH connection timeout"
+  type        = string
+  default     = "10m"
+}


### PR DESCRIPTION
# Release notes
This PR introduces a new variable called `ssh_connection_timeout`, which is set to `10m` (10 minutes) as default.
This gives the local ssh client used by terraform more time before aborting. The initial default of terraform is 5 minutes (see: https://developer.hashicorp.com/terraform/language/resources/provisioners/connection)

# Additional information
In some crowded regions and under some circumstances the full network-wise availability of the nodes might be delayed after a restart, which causes the installation to fail. 

In my specific case, I wasn't able to install a simple cluster (3 control-plane nodes, 2 workers) spanned over Falkenstein, Nuernberg, Helsinki within about 50! attempts. After investigating and switching  (from WSL2 to native Linux) as well as tweaking (various ssh connection and key options) of my local infrastructurel, I figured out that some of the nodes were usually just fully available via ssh after 7-8 minutes. Which nodes in which region was always different based on time and day (so not reproducable).

Increasing the ssh timeout to 20m using this new variable finally eased the situation for me and let me install a cluster in almost one shot.

# Linked issues

might cover: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/526