### PR TITLE
Fix/optional skip GitHub calico

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -22,7 +22,7 @@ data "github_release" "kured" {
 
 // github_release for kured
 data "github_release" "calico" {
-  count       = var.calico_version == null ? 1 : 0
+  count       = var.calico_version == null && var.cni_plugin == "calico" ? 1 : 0
   repository  = "calico"
   owner       = "projectcalico"
   retrieve_by = "latest"

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
   ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version    = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
   kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
-  calico_version = var.calico_version != null ? var.calico_version : data.github_release.calico[0].release_tag
+  calico_version = (var.calico_version != null || var.cni_plugin != "calico") ? var.calico_version : data.github_release.calico[0].release_tag
 
   additional_k3s_environment = join("\n",
     [

--- a/locals.tf
+++ b/locals.tf
@@ -289,7 +289,7 @@ locals {
   }
 
   cni_install_resources = {
-    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${local.calico_version}/manifests/calico.yaml"]
+    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${coalesce(local.calico_version, "NA")}/manifests/calico.yaml"]
     "cilium" = ["cilium.yaml"]
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
   ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version    = var.hetzner_csi_version != null ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
   kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
-  calico_version = (var.calico_version != null || var.cni_plugin != "calico") ? var.calico_version : data.github_release.calico[0].release_tag
+  calico_version = length(data.github_release.calico) == 0 ? var.calico_version : data.github_release.calico[0].release_tag
 
   additional_k3s_environment = join("\n",
     [


### PR DESCRIPTION
data "github_release" "..." can be skipped for those resources which are disabled by the user.