### PR TITLE
Drop default ssh firewall rule when custom ssh port is used

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -157,15 +157,7 @@ locals {
       source_ips  = ["0.0.0.0/0", "::/0"]
     },
 
-    # Allow all traffic to the ssh ports
-    {
-      description = "Allow Incoming SSH Traffic"
-      direction   = "in"
-      protocol    = "tcp"
-      port        = "22"
-      source_ips  = ["0.0.0.0/0", "::/0"]
-    }
-    ], var.ssh_port == 22 ? [] : [
+    # Allow all traffic to the ssh port
     {
       description = "Allow Incoming SSH Traffic"
       direction   = "in"


### PR DESCRIPTION
It is not necessary to open the standard port 22 when using a custom port