### PR TITLE
Feat change of cluster and service cidr

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -99,6 +99,9 @@ locals {
       node-label                  = v.labels
       node-taint                  = v.taints
       selinux                     = true
+      cluster-cidr                = var.cluster_ipv4_cidr
+      service-cidr                = var.service_ipv4_cidr
+      cluster-dns                 = var.cluster_dns_ipv4
       write-kubeconfig-mode       = "0644" # needed for import into rancher
     },
     lookup(local.cni_k3s_settings, var.cni_plugin, {}),

--- a/init.tf
+++ b/init.tf
@@ -40,6 +40,7 @@ resource "null_resource" "first_control_plane" {
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels
           cluster-cidr                = var.cluster_ipv4_cidr
           service-cidr                = var.service_ipv4_cidr
+          cluster-dns                 = var.cluster_dns_ipv4
           selinux                     = true
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),

--- a/init.tf
+++ b/init.tf
@@ -38,10 +38,10 @@ resource "null_resource" "first_control_plane" {
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels
+          selinux                     = true
           cluster-cidr                = var.cluster_ipv4_cidr
           service-cidr                = var.service_ipv4_cidr
           cluster-dns                 = var.cluster_dns_ipv4
-          selinux                     = true
         },
         lookup(local.cni_k3s_settings, var.cni_plugin, {}),
         var.use_control_plane_lb ? {

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -78,12 +78,19 @@ module "kube-hetzner" {
   # So to be able to create a maximum of 50 nodepools in total, the values below have to be changed to something outside that range, e.g. `10.200.0.0/16` and `10.201.0.0/16` for cluster and service respectively.
   
   # If you must change the cluster CIDR you can do so below, but it is highly advised against.
+  # Never change this value after you already initialized a cluster. Complete cluster redeploy needed!
   # The cluster CIDR must be a part of the network CIDR!
   # cluster_ipv4_cidr = "10.42.0.0/16"
 
   # If you must change the service CIDR you can do so below, but it is highly advised against.
+  # Never change this value after you already initialized a cluster. Complete cluster redeploy needed!
   # The service CIDR must be a part of the network CIDR!
   # service_ipv4_cidr = "10.43.0.0/16"
+
+  # If you must change the service IPv4 address of core-dns you can do so below, but it is highly advisd against.
+  # Never change this value after you already initialized a cluster. Complete cluster redeploy needed!
+  # The service IPv4 address must be part of the service CIDR!
+  # cluster_dns_ipv4 = "10.43.0.10"
 
   # For the control planes, at least three nodes are the minimum for HA. Otherwise, you need to turn off the automatic upgrades (see README).
   # **It must always be an ODD number, never even!** Search the internet for "split-brain problem with etcd" or see https://rancher.com/docs/k3s/latest/en/installation/ha-embedded/

--- a/variables.tf
+++ b/variables.tf
@@ -97,15 +97,21 @@ variable "network_ipv4_cidr" {
 }
 
 variable "cluster_ipv4_cidr" {
-  description = "Internal Pod CIDR, used for the controller and currently for calico."
+  description = "Internal Pod CIDR, used for the controller and currently for calico/cilium."
   type        = string
   default     = "10.42.0.0/16"
 }
 
 variable "service_ipv4_cidr" {
-  description = "Internal Service CIDR, used for the controller and currently for calico."
+  description = "Internal Service CIDR, used for the controller and currently for calico/cilium."
   type        = string
   default     = "10.43.0.0/16"
+}
+
+variable "cluster_dns_ipv4" {
+  description = "Internal Service IPv4 address of core-dns."
+  type        = string
+  default     = "10.43.0.10"
 }
 
 variable "load_balancer_location" {


### PR DESCRIPTION
@mysticaltech 

# Problem
You cannot change the cluster_ipv4_cidr and service_ipv4_cidr really. I tested this with Cilium and if changed those values to...

>   cluster_ipv4_cidr = "10.48.0.0/12"
>   service_ipv4_cidr = "10.64.0.0/12"

The ClusterIP of "kubernetes" service in default namespace was well referencing to 10.64.0.1 but the rest of the services were still running in 10.43.0.0/16 CIDR. To permanent set those values, you need to make sure that these values are fixed set in the config.yaml of k3s. This was well the case for the initial config create in init.tf for the first control plane node, but not the config update later on all control plane nodes. Also what it is missing for that feature to get really this working is setting the cluster-dns value which defines the IPv4 address of the core-dns service, which is always set fixed by k3s. Here a screenshot which gives you an overview of those values for "k3s server" command:

![Bildschirmfoto 2023-11-04 um 06 51 43](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/149453219/254a4de2-e9b4-458d-90a0-fcd63c1dae89)

# Solution and therefore PR
1. Set cluster-cidr and service-cidr permanent in control_planes.tf
2. Add new config variable for kube-hetzner called cluster_dns_ipv4 for setting the IPv4 address of the core-dns service, which needs to sit in the service-cidr
3. Added variable and default value of k3s in variables.tf
4. Added some explanation in kube.tf.example and also hints that you should never change those values after initialization of a cluster, otherwise this would lead probably to serious consequences. I am not 100% sure about the DNS part, but I guess it is better to let this stay there too.

# Proof it works
![Bildschirmfoto 2023-11-04 um 07 26 10](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/149453219/c19ba98b-23ff-4e72-8bb2-05be95221d29)

