### PR TITLE
A lot of QoL changes to Traefik - nothing breaking

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -660,7 +660,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.38.2"
+      version = ">= 1.39.0"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -502,6 +502,12 @@ resources:
     cpu: "300m"
     memory: "150Mi"
 %{endif~}
+%{if var.traefik_autoscaling~}
+autoscaling:
+  enabled: true
+  minReplicas: ${local.ingress_replica_count}
+  maxReplicas: ${local.ingress_max_replica_count}
+%{endif~}
   EOT
 
   rancher_values = var.rancher_values != "" ? var.rancher_values : <<EOT

--- a/locals.tf
+++ b/locals.tf
@@ -461,6 +461,7 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{if var.traefik_additional_ports != ""~}
 %{for option in var.traefik_additional_ports~}
   ${option}:
     proxyProtocol:
@@ -472,6 +473,7 @@ ports:
         - 127.0.0.1/32
         - 10.0.0.0/8
 %{endfor~}
+%{endif~}
 %{endif~}
 podDisruptionBudget:
 %{if var.traefik_pod_disruption_budget~}

--- a/locals.tf
+++ b/locals.tf
@@ -463,7 +463,11 @@ ports:
         - 10.0.0.0/8
 %{if var.traefik_additional_ports != ""~}
 %{for option in var.traefik_additional_ports~}
-  ${option}:
+  ${option.name}:
+    port: ${option.port}
+    expose: true
+    exposedPort: ${option.exposedPort}
+    protocol: ${option.protocol}
     proxyProtocol:
       trustedIPs:
         - 127.0.0.1/32

--- a/locals.tf
+++ b/locals.tf
@@ -100,7 +100,8 @@ locals {
 
   has_external_load_balancer = local.using_klipper_lb || local.ingress_controller == "none"
 
-  ingress_replica_count = (var.ingress_replica_count > 0) ? var.ingress_replica_count : (local.agent_count > 2) ? 3 : (local.agent_count == 2) ? 2 : 1
+  ingress_replica_count     = (var.ingress_replica_count > 0) ? var.ingress_replica_count : (local.agent_count > 2) ? 3 : (local.agent_count == 2) ? 2 : 1
+  ingress_max_replica_count = (var.ingress_max_replica_count > local.ingress_replica_count) ? var.ingress_max_replica_count : local.ingress_replica_count
 
   # disable k3s extras
   disable_extras = concat(["local-storage"], local.using_klipper_lb ? [] : ["servicelb"], ["traefik"], var.enable_metrics_server ? [] : ["metrics-server"])
@@ -506,7 +507,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: ${local.ingress_replica_count}
-  maxReplicas: ${var.ingress_max_replica_count}
+  maxReplicas: ${local.ingress_max_replica_count}
 %{endif~}
   EOT
 

--- a/locals.tf
+++ b/locals.tf
@@ -487,11 +487,21 @@ podDisruptionBudget:
   maxUnavailable: 33%
   minAvailable: 1
 %{endif~}
-%{if var.traefik_additional_options != ""~}
 additionalArguments:
+  - "--entrypoints.tcp=true"
+%{if var.traefik_additional_options != ""~}
 %{for option in var.traefik_additional_options~}
-- "${option}"
+  - "${option}"
 %{endfor~}
+%{endif~}
+%{if var.traefik_resource_limits~}
+resources:
+  requests:
+    cpu: "100m"
+    memory: "50Mi"
+  limits:
+    cpu: "300m"
+    memory: "150Mi"
 %{endif~}
   EOT
 

--- a/locals.tf
+++ b/locals.tf
@@ -485,7 +485,6 @@ ports:
 podDisruptionBudget:
   enabled: true
   maxUnavailable: 33%
-  minAvailable: 1
 %{endif~}
 additionalArguments:
   - "--entrypoints.tcp=true"

--- a/locals.tf
+++ b/locals.tf
@@ -506,7 +506,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: ${local.ingress_replica_count}
-  maxReplicas: ${local.ingress_max_replica_count}
+  maxReplicas: ${var.ingress_max_replica_count}
 %{endif~}
   EOT
 

--- a/locals.tf
+++ b/locals.tf
@@ -461,13 +461,15 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{endif~}
 %{if var.traefik_additional_ports != ""~}
 %{for option in var.traefik_additional_ports~}
   ${option.name}:
     port: ${option.port}
     expose: true
     exposedPort: ${option.exposedPort}
-    protocol: ${option.protocol}
+    protocol: TCP
+%{if !local.using_klipper_lb~}
     proxyProtocol:
       trustedIPs:
         - 127.0.0.1/32
@@ -476,8 +478,8 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
-%{endfor~}
 %{endif~}
+%{endfor~}
 %{endif~}
 %{if var.traefik_pod_disruption_budget~}
 podDisruptionBudget:

--- a/locals.tf
+++ b/locals.tf
@@ -475,12 +475,12 @@ ports:
 %{endfor~}
 %{endif~}
 %{endif~}
-podDisruptionBudget:
 %{if var.traefik_pod_disruption_budget~}
+podDisruptionBudget:
   enabled: true
-%{endif~}
   maxUnavailable: 33%
   minAvailable: 1
+%{endif~}
 %{if var.traefik_additional_options != ""~}
 additionalArguments:
 %{for option in var.traefik_additional_options~}

--- a/locals.tf
+++ b/locals.tf
@@ -461,7 +461,24 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for option in var.traefik_additional_ports~}
+  ${option}:
+    proxyProtocol:
+      trustedIPs:
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+    forwardedHeaders:
+      trustedIPs:
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+%{endfor~}
 %{endif~}
+podDisruptionBudget:
+%{if var.traefik_pod_disruption_budget~}
+  enabled: true
+%{endif~}
+  maxUnavailable: 33%
+  minAvailable: 1
 %{if var.traefik_additional_options != ""~}
 additionalArguments:
 %{for option in var.traefik_additional_options~}

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -3,7 +3,7 @@ locals {
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
   ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
   # shared flags for ssh to ignore host keys for all connections during provisioning.
-  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'IdentitiesOnly yes' -o PubkeyAuthentication=yes"
+  ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PubkeyAuthentication=yes"
 
   # ssh_client_identity is used for ssh "-i" flag, its the private key if that is set, or a public key
   # if an ssh agent is used.

--- a/modules/host/versions.tf
+++ b/modules/host/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.38.2"
+      version = ">= 1.39.0"
     }
   }
 }

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -52,6 +52,8 @@ locals {
     transactional-update --continue shell <<< "zypper --no-gpg-checks --non-interactive install https://github.com/k3s-io/k3s-selinux/releases/download/v1.3.testing.4/k3s-selinux-1.3-4.sle.noarch.rpm"
     transactional-update --continue shell <<< "zypper addlock k3s-selinux"
     transactional-update --continue shell <<< "restorecon -Rv /etc/selinux/targeted/policy && restorecon -Rv /var/lib && setenforce 1"
+    echo "Make sure to use NetworkManager"
+    touch /etc/NetworkManager/NetworkManager.conf
     sleep 1 && udevadm settle && reboot
   EOT
 
@@ -60,11 +62,6 @@ locals {
     echo "Second reboot successful, cleaning-up..."
     rm -rf /etc/ssh/ssh_host_*
     sleep 1 && udevadm settle
-  EOT
-
-  cloud_init_network = <<-EOT
-    echo 'Make sure to use NetworkManager'
-    touch /etc/NetworkManager/NetworkManager.conf
   EOT
 }
 
@@ -125,11 +122,6 @@ build {
     pause_before = "5s"
     inline       = [local.clean_up]
   }
-
-  # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
-  provisioner "shell" {
-    inline = [local.cloud_init_network]
-  }
 }
 
 # Build the MicroOS ARM snapshot
@@ -158,10 +150,5 @@ build {
   provisioner "shell" {
     pause_before = "5s"
     inline       = [local.clean_up]
-  }
-
-  # Create an empty config file, so cloud-init will generate NetworkManager system-connection files properly
-  provisioner "shell" {
-    inline = [local.cloud_init_network]
   }
 }

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -48,7 +48,7 @@ if [[ "$create_snapshots" =~ ^([Yy]es|[Yy])$ ]]; then
     export HCLOUD_TOKEN=$hcloud_token
     echo " "
     echo "Running: packer build packer build hcloud-microos-snapshots.pkr.hcl"
-    cd "${folder_path}/${folder_name}" && packer build hcloud-microos-snapshots.pkr.hcl
+    cd "${folder_path}" && packer build hcloud-microos-snapshots.pkr.hcl
 else
     echo " "
     echo "You can create the snapshots later by running 'packer build hcloud-microos-snapshots.pkr.hcl' in the folder."

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Check if terraform, packer and hcloud CLIs are present
+command -v ssh >/dev/null 2>&1 || { echo "openssh is not installed. Install it with 'brew install openssh'."; exit 1; }
 command -v terraform >/dev/null 2>&1 || { echo "terraform is not installed. Install it with 'brew install terraform'."; exit 1; }
 command -v packer >/dev/null 2>&1 || { echo "packer is not installed. Install it with 'brew install packer'."; exit 1; }
 command -v hcloud >/dev/null 2>&1 || { echo "hcloud (Hetzner CLI) is not installed. Install it with 'brew install hcloud'."; exit 1; }

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,6 @@ variable "traefik_additional_ports" {
     name        = string
     port        = number
     exposedPort = number
-    protocol    = string
   }))
   default     = []
   description = "Additional ports to pass to Traefik as a list of strings. These are the ones that go into the ports section of the Traefik helm values file."

--- a/variables.tf
+++ b/variables.tf
@@ -209,11 +209,11 @@ variable "ingress_replica_count" {
 variable "ingress_max_replica_count" {
   type        = number
   default     = 10
-  description = "Number of maximum replicas per ingress controller. Used for ingress HPA."
+  description = "Number of maximum replicas per ingress controller. Used for ingress HPA. Must be higher than number of replicas."
 
   validation {
-    condition     = var.ingress_max_replica_count > var.ingress_replica_count
-    error_message = "Number of ingress maximum replicas can't be below or equal to number of replicas."
+    condition     = var.ingress_max_replica_count >= 0
+    error_message = "Number of ingress maximum replicas can't be below 0."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,12 @@ variable "traefik_pod_disruption_budget" {
   description = "Should traefik enable pod disruption budget. Default values are maxUnavailable: 33% and minAvailable: 1."
 }
 
+variable "traefik_resource_limits" {
+  type        = bool
+  default     = true
+  description = "Should traefik enable default resource requests and limits. Default values are requests: 100m & 50Mi and limits: 300m & 150Mi."
+}
+
 variable "traefik_additional_ports" {
   type = list(object({
     name        = string

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,23 @@ variable "ingress_replica_count" {
   }
 }
 
+variable "ingress_max_replica_count" {
+  type        = number
+  default     = 10
+  description = "Number of maximum replicas per ingress controller. Used for ingress HPA."
+
+  validation {
+    condition     = var.ingress_max_replica_count > var.ingress_replica_count
+    error_message = "Number of ingress maximum replicas can't be below or equal to number of replicas."
+  }
+}
+
+variable "traefik_autoscaling" {
+  type        = bool
+  default     = true
+  description = "Should traefik enable Horizontal Pod Autoscaler."
+}
+
 variable "traefik_redirect_to_https" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "traefik_redirect_to_https" {
   description = "Should traefik redirect http traffic to https."
 }
 
+variable "traefik_additional_ports" {
+  type        = list(string)
+  default     = []
+  description = "Additional ports to pass to Traefik as a list of strings. These are the ones that go into the ports section of the Traefik helm values file."
+}
+
 variable "traefik_additional_options" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "traefik_redirect_to_https" {
   description = "Should traefik redirect http traffic to https."
 }
 
+variable "traefik_pod_disruption_budget" {
+  type        = bool
+  default     = true
+  description = "Should traefik enable pod disruption budget. Default values are maxUnavailable: 33% and minAvailable: 1."
+}
+
 variable "traefik_additional_ports" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -231,7 +231,7 @@ variable "traefik_additional_ports" {
     exposedPort = number
   }))
   default     = []
-  description = "Additional ports to pass to Traefik as a list of strings. These are the ones that go into the ports section of the Traefik helm values file."
+  description = "Additional ports to pass to Traefik. These are the ones that go into the ports section of the Traefik helm values file."
 }
 
 variable "traefik_additional_options" {

--- a/variables.tf
+++ b/variables.tf
@@ -213,7 +213,12 @@ variable "traefik_pod_disruption_budget" {
 }
 
 variable "traefik_additional_ports" {
-  type        = list(string)
+  type = list(object({
+    name        = string
+    port        = number
+    exposedPort = number
+    protocol    = string
+  }))
   default     = []
   description = "Additional ports to pass to Traefik as a list of strings. These are the ones that go into the ports section of the Traefik helm values file."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.38.2"
+      version = ">= 1.39.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
1. Added `traefik_pod_disruption_budget` which is enabled by default
2. Added `traefik_resource_limits` which are enabled by default
3. Added `traefik_additional_ports` which allow users to add custom ports to Traefik, for example port 22 for ssh is added with these rules:
```terraform
traefik_additional_ports = [
    {
      name        = "ssh",
      port        = 22,
      exposedPort = 22
    }
  ]
```