### PR TITLE
set k3s_token output to sensitive

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -45,6 +45,7 @@ output "k3s_endpoint" {
 output "k3s_token" {
   description = "The k3s token to register new nodes"
   value       = local.k3s_token
+  sensitive   = true
 }
 
 # Keeping for backward compatibility


### PR DESCRIPTION
To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your intent.

If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
    sensitive = true