### PR TITLE
Unify NetworkManager Connection Names

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -576,7 +576,7 @@ fi
 EOF
 
   cloudinit_write_files_common = <<EOT
-# Script to rename the private interface to eth1
+# Script to rename the private interface to eth1 and unify NetworkManager connection naming
 - path: /etc/cloud/rename_interface.sh
   content: |
     #!/bin/bash
@@ -594,6 +594,18 @@ EOF
     ip link set $INTERFACE down
     ip link set $INTERFACE name eth1
     ip link set eth1 up
+
+    eth0_connection=$(nmcli -g GENERAL.CONNECTION device show eth0)
+    nmcli connection modify "$eth0_connection" \
+      con-name eth0 \
+      connection.interface-name eth0
+
+    eth1_connection=$(nmcli -g GENERAL.CONNECTION device show eth1)
+    nmcli connection modify "$eth1_connection" \
+      con-name eth1 \
+      connection.interface-name eth1
+
+    systemctl restart NetworkManager
   permissions: "0744"
 
 # Disable ssh password authentication


### PR DESCRIPTION
This PR is mainly a cosmetic change to unify NetworkManager connection names to make life easier for humans interacting with `nmcli`.

Before the change:
```bash
# nmcli connection show
NAME                UUID                                  TYPE      DEVICE 
cloud-init eth0     1dd9a779-d327-56e1-8454-c65e2556c12c  ethernet  eth0   
Wired connection 1  fdcd1a0a-bb69-3017-a940-96773f29fb8d  ethernet  eth1   
lo                  9e961e02-e328-4a5f-98ed-227fbf4b189d  loopback  lo 
```

After the change:
```bash
# nmcli connection show
NAME  UUID                                  TYPE      DEVICE 
eth0  1dd9a779-d327-56e1-8454-c65e2556c12c  ethernet  eth0   
eth1  2a211c06-56de-35bb-967d-5b0c8378449e  ethernet  eth1   
lo    086d46a4-41f2-4089-81ce-0517216dbe80  loopback  lo  
```