### PR TITLE
Allow KlipperLB to be used without scheduling on the control plane

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -105,8 +105,8 @@ locals {
   # disable k3s extras
   disable_extras = concat(["local-storage"], local.using_klipper_lb ? [] : ["servicelb"], ["traefik"], var.enable_metrics_server ? [] : ["metrics-server"])
 
-  # Determine if scheduling should be allowed on control plane nodes, which will be always true for single node clusters and clusters using the klipper lb or if scheduling is allowed on control plane nodes
-  allow_scheduling_on_control_plane = (local.is_single_node_cluster || local.using_klipper_lb) ? true : var.allow_scheduling_on_control_plane
+  # Determine if scheduling should be allowed on control plane nodes, which will be always true for single node clusters and clusters or if scheduling is allowed on control plane nodes
+  allow_scheduling_on_control_plane = local.is_single_node_cluster ? true : var.allow_scheduling_on_control_plane
   # Determine if loadbalancer target should be allowed on control plane nodes, which will be always true for single node clusters or if scheduling is allowed on control plane nodes
   allow_loadbalancer_target_on_control_plane = local.is_single_node_cluster ? true : var.allow_scheduling_on_control_plane
 


### PR DESCRIPTION
# Issue
Right now, in case KlipperLB is activated scheduling on the control plane is activated too. 
This has historical reasons, please see the following quote:
> [...] initially, we only activated Klipper for single-node clusters, so we had to allow scheduling on the control plane for obvious reasons, but then I added the option of using Klipper even for multi-node clusters, and the old logic stayed.

https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/201#discussioncomment-2810840

Considering the above statement it should be possible to use KlipperLB **without** enabling scheduling on the control plane at the same time.

@mysticaltech I could not find an explanation on why the code has not been changed as described in your comment. This pull request will apply the logic as you have described it in your comment.

# Related
https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/201
https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/commit/3558a462e4fc224815dfa5d4a72c5c8fff652988