### PR TITLE
Publish traefik service by default, and allow custom namespace target for the ingress_controllers

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,13 +13,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_github"></a> [github](#provider\_github) | >= 5.38.0 |
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.43.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_remote"></a> [remote](#provider\_remote) | >= 0.1.2 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.38.0 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.43.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_remote"></a> [remote](#provider\_remote) | 0.1.2 |
 
 ### Modules
 
@@ -147,9 +147,13 @@
 | <a name="input_ingress_controller"></a> [ingress\_controller](#input\_ingress\_controller) | The name of the ingress controller. | `string` | `"traefik"` | no |
 | <a name="input_ingress_max_replica_count"></a> [ingress\_max\_replica\_count](#input\_ingress\_max\_replica\_count) | Number of maximum replicas per ingress controller. Used for ingress HPA. Must be higher than number of replicas. | `number` | `10` | no |
 | <a name="input_ingress_replica_count"></a> [ingress\_replica\_count](#input\_ingress\_replica\_count) | Number of replicas per ingress controller. 0 means autodetect based on the number of agent nodes. | `number` | `0` | no |
+| <a name="input_ingress_target_namespace"></a> [ingress\_target\_namespace](#input\_ingress\_target\_namespace) | The namespace to deploy the ingress controller to. Defaults to ingress name. | `string` | `""` | no |
 | <a name="input_initial_k3s_channel"></a> [initial\_k3s\_channel](#input\_initial\_k3s\_channel) | Allows you to specify an initial k3s channel. | `string` | `"v1.27"` | no |
+| <a name="input_k3s_agent_kubelet_args"></a> [k3s\_agent\_kubelet\_args](#input\_k3s\_agent\_kubelet\_args) | Kubelet args for agent nodes. | `list(string)` | `[]` | no |
+| <a name="input_k3s_control_plane_kubelet_args"></a> [k3s\_control\_plane\_kubelet\_args](#input\_k3s\_control\_plane\_kubelet\_args) | Kubelet args for control plane nodes. | `list(string)` | `[]` | no |
 | <a name="input_k3s_exec_agent_args"></a> [k3s\_exec\_agent\_args](#input\_k3s\_exec\_agent\_args) | Agents nodes are started with `k3s agent {k3s_exec_agent_args}`. Use this to add kubelet-arg for example. | `string` | `""` | no |
 | <a name="input_k3s_exec_server_args"></a> [k3s\_exec\_server\_args](#input\_k3s\_exec\_server\_args) | The control plane is started with `k3s server {k3s_exec_server_args}`. Use this to add kube-apiserver-arg for example. | `string` | `""` | no |
+| <a name="input_k3s_global_kubelet_args"></a> [k3s\_global\_kubelet\_args](#input\_k3s\_global\_kubelet\_args) | Global kubelet args for all nodes. | `list(string)` | `[]` | no |
 | <a name="input_k3s_registries"></a> [k3s\_registries](#input\_k3s\_registries) | K3S registries.yml contents. It used to access private docker registries. | `string` | `" "` | no |
 | <a name="input_k3s_token"></a> [k3s\_token](#input\_k3s\_token) | k3s master token (must match when restoring a cluster). | `string` | `null` | no |
 | <a name="input_kured_options"></a> [kured\_options](#input\_kured\_options) | n/a | `map(string)` | `{}` | no |

--- a/init.tf
+++ b/init.tf
@@ -148,7 +148,8 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/traefik_ingress.yaml.tpl",
       {
-        values = indent(4, trimspace(local.traefik_values))
+        values           = indent(4, trimspace(local.traefik_values))
+        target_namespace = local.ingress_target_namespace
     })
     destination = "/var/post_install/traefik_ingress.yaml"
   }
@@ -158,7 +159,8 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/nginx_ingress.yaml.tpl",
       {
-        values = indent(4, trimspace(local.nginx_values))
+        values           = indent(4, trimspace(local.nginx_values))
+        target_namespace = local.ingress_target_namespace
     })
     destination = "/var/post_install/nginx_ingress.yaml"
   }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -388,6 +388,7 @@ module "kube-hetzner" {
   # After the cluster is deployed, you can always use HelmChartConfig definition to tweak the configuration.
   # If you want to disable both controllers set this to "none"
   # ingress_controller = "nginx"
+  # ingress_target_namespace = "" // In which namespace to deploy the ingress controllers. Defaults to the ingress_controller variable, eg (nginx, traefik)
 
   # You can change the number of replicas for selected ingress controller here. The default 0 means autoselecting based on number of agent nodes (1 node = 1 replica, 2 nodes = 2 replicas, 3+ nodes = 3 replicas)
   # ingress_replica_count = 1
@@ -400,6 +401,7 @@ module "kube-hetzner" {
 
   # If you want to configure additional arguments for traefik, enter them here as a list and in the form of traefik CLI arguments; see https://doc.traefik.io/traefik/reference/static-configuration/cli/
   # They are the options that go into the additionalArguments section of the Traefik helm values file.
+  # We already add "providers.kubernetesingress.ingressendpoint.publishedservice" by default so that Traefik works automatically with services such as External-DNS and ArgoCD.
   # Example:
   # traefik_additional_options = ["--log.level=DEBUG", "--tracing=true"]
 

--- a/locals.tf
+++ b/locals.tf
@@ -160,6 +160,11 @@ locals {
   has_external_load_balancer = local.using_klipper_lb || local.ingress_controller == "none"
   load_balancer_name         = "${var.cluster_name}-${var.ingress_controller}"
 
+  default_ingress_namespace_mapping = {
+    "traefik" = "traefik"
+    "nginx"   = "nginx"
+  }
+  ingress_target_namespace  = var.ingress_target_namespace != "" ? var.ingress_target_namespace : local.default_ingress_namespace_mapping[var.ingress_controller]
   ingress_replica_count     = (var.ingress_replica_count > 0) ? var.ingress_replica_count : (local.agent_count > 2) ? 3 : (local.agent_count == 2) ? 2 : 1
   ingress_max_replica_count = (var.ingress_max_replica_count > local.ingress_replica_count) ? var.ingress_max_replica_count : local.ingress_replica_count
 
@@ -567,6 +572,7 @@ podDisruptionBudget:
 %{endif~}
 additionalArguments:
   - "--entrypoints.tcp=true"
+  - "--providers.kubernetesingress.ingressendpoint.publishedservice=${local.ingress_target_namespace}/traefik"
 %{for option in var.traefik_additional_options~}
   - "${option}"
 %{endfor~}

--- a/templates/nginx_ingress.yaml.tpl
+++ b/templates/nginx_ingress.yaml.tpl
@@ -12,7 +12,7 @@ metadata:
 spec:
   chart: ingress-nginx
   repo: https://kubernetes.github.io/ingress-nginx
-  targetNamespace: nginx
+  targetNamespace: ${target_namespace}
   bootstrap: true
   valuesContent: |-
     ${values}

--- a/templates/traefik_ingress.yaml.tpl
+++ b/templates/traefik_ingress.yaml.tpl
@@ -12,7 +12,7 @@ metadata:
 spec:
   chart: traefik
   repo: https://traefik.github.io/charts
-  targetNamespace: traefik
+  targetNamespace: ${target_namespace}
   bootstrap: true
   valuesContent: |-
     ${values}

--- a/variables.tf
+++ b/variables.tf
@@ -827,3 +827,27 @@ variable "k3s_exec_agent_args" {
   default     = ""
   description = "Agents nodes are started with `k3s agent {k3s_exec_agent_args}`. Use this to add kubelet-arg for example."
 }
+
+variable "k3s_global_kubelet_args" {
+  type        = list(string)
+  default     = []
+  description = "Global kubelet args for all nodes."
+}
+
+variable "k3s_control_plane_kubelet_args" {
+  type        = list(string)
+  default     = []
+  description = "Kubelet args for control plane nodes."
+}
+
+variable "k3s_agent_kubelet_args" {
+  type        = list(string)
+  default     = []
+  description = "Kubelet args for agent nodes."
+}
+
+variable "ingress_target_namespace" {
+  type        = string
+  default     = ""
+  description = "The namespace to deploy the ingress controller to. Defaults to ingress name."
+}


### PR DESCRIPTION
`providers.kubernetesingress.ingressendpoint.publishedservice` is now set by default and will also work with custom namespace targets :)

It is also now possible to deploy nginx or traefik to a namespace of your liking.

I did not change the nginx one to the default `ingress-nginx` since I don't know if changing the targetNamespace causes orphaned HelmReleases ;]

This should close
https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/1048
https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/1042