### PR TITLE
Added Example to exclude Destination CIDRs from Egress Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ spec:
 
   destinationCIDRs:
   - "0.0.0.0/0"
+  excludedCIDRs:
+  - "10.0.0.0/8"
 
   egressGateway:
     nodeSelector:


### PR DESCRIPTION
Cilium 1.14 adds support to exclude specific destination CIDRs (`excludedCIDRs`) from routing to the egress gateway. Just added this to the egress gateway policy example. Cilium has exceptions by default, but only for some "known" CIDRs/IPs. Everything else matching `destinationCIDRs` would be routed to the egress gateway.

See https://github.com/cilium/cilium/pull/23448 and https://docs.cilium.io/en/stable/network/egress-gateway/#selecting-the-destination

**Ping from Pod to LB without `excludedCIDRs`:**
```bash
# ping 10.0.0.2 -c 5 -W 1
PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data.

--- 10.0.0.2 ping statistics ---
5 packets transmitted, 0 received, 100% packet loss, time 58ms
```
**Ping from Pod to LB with `excludedCIDRs`:**
```bash
# ping 10.0.0.2 -c 5 -W 1
PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data.
64 bytes from 10.0.0.2: icmp_seq=1 ttl=62 time=0.451 ms
64 bytes from 10.0.0.2: icmp_seq=2 ttl=62 time=0.466 ms
64 bytes from 10.0.0.2: icmp_seq=3 ttl=62 time=0.418 ms
64 bytes from 10.0.0.2: icmp_seq=4 ttl=62 time=0.417 ms
64 bytes from 10.0.0.2: icmp_seq=5 ttl=62 time=0.662 ms

--- 10.0.0.2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 60ms
rtt min/avg/max/mdev = 0.417/0.482/0.662/0.095 ms
```


