### PR TITLE
fix waiting for load-balancer IP in case no IP is assigned

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -293,8 +293,8 @@ resource "null_resource" "kustomization" {
       local.has_external_load_balancer ? [] : [
         <<-EOT
       timeout 360 bash <<EOF
-      until [ -n "\$(kubectl get -n ${lookup(local.ingress_controller_namespace_names, local.ingress_controller)} service/${lookup(local.ingress_controller_service_names, local.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2> /dev/null)" ]; do
-          echo "Waiting for load-balancer to get an IP..."
+      until [ -n "\$(kubectl get -n ${lookup(local.ingress_controller_namespace_names, local.ingress_controller)} service/${lookup(local.ingress_controller_service_names, local.ingress_controller)} --output=jsonpath=${var.lb_hostname == "" ? "'{.status.loadBalancer.ingress[0].ip}'" : "'{.status.loadBalancer.ingress[0].hostname}'"} 2> /dev/null)" ]; do
+          echo "Waiting for load-balancer to get an IP/Hostname..."
           sleep 2
       done
       EOF


### PR DESCRIPTION
fix waiting for load-balancer IP in case no IP is assigned, but a hostname (e.g. when lb_hostname is set)