### PR TITLE
Add k3s-token and k3s-endpoint as output so other modules can re-use it.

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -37,6 +37,14 @@ output "ingress_public_ipv6" {
   value       = (local.has_external_load_balancer || var.load_balancer_disable_ipv6) ? null : data.hcloud_load_balancer.cluster[0].ipv6
 }
 
+output "k3s_endpoint" {
+  value = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+}
+
+output "k3s_token" {
+  value = random_password.k3s_token.result
+}
+
 # Keeping for backward compatibility
 output "kubeconfig_file" {
   value       = local.kubeconfig_external

--- a/output.tf
+++ b/output.tf
@@ -38,11 +38,13 @@ output "ingress_public_ipv6" {
 }
 
 output "k3s_endpoint" {
-  value = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+  description = "A controller endpoint to register new nodes"
+  value       = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
 }
 
 output "k3s_token" {
-  value = random_password.k3s_token.result
+  description = "The k3s token to register new nodes"
+  value       = random_password.k3s_token.result
 }
 
 # Keeping for backward compatibility


### PR DESCRIPTION
Hi there,

I'm currently building a terraform environment to add root-server to this cluster.
This is my current state of work: https://github.com/nupplaphil/terraform-root-kube-hetzner

Since I don't want to mix up root server and hcloud server, I choose a different repo for it.

The only thing missing is the "glue" between the hcloud terraform module and my root terraform module.
--> the k3s token and endpoint is missing.

With these two outputs, I was successfully to add a root-server to a cluster out of this project :)

btw the cilium config
```yaml
loadBalancer:
  # Enable LoadBalancer & NodePort XDP Acceleration (direct routing (routingMode=native) is recommended to achieve optimal performance)
  acceleration: native
```

doesn't work because XDP is incompatible with the vlan interface of the vSwitch subnet.
--> I manually overwrite the `cilium_values`