### PR TITLE
Pin Traefik Chart to v24.0.0

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -502,7 +502,9 @@ service:
 ports:
   web:
 %{if var.traefik_redirect_to_https~}
-    redirectTo: websecure
+    redirectTo:
+      port: websecure
+      priority: 10
 %{endif~}
 %{if !local.using_klipper_lb~}
     proxyProtocol:

--- a/templates/traefik_ingress.yaml.tpl
+++ b/templates/traefik_ingress.yaml.tpl
@@ -11,6 +11,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: traefik
+  version: v24.0.0
   repo: https://traefik.github.io/charts
   targetNamespace: traefik
   bootstrap: true

--- a/templates/traefik_ingress.yaml.tpl
+++ b/templates/traefik_ingress.yaml.tpl
@@ -11,7 +11,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: traefik
-  version: v24.0.0
+  version: v25.0.0
   repo: https://traefik.github.io/charts
   targetNamespace: traefik
   bootstrap: true


### PR DESCRIPTION
Traefik Chart v25.0.0 was released with a breaking change (https://github.com/traefik/traefik-helm-chart/pull/934). This is a quick fix to pin to the old behaviour.