### PR TITLE
Fix name for control-lb + prevent infinite waiting when using lb_host…

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -30,7 +30,7 @@ data "github_release" "calico" {
 
 data "hcloud_load_balancer" "cluster" {
   count = local.has_external_load_balancer ? 0 : 1
-  name  = var.cluster_name
+  name  = "${var.cluster_name}-control-plane"
 
   depends_on = [null_resource.kustomization]
 }

--- a/init.tf
+++ b/init.tf
@@ -320,7 +320,7 @@ resource "null_resource" "kustomization" {
       local.has_external_load_balancer ? [] : [
         <<-EOT
       timeout 360 bash <<EOF
-      until [ -n "\$(kubectl get -n ${lookup(local.ingress_controller_namespace_names, local.ingress_controller)} service/${lookup(local.ingress_controller_service_names, local.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].${var.lb_hostname != "" ? "hostname" : "ip"}}' 2> /dev/null)" ]; do
+      until [ -n "\$(kubectl get -n ${lookup(local.ingress_controller_namespace_names, local.ingress_controller)} service/${lookup(local.ingress_controller_service_names, local.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2> /dev/null)" ]; do
           echo "Waiting for load-balancer to get an IP..."
           sleep 2
       done


### PR DESCRIPTION
1. Correlates '"hcloud_load_balancer" "cluster"' name between control_planes.tf and data.tf
2. When using lb_hostname="some.fqdn" terraform is stuck in 'Waiting for load-balancer to get an IP...', this is because `kubectl get -n traefik service/traefik --output=jsonpath='{.status.loadBalancer.ingress[0]}'`
return only `{"ip":"1.1.1.1"}`