### PR TITLE
Expose ingress_controller variable in example

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -225,12 +225,15 @@ module "kube-hetzner" {
   load_balancer_type     = "lb11"
   load_balancer_location = "fsn1"
 
+  # In order to disable load balancer completely set ingress_controller = "none" by default it is traefik
+  ingress_controller     = "traefik"
+
   # Disable IPv6 for the load balancer, the default is false.
   # load_balancer_disable_ipv6 = true
 
   # Disables the public network of the load balancer. (default: false).
   # load_balancer_disable_public_network = true
-
+  
   # Specifies the algorithm type of the load balancer. (default: round_robin).
   # load_balancer_algorithm_type = "least_connections"
 


### PR DESCRIPTION
There are cases where we need to disable load balancer completely. Even if the option is available in tf code it is not exposed In kube.tf example