### PR TITLE
Properly guide cloud-init to use NetworkManager

### DIFF
--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -61,6 +61,11 @@ locals {
     rm -rf /etc/ssh/ssh_host_*
     sleep 1 && udevadm settle
   EOT
+
+  cloud_init_network = <<-EOT
+    echo 'Make sure to use NetworkManager'
+    touch /etc/NetworkManager/NetworkManager.conf
+  EOT
 }
 
 # Source for the MicroOS x86 snapshot
@@ -120,6 +125,11 @@ build {
     pause_before = "5s"
     inline       = [local.clean_up]
   }
+
+  # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
+  provisioner "shell" {
+    inline = [local.cloud_init_network]
+  }
 }
 
 # Build the MicroOS ARM snapshot
@@ -148,5 +158,10 @@ build {
   provisioner "shell" {
     pause_before = "5s"
     inline       = [local.clean_up]
+  }
+
+  # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
+  provisioner "shell" {
+    inline = [local.cloud_init_network]
   }
 }


### PR DESCRIPTION
# Summary
Cloud-init does not generate the connections config correctly for NetworkManager as stated in issue https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/772. By creating the necessary file, cloud-init will properly configure NetworkManager and resolve the IPv6 issue on our Nodes. IPv6 for Pods is step two.

# Detailed info

Cloud-init correctly reads the configuration given by Hetzner, but incorrectly detects systemd-network as the network service instead of the actual NetworkManager. This is due to a missing `/etc/NetworkManager/NetworkManager.conf` file, which is required according to cloud-init's source code: https://github.com/canonical/cloud-init/blob/main/cloudinit/net/network_manager.py#L381

By creating this file before generating the network config, cloud-init is correctly guided to use NetworkManager and a valid file is written to `/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection`. The NetworkManager.conf file creation is performed in the packer file because the network configuration is generated early in the process, making it too late to create the file in `cloudinit_write_files_common` for example.