### PR TITLE
Kube 1.28

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -320,7 +320,7 @@ locals {
   }
 
   cni_install_resources = {
-    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${coalesce(local.calico_version, "v3.25.1")}/manifests/calico.yaml"]
+    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${coalesce(local.calico_version, "v3.26.4")}/manifests/calico.yaml"]
     "cilium" = ["cilium.yaml"]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -430,11 +430,11 @@ variable "enable_metrics_server" {
 
 variable "initial_k3s_channel" {
   type        = string
-  default     = "v1.27"
+  default     = "v1.28"
   description = "Allows you to specify an initial k3s channel."
 
   validation {
-    condition     = contains(["stable", "latest", "testing", "v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25", "v1.26", "v1.27"], var.initial_k3s_channel)
+    condition     = contains(["stable", "latest", "testing", "v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25", "v1.26", "v1.27", "v1.28", "v1.29", "v1.30", "v1.31", "v1.32", "v1.33"], var.initial_k3s_channel)
     error_message = "The initial k3s channel must be one of stable, latest or testing, or any of the minor kube versions like v1.26."
   }
 }
@@ -551,7 +551,7 @@ variable "cilium_values" {
 
 variable "cilium_version" {
   type        = string
-  default     = "v1.14.0"
+  default     = "1.14.4"
   description = "Version of Cilium."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.38.0, < 5.41.0"
+      version = ">= 5.38.0"
     }
     hcloud = {
       source  = "hetznercloud/hcloud"


### PR DESCRIPTION
Upgraded all relevant versions and bumped k3s to v1.28.

Follows on the footsteps of #995.