### PR TITLE
Fix missing dependencies for #1073

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -139,6 +139,11 @@ resource "null_resource" "control_plane_config" {
   provisioner "remote-exec" {
     inline = [local.k3s_config_update_script]
   }
+
+  depends_on = [
+    null_resource.first_control_plane,
+    hcloud_network_subnet.control_plane
+  ]
 }
 
 resource "null_resource" "control_planes" {

--- a/init.tf
+++ b/init.tf
@@ -322,7 +322,7 @@ resource "null_resource" "kustomization" {
 
   depends_on = [
     hcloud_load_balancer.cluster,
-    null_resource.first_control_plane,
+    null_resource.control_planes,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume
   ]


### PR DESCRIPTION
@mysticaltech @Silvest89 This basically fixes all the issues I experienced in #1073 .

- [x] The problem mentioned in the last comment regarding k3s.service does not occur anymore
- [x] I am able to destroy and deploy the same cluster config again and again

I 100% sure, that all other problems I had in #1073 were basically only happening because of pure randomness. Due these changes updating k3s configs only happens when first node is provisioned with base config and has running k3s.service. Also made sure that kustomization regarding all the other stuff CNI/CSI... is happening after all control nodes are deployed and have running k3s.