### PR TITLE
fix: added timeout for checking internet connectivity, it can actuall…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -42,7 +42,7 @@ locals {
     # User-defined commands to execute just before installing k3s.
     var.preinstall_exec,
     # Wait for a successful connection to the internet.
-    ["while ! ping -c 1 1.1.1.1 >/dev/null 2>&1; do echo 'Ready for k3s installation, waiting for a successful connection to the internet...'; sleep 5; done; echo 'Connected'"]
+    ["timeout 180s /bin/sh -c 'while ! ping -c 1 1.1.1.1 >/dev/null 2>&1; do echo \"Ready for k3s installation, waiting for a successful connection to the internet...\"; sleep 5; done; echo Connected'"]
   )
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -42,7 +42,7 @@ locals {
     # User-defined commands to execute just before installing k3s.
     var.preinstall_exec,
     # Wait for a successful connection to the internet.
-    ["timeout 180s /bin/sh -c 'while ! ping -c 1 1.1.1.1 >/dev/null 2>&1; do echo \"Ready for k3s installation, waiting for a successful connection to the internet...\"; sleep 5; done; echo Connected'"]
+    ["timeout 180s /bin/sh -c 'while ! ping -c 1 ${var.address_for_connectivity_test} >/dev/null 2>&1; do echo \"Ready for k3s installation, waiting for a successful connection to the internet...\"; sleep 5; done; echo Connected'"]
   )
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -593,6 +593,12 @@ variable "dns_servers" {
   }
 }
 
+variable "address_for_connectivity_test" {
+  type        = string
+  default     = "1.1.1.1"
+  description = "Before installing k3s, we actually verify that there is internet connectivity. By default we ping 1.1.1.1, but if you use a proxy, you may simply want to ping that proxy instead (assuming that the proxy has its own checks for internet connectivity)."
+}
+
 variable "additional_k3s_environment" {
   type        = map(any)
   default     = {}


### PR DESCRIPTION
…y happen that a node has no internet at all.

Terrible, but it happens in real life: sometimes a node cannot even ping 1.1.1.1. So we need a timeout here. I set it to 3 minutes, but feel free to impose a different choice.