### PR TITLE
Performance Improvements and Native Routing Mode for Cilium

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,17 +372,21 @@ cluster_ipv4_cidr = local.cluster_ipv4_cidr
 
 cilium_values = <<EOT
 ipam:
-  operator:
-    clusterPoolIPv4PodCIDRList:
-      - ${local.cluster_ipv4_cidr}
-kubeProxyReplacement: strict
-l7Proxy: "false"
+  mode: kubernetes
+k8s:
+  requireIPv4PodCIDR: true
+kubeProxyReplacement: true
+routingMode: native
+ipv4NativeRoutingCIDR: "10.0.0.0/8"
+endpointRoutes:
+  enabled: true
+loadBalancer:
+  acceleration: native
 bpf:
-  masquerade: "true"
+  masquerade: true
 egressGateway:
-  enabled: "true"
-extraConfig:
-  mtu: "1450"
+  enabled: true
+MTU: 1450
 EOT
 ```
 

--- a/init.tf
+++ b/init.tf
@@ -108,6 +108,7 @@ resource "null_resource" "kustomization" {
       coalesce(var.hetzner_csi_version, "N/A"),
       coalesce(var.kured_version, "N/A"),
       coalesce(var.calico_version, "N/A"),
+      coalesce(var.cilium_version, "N/A"),
     ])
     options = join("\n", [
       for option, value in var.kured_options : "${option}=${value}"
@@ -176,7 +177,8 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/cilium.yaml.tpl",
       {
-        values = indent(4, trimspace(local.cilium_values))
+        values  = indent(4, trimspace(local.cilium_values))
+        version = var.cilium_version
     })
     destination = "/var/post_install/cilium.yaml"
   }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -532,6 +532,18 @@ module "kube-hetzner" {
   # Also, see the cilium_values at towards the end of this file, in the advanced section.
   # cni_plugin = "cilium"
 
+  # You can choose the version of Cilium that you want. By default we keep the version up to date and configure Cilium with compatible settings according to the version.
+  # cilium_version = "v1.14.0"
+  
+  # Set native-routing mode ("native") or tunneling mode ("tunnel"). Default: tunnel
+  # cilium_routing_mode = "native"
+
+  # Used when Cilium is configured in native routing mode. The CNI assumes that the underlying network stack will forward packets to this destination without the need to apply SNAT. Default: value of "cluster_ipv4_cidr"
+  # cilium_ipv4_native_routing_cidr = "10.0.0.0/8"
+
+  # Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. Default: false
+  # cilium_egress_gateway_enabled = true
+
   # You can choose the version of Calico that you want. By default, the latest is used.
   # More info on available versions can be found at https://github.com/projectcalico/calico/releases
   # Please note that if you are getting 403s from Github, it's also useful to set the version manually. However there is rarely a need for that!
@@ -662,20 +674,26 @@ module "kube-hetzner" {
   # We advise you to use the default values, and only change them if you know what you are doing!
 
   # Cilium, all Cilium helm values can be found at https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml
+  # Be careful when maintaining your own cilium_values, as the choice of available settings depends on the Cilium version used. See also the cilium_version setting to fix a specific version.
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   cilium_values = <<EOT
 ipam:
   mode: kubernetes
-devices: "eth1"
 k8s:
   requireIPv4PodCIDR: true
-kubeProxyReplacement: strict
-l7Proxy: false
+kubeProxyReplacement: true
+routingMode: native
+ipv4NativeRoutingCIDR: "10.0.0.0/8"
+endpointRoutes:
+  enabled: true
+loadBalancer:
+  acceleration: native
+bpf:
+  masquerade: true
 encryption:
   enabled: true
   type: wireguard
-extraConfig:
-  mtu: "1450"
+MTU: 1450
   EOT */
 
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml

--- a/templates/cilium.yaml.tpl
+++ b/templates/cilium.yaml.tpl
@@ -7,6 +7,7 @@ metadata:
 spec:
   chart: cilium
   repo: https://helm.cilium.io/
+  version: "${version}"
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/variables.tf
+++ b/variables.tf
@@ -454,10 +454,39 @@ variable "cni_plugin" {
   }
 }
 
+variable "cilium_egress_gateway_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables egress gateway to redirect and SNAT the traffic that leaves the cluster."
+}
+
+variable "cilium_ipv4_native_routing_cidr" {
+  type        = string
+  default     = null
+  description = "Used when Cilium is configured in native routing mode. The CNI assumes that the underlying network stack will forward packets to this destination without the need to apply SNAT. Default: value of \"cluster_ipv4_cidr\""
+}
+
+variable "cilium_routing_mode" {
+  type        = string
+  default     = "tunnel"
+  description = "Set native-routing mode (\"native\") or tunneling mode (\"tunnel\")."
+
+  validation {
+    condition     = contains(["tunnel", "native"], var.cilium_routing_mode)
+    error_message = "The cilium_routing_mode must be one of \"tunnel\" or \"native\"."
+  }
+}
+
 variable "cilium_values" {
   type        = string
   default     = ""
   description = "Additional helm values file to pass to Cilium as 'valuesContent' at the HelmChart."
+}
+
+variable "cilium_version" {
+  type        = string
+  default     = "v1.14.0"
+  description = "Version of Cilium."
 }
 
 variable "calico_values" {


### PR DESCRIPTION
This PR modifies the Cilium configuration to achieve the best possible performance and also native routing functionality for Cilium, allowing configuration of a fully integrated network model. For more background information, please have a look here: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/911

**Changes:**
- Fixed decoupling issue between CCM IPAM and the Cilium IPAM. Now Cilium honors the IPAM from the CCM and Hetzner Network Routes are set accordingly to allow native routing directly to pod IPs as well. See also https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/pull/902#issuecomment-1648189450
- Updated Cilium options according to the latest deprecation warnings: https://docs.cilium.io/en/latest/operations/upgrade/#deprecated-options
- The Cilium version is now maintained explicitly. This PR sets it to 1.14.0 and some settings require that as the minimum version.
- Enabled per endpoint routes instead of routing via the `cilium_host` interface.
- Native routing mode has been added so that even a fully integrated network model (flat model) can be configured with Cilium
- Enabled eBPF-based masquerading, considered the most efficient implementation.
- Added LoadBalancer & NodePort XDP Acceleration (eBPF is operating directly in the networking driver instead of a higher layer)
- Added option to enable the Egress Gateway for Cilium (disabled by default)


The native routing mode is disabled by default as we have been using tunnel mode so far. As we gain more experience with this setup, I would suggest changing the default to native. This also appears to be the setting Hetzner uses when testing their CCM with Cilium.

I've done my best to test many different cases, but I'd be very grateful for a thorough review :slightly_smiling_face: 