### PR TITLE
feat: added option to pin traefik image tag with example for traefik beta

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -430,6 +430,10 @@ module "kube-hetzner" {
   # Example:
   # traefik_additional_options = ["--log.level=DEBUG", "--tracing=true"]
 
+  # By default traefik image tag is an empty string which uses latest image tag.
+  # The default is "".
+  # traefik_image_tag = "v3.0.0-beta5"
+
   # By default traefik is configured to redirect http traffic to https, you can set this to "false" to disable the redirection.
   # The default is true.
   # traefik_redirect_to_https = false

--- a/locals.tf
+++ b/locals.tf
@@ -484,6 +484,8 @@ controller:
   EOT
 
   traefik_values = var.traefik_values != "" ? var.traefik_values : <<EOT
+image:
+  tag: ${var.traefik_image_tag}
 deployment:
   replicas: ${local.ingress_replica_count}
 globalArguments: []

--- a/variables.tf
+++ b/variables.tf
@@ -358,6 +358,12 @@ variable "ingress_max_replica_count" {
   }
 }
 
+variable "traefik_image_tag" {
+  type        = string
+  default     = ""
+  description = "Traefik image tag. Useful to use the beta version for new features. Example: v3.0.0-beta5"
+}
+
 variable "traefik_autoscaling" {
   type        = bool
   default     = true


### PR DESCRIPTION
Useful if someone wants the new v3 opentelemetry metrics and tracing.