### PR TITLE
Added advanced Load Balancer Options

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -219,6 +219,18 @@ module "kube-hetzner" {
   # Disable IPv6 for the load balancer, the default is false.
   # load_balancer_disable_ipv6 = true
 
+  # Specifies the algorithm type of the load balancer. (default: round_robin).
+  # load_balancer_algorithm_type = "least_connections"
+
+  # Specifies the interval at which a health check is performed. Minimum is 3s (default: 15s).
+  # load_balancer_health_check_interval = "5s"
+
+  # Specifies the timeout of a single health check. Must not be greater than the health check interval. Minimum is 1s (default: 10s).
+  # load_balancer_health_check_timeout = "3s"
+
+  # Specifies the number of times a health check is retried before a target is marked as unhealthy. (default: 3)
+  # load_balancer_health_check_retries = 3
+
   ### The following values are entirely optional (and can be removed from this if unused)
 
   # You can refine a base domain name to be use in this form of nodename.base_domain for setting the reserve dns inside Hetzner

--- a/locals.tf
+++ b/locals.tf
@@ -410,6 +410,10 @@ controller:
       "load-balancer.hetzner.cloud/location": "${var.load_balancer_location}"
       "load-balancer.hetzner.cloud/type": "${var.load_balancer_type}"
       "load-balancer.hetzner.cloud/uses-proxyprotocol": "${!local.using_klipper_lb}"
+      "load-balancer.hetzner.cloud/algorithm-type": "${var.load_balancer_algorithm_type}"
+      "load-balancer.hetzner.cloud/health-check-interval": "${var.load_balancer_health_check_interval}"
+      "load-balancer.hetzner.cloud/health-check-timeout": "${var.load_balancer_health_check_timeout}"
+      "load-balancer.hetzner.cloud/health-check-retries": "${var.load_balancer_health_check_retries}"
 %{if var.lb_hostname != ""~}
       "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
 %{endif~}
@@ -432,6 +436,10 @@ service:
     "load-balancer.hetzner.cloud/location": "${var.load_balancer_location}"
     "load-balancer.hetzner.cloud/type": "${var.load_balancer_type}"
     "load-balancer.hetzner.cloud/uses-proxyprotocol": "${!local.using_klipper_lb}"
+    "load-balancer.hetzner.cloud/algorithm-type": "${var.load_balancer_algorithm_type}"
+    "load-balancer.hetzner.cloud/health-check-interval": "${var.load_balancer_health_check_interval}"
+    "load-balancer.hetzner.cloud/health-check-timeout": "${var.load_balancer_health_check_timeout}"
+    "load-balancer.hetzner.cloud/health-check-retries": "${var.load_balancer_health_check_retries}"
 %{if var.lb_hostname != ""~}
     "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
 %{endif~}

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,30 @@ variable "load_balancer_disable_ipv6" {
   default     = false
 }
 
+variable "load_balancer_algorithm_type" {
+  description = "Specifies the algorithm type of the load balancer."
+  type        = string
+  default     = "round_robin"
+}
+
+variable "load_balancer_health_check_interval" {
+  description = "Specifies the interval at which a health check is performed. Minimum is 3s."
+  type        = string
+  default     = "15s"
+}
+
+variable "load_balancer_health_check_timeout" {
+  description = "Specifies the timeout of a single health check. Must not be greater than the health check interval. Minimum is 1s."
+  type        = string
+  default     = "10s"
+}
+
+variable "load_balancer_health_check_retries" {
+  description = "Specifies the number of times a health check is retried before a target is marked as unhealthy."
+  type        = number
+  default     = 3
+}
+
 variable "control_plane_nodepools" {
   description = "Number of control plane nodes."
   type = list(object({


### PR DESCRIPTION
I added some advanced load balancing options and set their defaults to Hetzner's. Now the interval, timeout and retries for the health check can be customized and the load balancing algorithm is also selectable.