### PR TITLE
[Critical Bug]: Waiting for MicroOS to become available...

### DIFF
--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -3,7 +3,7 @@ locals {
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
   ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
   # shared flags for ssh to ignore host keys for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'IdentitiesOnly yes' -o PubkeyAuthentication=yes"
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PubkeyAuthentication=yes"
 
   # ssh_client_identity is used for ssh "-i" flag, its the private key if that is set, or a public key
   # if an ssh agent is used.


### PR DESCRIPTION
Was `-o IdentitiesOnly yes` instead of `-o IdentitiesOnly=yes`.

This resulted in the error message
```
command-line line 0: no argument after keyword "identitiesonly"
```
when used with `OpenSSH_8.9p1 Ubuntu-3ubuntu0.1, OpenSSL 3.0.2 15 Mar 2022`

I was debugging an issue with cluster creation and manually ran the SSH command that gets used to wait for MicroOS ("Waiting for MicroOS to become available...") when I noticed the error message. I'm not sure if this broke anything because I had also forgotten to load the SSH key in to the agent. 