### PR TITLE
fix: allow for v1.28 in var.initial_k3s_channel .

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -381,7 +381,7 @@ variable "initial_k3s_channel" {
   description = "Allows you to specify an initial k3s channel."
 
   validation {
-    condition     = contains(["stable", "latest", "testing", "v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25", "v1.26", "v1.27"], var.initial_k3s_channel)
+    condition     = contains(["stable", "latest", "testing", "v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25", "v1.26", "v1.27", "v1.28"], var.initial_k3s_channel)
     error_message = "The initial k3s channel must be one of stable, latest or testing, or any of the minor kube versions like v1.26."
   }
 }


### PR DESCRIPTION
A very simple bump. Works "on my machine"...
1.28.2 is out, which fixes the regression in 1.28.0/1. Let us play.