### PR TITLE
Fix error with extra-manifests

### DIFF
--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -1,6 +1,5 @@
 locals {
-  extra_manifests_exists       = fileexists("extra-manifests")
-  user_kustomization_templates = local.extra_manifests_exists ? fileset("extra-manifests", "*.yaml.tpl") : toset([])
+  user_kustomization_templates = try(fileset("extra-manifests", "*.yaml.tpl"), [])
 }
 
 resource "null_resource" "kustomization_user_setup" {


### PR DESCRIPTION
Using the `fileexists` function on the `extra-manifests` directory throws the following error when it exists: 

```

╷
│ Error: Error in function call
│ 
│   on .terraform/modules/k8s.kube-hetzner/kustomization_user.tf line 2, in locals:
│    2:   extra_manifests_exists       = fileexists("extra-manifests")
│     ├────────────────
│     │ while calling fileexists(path)
│ 
│ Call to function "fileexists" failed: "extra-manifests" is a directory, not
│ a file.
```

The function can be used only on a file, not a directory. 

A safer solution would be to use the `try` function if there is some error with `fileset`.