### PR TITLE
fix longhorn prevent downscaling

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -378,6 +378,9 @@ spec:
 
   longhorn_values = var.longhorn_values != "" ? var.longhorn_values : <<EOT
 defaultSettings:
+%{if length(var.autoscaler_nodepools) != 0~}
+  kubernetesClusterAutoscalerEnabled: true
+%{endif~}
   defaultDataPath: /var/longhorn
 persistence:
   defaultFsType: ${var.longhorn_fstype}


### PR DESCRIPTION
when using autoscaler and longhorn at the same time, the longhorn instance manager is deployed on the autoscaler nodes.
When downscaling, these pods cannot be unscheduled.
Longhorn has integrated the "kubernetesClusterAutoscalerEnabled" configuration switch into the Helmchart to solve this problem.