### PR TITLE
Change default DNS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,8 @@ Code contributions are very much **welcome**.
     packer build ../kube-hetzner/packer-template/hcloud-microos-snapshots.pkr.hcl
     ```
 
+1. Update examples in `kube.tf.example` if required.
+1. Run [terraform-docs](https://github.com/terraform-docs/terraform-docs) generator `docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.16.0 markdown /terraform-docs > docs/terraform.md` if you changed default variables.
 1. Commit your Changes (`git commit -m 'Add some AmazingFeature')
 1. Push to the Branch (`git push origin AmazingFeature`)
 1. Open a Pull Request targeting the `staging` branch.

--- a/README.md
+++ b/README.md
@@ -867,7 +867,6 @@ Code contributions are very much **welcome**.
     ```
 
 1. Update examples in `kube.tf.example` if required.
-1. Run [terraform-docs](https://github.com/terraform-docs/terraform-docs) generator `docker run --rm --volume "$(pwd):/terraform-docs" -u $(id -u) quay.io/terraform-docs/terraform-docs:0.16.0 markdown /terraform-docs > docs/terraform.md` if you changed default variables.
 1. Commit your Changes (`git commit -m 'Add some AmazingFeature')
 1. Push to the Branch (`git push origin AmazingFeature`)
 1. Open a Pull Request targeting the `staging` branch.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -115,7 +115,7 @@
 | <a name="input_csi_driver_smb_values"></a> [csi\_driver\_smb\_values](#input\_csi\_driver\_smb\_values) | Additional helm values file to pass to csi-driver-smb as 'valuesContent' at the HelmChart. | `string` | `""` | no |
 | <a name="input_disable_hetzner_csi"></a> [disable\_hetzner\_csi](#input\_disable\_hetzner\_csi) | Disable hetzner csi driver. | `bool` | `false` | no |
 | <a name="input_disable_network_policy"></a> [disable\_network\_policy](#input\_disable\_network\_policy) | Disable k3s default network policy controller (default false, automatically true for calico and cilium). | `bool` | `false` | no |
-| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner. The length is limited to 3 entries, more entries is not supported by kubernetes | `list(string)` | <pre>[<br>  "1.1.1.1",<br>  "8.8.8.8",<br>  "9.9.9.9"<br>]</pre> | no |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner. The length is limited to 3 entries, more entries is not supported by kubernetes | `list(string)` | `[]` | no |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable cert manager. | `bool` | `true` | no |
 | <a name="input_enable_csi_driver_smb"></a> [enable\_csi\_driver\_smb](#input\_enable\_csi\_driver\_smb) | Whether or not to enable csi-driver-smb. | `bool` | `false` | no |
 | <a name="input_enable_klipper_metal_lb"></a> [enable\_klipper\_metal\_lb](#input\_enable\_klipper\_metal\_lb) | Use klipper load balancer. | `bool` | `false` | no |

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -564,9 +564,9 @@ module "kube-hetzner" {
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "true".
   # enable_cert_manager = false
 
-  # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", "8.8.8.8", "9.9.9.10"].
+  # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner https://docs.hetzner.com/dns-console/dns/general/recursive-name-servers/, (defaults is []).
   # The number of different DNS servers is limited to 3 by Kubernetes itself.
-  # dns_servers = []
+  # dns_servers = ["1.1.1.1", "8.8.8.8", "9.9.9.10"]
 
   # When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability.
   # The default is false.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -564,7 +564,7 @@ module "kube-hetzner" {
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "true".
   # enable_cert_manager = false
 
-  # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", "8.8.8.8", "9.9.9.9"].
+  # IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner, defaults to ["1.1.1.1", "8.8.8.8", "9.9.9.10"].
   # The number of different DNS servers is limited to 3 by Kubernetes itself.
   # dns_servers = []
 

--- a/variables.tf
+++ b/variables.tf
@@ -679,7 +679,7 @@ variable "control_plane_lb_enable_public_interface" {
 
 variable "dns_servers" {
   type        = list(string)
-  default     = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+  default     = ["1.1.1.1", "8.8.8.8", "9.9.9.10"]
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner. The length is limited to 3 entries, more entries is not supported by kubernetes"
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -679,7 +679,7 @@ variable "control_plane_lb_enable_public_interface" {
 
 variable "dns_servers" {
   type        = list(string)
-  default     = ["1.1.1.1", "8.8.8.8", "9.9.9.10"]
+  default     = []
   description = "IP Addresses to use for the DNS Servers, set to an empty list to use the ones provided by Hetzner. The length is limited to 3 entries, more entries is not supported by kubernetes"
 
   validation {


### PR DESCRIPTION
DNS 9.9.9.9 applies filtering based on the VirusTotal database. My domain was included in this database by mistake and I spent several days debugging to understand what was wrong.
![2023-09-11_09-40-20](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6608896/6079e4d0-9bac-4b72-9ae3-4d0cb5b9bf70)


After updating the cluster and the release of the 9.9.9.9 resolver, my sites in the yucca.app domain began to sometimes return http 500, this is because nginx ingress cannot resolve the request on the incoming domain.

![2023-09-11_09-32-12](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6608896/e4dee982-8f24-4b68-8a78-4192ced048d9)
![2023-09-11_09-32-29](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6608896/24b646b6-720f-4bb7-b13c-6401cef3117d)
![2023-09-11_09-32-38](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6608896/bedfcd6c-1d5c-4816-ac3d-d66400351dc6)

I suggest not using the default DNS which uses any filtering and can lead to service failure. The use of such resolvers should be a conscious choice. On its website, quad9 suggests using the address without filtering, so I replaced it in the default variable.