### PR TITLE
Fix wrong MTU calculation for cilium

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ bpf:
   masquerade: "true"
 egressGateway:
   enabled: "true"
+extraConfig:
+  mtu: "1450"
 EOT
 ```
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -527,6 +527,8 @@ l7Proxy: false
 encryption:
   enabled: true
   type: wireguard
+extraConfig:
+  mtu: "1450"
   EOT */
 
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -344,6 +344,8 @@ encryption:
   enabled: true
   type: wireguard
 %{endif~}
+extraConfig:
+  mtu: "1450"
   EOT
 
   # Not to be confused with the other helm values, this is used for the calico.yaml kustomize patch


### PR DESCRIPTION
Cilium does not pick the correct interface for the MTU calculation. In all my tests it used 1500 from the eth0 interface as base. Due to the Hetzner OpenStack VXLAN based internal networking, the "normal" 1500 MTU is reduced by 50 Bytes to 1450. Unfortunately Cilium is not able to handle it properly (https://github.com/cilium/cilium/issues/14339).

I tried Cilium with wireguard encryption and immediately saw the wrongly calculated MTU values, especially for the `cilium_wg0` interface. Inside of the tunnel everything looks fine, but outside of it you will see a lot of fragmented packets. This can be observed with tcpdump. I used this filter for the detection: `tcpdump -i eth1 -f "ip[6:2] & 0x3fff != 0x0000"`

This pull request tells Cilium which MTU to use as the base for the MTU calculation of the interfaces to be created, instead of letting Cilium choose an interface at random (it was always eth0 for me).

**Before the change:**
```shell
k3s-control-plane-fsn1-sim:~ # ip a | grep mtu
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
4: cilium_wg0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN group default 
5: cilium_net@cilium_host: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
6: cilium_host@cilium_net: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
7: cilium_vxlan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
9: lxc_health@if8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
11: lxcdedea9fcbd4d@if10: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
13: lxc649c050e679a@if12: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
15: lxcaa850f2fc770@if14: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
17: lxc858e6e1c3bbf@if16: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
19: lxc5ff05d5ef2e0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
```

**After the change:**
```shell
k3s-control-plane-fsn1-xlr:~ # ip a | grep mtu
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
4: cilium_wg0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1370 qdisc noqueue state UNKNOWN group default 
5: cilium_net@cilium_host: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
6: cilium_host@cilium_net: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
7: cilium_vxlan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN group default qlen 1000
9: lxc_health@if8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
11: lxc7d9d6178f9d3@if10: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
13: lxc9350d1070a35@if12: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
15: lxc3764298dcf70@if14: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
17: lxc46d7d64952c5@if16: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
19: lxc19ba2c3ef654@if18: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default qlen 1000
```