### PR TITLE
feat: specify the version of the ingress (traefik & nginx) helm chart

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -131,6 +131,8 @@ resource "null_resource" "kustomization" {
       coalesce(var.kured_version, "N/A"),
       coalesce(var.calico_version, "N/A"),
       coalesce(var.cilium_version, "N/A"),
+      coalesce(var.traefik_version, "N/A"),
+      coalesce(var.nginx_version, "N/A"),
     ])
     options = join("\n", [
       for option, value in var.kured_options : "${option}=${value}"
@@ -156,6 +158,7 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/traefik_ingress.yaml.tpl",
       {
+        version          = var.traefik_version
         values           = indent(4, trimspace(local.traefik_values))
         target_namespace = local.ingress_target_namespace
     })
@@ -167,6 +170,7 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/nginx_ingress.yaml.tpl",
       {
+        version          = var.nginx_version
         values           = indent(4, trimspace(local.nginx_values))
         target_namespace = local.ingress_target_namespace
     })

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -833,6 +833,9 @@ persistence:
   defaultClass: true
   EOT */
 
+  # If you want to use a specific Traefik helm chart version, set it below; otherwise, leave them as-is for the latest versions.
+  # traefik_version = ""
+
   # Traefik, all Traefik helm values can be found at https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   traefik_values = <<EOT
@@ -874,6 +877,9 @@ ports:
         - 127.0.0.1/32
         - 10.0.0.0/8
   EOT */
+
+  # If you want to use a specific Nginx helm chart version, set it below; otherwise, leave them as-is for the latest versions.
+  # nginx_version = ""
 
   # Nginx, all Nginx helm values can be found at https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   # You can also have a look at https://kubernetes.github.io/ingress-nginx/, to understand how it works, and all the options at your disposal.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -430,6 +430,10 @@ module "kube-hetzner" {
   # Example:
   # traefik_additional_options = ["--log.level=DEBUG", "--tracing=true"]
 
+  # By default traefik image tag is an empty string which uses latest image tag.
+  # The default is "".
+  # traefik_image_tag = "v3.0.0-beta5"
+
   # By default traefik is configured to redirect http traffic to https, you can set this to "false" to disable the redirection.
   # The default is true.
   # traefik_redirect_to_https = false

--- a/locals.tf
+++ b/locals.tf
@@ -484,6 +484,8 @@ controller:
   EOT
 
   traefik_values = var.traefik_values != "" ? var.traefik_values : <<EOT
+image:
+  tag: ${var.traefik_image_tag}
 deployment:
   replicas: ${local.ingress_replica_count}
 globalArguments: []

--- a/templates/nginx_ingress.yaml.tpl
+++ b/templates/nginx_ingress.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nginx
+  name: ${target_namespace}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -11,6 +11,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: ingress-nginx
+  version: "${version}"
   repo: https://kubernetes.github.io/ingress-nginx
   targetNamespace: ${target_namespace}
   bootstrap: true

--- a/templates/traefik_ingress.yaml.tpl
+++ b/templates/traefik_ingress.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: traefik
+  name: ${target_namespace}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -11,6 +11,7 @@ metadata:
   namespace: kube-system
 spec:
   chart: traefik
+  version: "${version}"
   repo: https://traefik.github.io/charts
   targetNamespace: ${target_namespace}
   bootstrap: true

--- a/variables.tf
+++ b/variables.tf
@@ -358,6 +358,12 @@ variable "ingress_max_replica_count" {
   }
 }
 
+variable "traefik_image_tag" {
+  type        = string
+  default     = ""
+  description = "Traefik image tag. Useful to use the beta version for new features. Example: v3.0.0-beta5"
+}
+
 variable "traefik_autoscaling" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -404,10 +404,22 @@ variable "traefik_additional_trusted_ips" {
   description = "Additional Trusted IPs to pass to Traefik. These are the ones that go into the trustedIPs section of the Traefik helm values file."
 }
 
+variable "traefik_version" {
+  type        = string
+  default     = ""
+  description = "Version of Traefik helm chart."
+}
+
 variable "traefik_values" {
   type        = string
   default     = ""
   description = "Additional helm values file to pass to Traefik as 'valuesContent' at the HelmChart."
+}
+
+variable "nginx_version" {
+  type        = string
+  default     = ""
+  description = "Version of Nginx helm chart."
 }
 
 variable "nginx_values" {


### PR DESCRIPTION
With these two new options, you can control the helm chart version for traefik and nginx ingresses.