### PR TITLE
chore(traefik): remove unused entrypoint

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -581,7 +581,6 @@ podDisruptionBudget:
   maxUnavailable: 33%
 %{endif~}
 additionalArguments:
-  - "--entrypoints.tcp=true"
   - "--providers.kubernetesingress.ingressendpoint.publishedservice=${local.ingress_controller_namespace}/traefik"
 %{for option in var.traefik_additional_options~}
   - "${option}"


### PR DESCRIPTION
I noticed that the Traefik configuration includes the option `--entrypoints.tcp=true`,
which generates an entry point named `tcp` without configuring it.
While this option doesn’t cause any harm, it is entirely unnecessary.
Therefore, I suggest removing it.