### PR TITLE
waiting for the completion of the cloudinit's work

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -90,6 +90,12 @@ resource "hcloud_server" "server" {
       EOT
     ]
   }
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait"
+    ]
+  }
+
 }
 
 resource "null_resource" "registries" {


### PR DESCRIPTION
You should wait for the cloudinit's work to be completed  to avoid collisions, locks and other things.