### PR TITLE
[FIX] FloatingIP: Change MicroOS wickedd to networkmanager

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -171,6 +171,12 @@ resource "null_resource" "configure_floating_ip" {
 
   provisioner "remote-exec" {
     inline = [
+      # Reconfigure eth0:
+      #  - add floating_ip as first and other IP as second address
+      #  - add 172.31.1.1 as default gateway (In the Hetzner Cloud, the
+      #    special private IP address 172.31.1.1 is the default
+      #    gateway for the public network)
+      # The configuration is stored in file /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection
       <<-EOT
       NM_CONNECTION=$(nmcli -g GENERAL.CONNECTION device show eth0)
       nmcli connection modify "$NM_CONNECTION" \


### PR DESCRIPTION
To solve https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/869 I took the implementation from https://github.com/treeumcorp/terraform-hcloud-kube-hetzner/blob/4ea2865a5a7b4a7a9a6e821b9724b4d4bffd7106/modules/host/main.tf#L122-L128 (using `nmcli` to configure the network interface in a persistent way) and added some comments. I don't know if @sshcherbinin plans to PR his changes (I also think it is useful to provide floating IP for all nodes, and put the floating IP code to the host module), but we should fix the bug in the current implementation anyway.

Tested if floating IP is persistent:
```
$ ssh -i id_ed25519 root@5.75.248.17

k3s-agent-small-zsk:~ # ip a s eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 96:00:02:56:d8:84 brd ff:ff:ff:ff:ff:ff
    altname enp1s0
    inet 116.202.2.72/32 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet 5.75.248.17/32 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet6 2a01:4f8:c012:84eb::1/64 scope global noprefixroute 
       valid_lft forever preferred_lft forever
    inet6 fe80::9400:2ff:fe56:d884/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever

k3s-agent-small-zsk:~ # reboot

$ ssh -i id_ed25519 root@5.75.248.17

k3s-agent-small-zsk:~ # ip a s eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 96:00:02:56:d8:84 brd ff:ff:ff:ff:ff:ff
    altname enp1s0
    inet 116.202.2.72/32 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet 5.75.248.17/32 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet6 2a01:4f8:c012:84eb::1/64 scope global noprefixroute 
       valid_lft forever preferred_lft forever
    inet6 fe80::9400:2ff:fe56:d884/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever
```

The configuration created by the `nmcli` call:
```
k3s-agent-small-zsk:~ # cat /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection 
[connection]
id=cloud-init eth0
uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
type=ethernet
timestamp=1688478322

[ethernet]
mac-address=96:00:02:56:D8:84

[ipv4]
address1=116.202.2.72/32,172.31.1.1
address2=5.75.248.17/32
may-fail=false
method=manual
route-metric=100

[ipv6]
address1=2a01:4f8:c012:84eb::1/64,fe80::1
dns=2a01:4ff:ff00::add:2;2a01:4ff:ff00::add:1;
may-fail=false
method=manual

[proxy]

[user]
org.freedesktop.NetworkManager.origin=cloud-init
```

The configuration is persistent on system reboot, the floating IP is configured as first IP (needed for egress routing) and the servers primary IP is placed as second IP. 