### PR TITLE
Add hcloud_network and hcloud_ssh_key ids to output so other resources outside of the module can refer to them

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -3,6 +3,16 @@ output "cluster_name" {
   description = "Shared suffix for all resources belonging to this cluster."
 }
 
+output "network_id" {
+  value       = hcloud_network.k3s.id
+  description = "The ID of the HCloud network."
+}
+
+output "ssh_key_id" {
+  value       = local.hcloud_ssh_key_id
+  description = "The ID of the HCloud SSH key."
+}
+
 output "control_planes_public_ipv4" {
   value = [
     for obj in module.control_planes : obj.ipv4_address


### PR DESCRIPTION
In my setup I also create another VMs that should use the same key as created by the module.

I also use the same network.

Using data resources and depends_on leads to recreation of resources every time a value in the kube-hetzner module changes.
