### PR TITLE
drop default for var.hcloud_token

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,6 @@ variable "hcloud_token" {
   description = "Hetzner Cloud API Token."
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "microos_x86_snapshot_id" {


### PR DESCRIPTION
the token is used to create the hcloud secret in the kube-system namespace. Previously it could be left empty, breaking the setup during the kustomization stage. This change forces the user to set a value.

Closes: #885