### PR TITLE
Traefik Trusted IPs

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -501,19 +501,31 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
     forwardedHeaders:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
   websecure:
     proxyProtocol:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
     forwardedHeaders:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
 %{endif~}
 %{if var.traefik_additional_ports != ""~}
 %{for option in var.traefik_additional_ports~}
@@ -527,10 +539,16 @@ ports:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
     forwardedHeaders:
       trustedIPs:
         - 127.0.0.1/32
         - 10.0.0.0/8
+%{for ip in var.traefik_additional_trusted_ips~}
+        - "${ip}"
+%{endfor~}
 %{endif~}
 %{endfor~}
 %{endif~}
@@ -541,11 +559,9 @@ podDisruptionBudget:
 %{endif~}
 additionalArguments:
   - "--entrypoints.tcp=true"
-%{if var.traefik_additional_options != ""~}
 %{for option in var.traefik_additional_options~}
   - "${option}"
 %{endfor~}
-%{endif~}
 %{if var.traefik_resource_limits~}
 resources:
   requests:

--- a/variables.tf
+++ b/variables.tf
@@ -345,6 +345,12 @@ variable "traefik_additional_options" {
   description = "Additional options to pass to Traefik as a list of strings. These are the ones that go into the additionalArguments section of the Traefik helm values file."
 }
 
+variable "traefik_additional_trusted_ips" {
+  type        = list(string)
+  default     = []
+  description = "Additional Trusted IPs to pass to Traefik. These are the ones that go into the trustedIPs section of the Traefik helm values file."
+}
+
 variable "traefik_values" {
   type        = string
   default     = ""


### PR DESCRIPTION
Example for Cloudflare:
```terraform
traefik_additional_trusted_ips = [
    "173.245.48.0/20",
    "103.21.244.0/22",
    "103.22.200.0/22",
    "103.31.4.0/22",
    "141.101.64.0/18",
    "108.162.192.0/18",
    "190.93.240.0/20",
    "188.114.96.0/20",
    "197.234.240.0/22",
    "198.41.128.0/17",
    "162.158.0.0/15",
    "104.16.0.0/13",
    "104.24.0.0/14",
    "172.64.0.0/13",
    "131.0.72.0/22",
    "2400:cb00::/32",
    "2606:4700::/32",
    "2803:f800::/32",
    "2405:b500::/32",
    "2405:8100::/32",
    "2a06:98c0::/29",
    "2c0f:f248::/32"
  ]
  ```