### PR TITLE
Allow for mixed-type maps for control plane config

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -642,7 +642,7 @@ variable "enable_wireguard" {
 }
 
 variable "control_planes_custom_config" {
-  type        = map(any)
+  type        = any
   default     = {}
   description = "Custom control plane configuration e.g to allow etcd monitoring."
 }


### PR DESCRIPTION
I'm trying to apply this control plane config to our cluster:

```tf
  control_planes_custom_config = {
    etcd-expose-metrics         = true,
    kube-controller-manager-arg = "bind-address=0.0.0.0",
    kube-proxy-arg              = "metrics-bind-address=0.0.0.0",
    kube-scheduler-arg          = "bind-address=0.0.0.0",
    kube-apiserver-arg = [
      "oidc-issuer-url=https://auth.example.org/issuer",
      "oidc-client-id=<redacted>",
      "oidc-username-claim=name",
      "oidc-username-prefix=oidc:",
      "oidc-groups-claim=groups",
      "oidc-groups-prefix=oidc:",
    ]
  }
```

terraform complains with:

> Error: Invalid value for input variable
> on `kube.tf line 144`, in module "kube-hetzner":
> 
> [repeats TF file]
> 
> The given value is not suitable for `module.kube-hetzner.var.control_planes_custom_config` declared at `.terraform/modules/kube-hetzner/variables.tf:644,1-40`: all map elements must have the same type.

---

Imho, `map(any)` is the wrong type for this variable because:

> ### `any` with Collection Types
>
> All of the elements of a collection must have the same type, so if you use any as the placeholder for the element type of a collection then Terraform will attempt to find a single exact element type to use for the resulting collection.
> ([source](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#any-with-collection-types))

Here is the part of the docs that tells us why `any` is correct:

> The only situation where it's appropriate to use `any` is if you will pass the given value directly to some other system without directly accessing its contents. For example, it's okay to use a variable of type any if you use it only with `jsonencode` to pass the full value directly to a resource, ...
> ([source](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#dynamic-types-the-any-constraint))

since the value is just passed to `yamlencode` and not processed in the context of terraform.