### PR TITLE
feat: explicit ip for the control-plane LB, as Hetzner's automatic IP…

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -58,6 +58,7 @@ resource "hcloud_load_balancer_network" "control_plane" {
   load_balancer_id        = hcloud_load_balancer.control_plane.*.id[0]
   subnet_id               = hcloud_network_subnet.control_plane.*.id[0]
   enable_public_interface = var.control_plane_lb_enable_public_interface
+  ip                      = cidrhost(hcloud_network_subnet.control_plane.*.ip_range[0], 1)
 }
 
 resource "hcloud_load_balancer_target" "control_plane" {


### PR DESCRIPTION
… assignment is broken (not guaranteed to be on the given subnet).

If you let Hetzner assign ip addresses, you get an address in the last created subnet, not in the subnet which you give as an argument. This fix sets the ip for the control plane load balancer explicitly, in line with other resources, so it actually is guaranteed to be in the subnet which it is supposed to end up in.

This is a long-standing bug in Hetzner Cloud, which they know about, and they have no solution for it.