### PR TITLE
Bash Autocompletion for Kubectl

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -25,6 +25,21 @@ locals {
   set -a; source /etc/environment; set +a;
   EOT
 
+  install_system_alias = <<-EOT
+  cat > /etc/profile.d/00-alias.sh <<EOF
+  alias k=kubectl
+  EOF
+  EOT
+
+  install_kubectl_bash_completion = <<-EOT
+  cat > /etc/bash_completion.d/kubectl <<EOF
+  if command -v kubectl >/dev/null; then
+    source <(kubectl completion bash)
+    complete -o default -F __start_kubectl k
+  fi
+  EOF
+  EOT
+
   common_pre_install_k3s_commands = concat(
     [
       "set -ex",
@@ -38,6 +53,8 @@ locals {
       # if the server has already been initialized just stop here
       "[ -e /etc/rancher/k3s/k3s.yaml ] && exit 0",
       local.install_additional_k3s_environment,
+      local.install_system_alias,
+      local.install_kubectl_bash_completion,
     ],
     # User-defined commands to execute just before installing k3s.
     var.preinstall_exec,

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -38,7 +38,7 @@ variable "packages_to_install" {
 }
 
 locals {
-  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console bind-utils wireguard-tools open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils"], var.packages_to_install))
+  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console bind-utils wireguard-tools open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils bash-completion"], var.packages_to_install))
 
   # Add local variables for inline shell commands
   download_image = "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only "


### PR DESCRIPTION
As discussed in https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/872 here is a PR to add `kubectl` bash autocompletion. Additionally I added the `k` alias and the autocompletion for it as well.

Unfortunately I had to wrap the bash completion into a condition, because `kubectl` is not reachable from the transactional-update shell. This would not cause big problems, but you would see an error message at the beginning, which is not so nice. So I decided to add a check if `kubectl` is available.

Normal bash shell:
```bash
k3s-p-ctl-hel-hnr-dmm:~ # which kubectl
/usr/local/bin/kubectl
k3s-p-ctl-hel-hnr-dmm:~ # ls -la /usr/local/
total 0
drwxr-xr-x. 1 root root  80 Jul 19 01:16 .
drwxr-xr-x. 1 root root 124 Jul 20 09:31 ..
drwxr-xr-x. 1 root root  98 Jul 20 09:39 bin
drwxr-xr-x. 1 root root   0 Jul 19 01:16 include
drwxr-xr-x. 1 root root   0 Jul 19 01:16 lib
drwxr-xr-x. 1 root root   0 Jul 19 01:16 lib64
drwxr-xr-x. 1 root root   0 Jul 19 01:16 libexec
drwxr-xr-x. 1 root root  80 Jul 19 01:16 man
drwxr-xr-x. 1 root root   0 Jul 19 01:16 sbin
drwxr-xr-x. 1 root root   0 Jul 19 01:16 share
drwxr-xr-x. 1 root root   0 Jul 19 01:16 src
```
transactional-update shell:
```bash
transactional update # which kubectl
which: no kubectl in (/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin)
transactional update # ls -la /usr/local/
total 0
drwxr-xr-x. 1 root root   0 Jul 19 01:18 .
drwxr-xr-x. 1 root root 124 Jul 20 14:12 ..
```

Reference: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-autocomplete