### PR TITLE
fix: ignore changes to LB's hcloud-ccm/service-uid label

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -9,6 +9,13 @@ resource "hcloud_load_balancer" "cluster" {
   algorithm {
     type = var.load_balancer_algorithm_type
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to hcloud-ccm/service-uid label that is managed by the CCM.
+      labels["hcloud-ccm/service-uid"],
+    ]
+  }
 }
 
 


### PR DESCRIPTION
Hetzner cloud-controller-manager automatically adds the "hcloud-ccm/service-uid" label to identify the load balancer in case of a rename.

Previously, Terraform removed the label at every application, only for it to be added back immediately by the manager.