### PR TITLE
Fix CCM Webhook Listener Port Collision

### DIFF
--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -16,6 +16,7 @@ spec:
             - "--allow-untagged-cloud"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=${cluster_cidr_ipv4}"
+            - "--webhook-secure-port=0"
 %{if using_klipper_lb~}
             - "--secure-port=10288"
 %{endif~}


### PR DESCRIPTION
This PR fixes #934 

It seems K3s CCM is (partially) active in case Klipper LB is used. In this situation, if Hetzner CCM (HCCM) is running on a CP node, there will be a port conflict as both K3s CCM and HCCM try to bind to port `10260`. This is caused by a new feature introduced in Kubernetes 1.27 with https://github.com/kubernetes/kubernetes/pull/108838.

Thanks to [@apricote](https://github.com/apricote) we have a workaround to disable the HCCM webhook listener by adding `--webhook-secure-port=0` flag to HCCM. This can be used in HCCM > v1.16.0.

See also https://github.com/kubernetes/kubernetes/issues/120043.

I tested this flag with and without using Klipper LB and it seems to work fine :slightly_smiling_face: 