### PR TITLE
Enhancements to Placement Group Logic 

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -16,7 +16,7 @@ module "agents" {
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
-  placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.agent[floor(index(keys(local.agent_nodes), each.key) / 10)].id
+  placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.agent[local.agent_nodes_indices[each.key]].id
   location                     = each.value.location
   server_type                  = each.value.server_type
   backups                      = each.value.backups

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -16,7 +16,7 @@ module "control_planes" {
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
-  placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.control_plane[floor(index(keys(local.control_plane_nodes), each.key) / 10)].id
+  placement_group_id           = var.placement_group_disable ? null : hcloud_placement_group.control_plane[local.control_plane_nodes_indices[each.key]].id
   location                     = each.value.location
   server_type                  = each.value.server_type
   backups                      = each.value.backups

--- a/locals.tf
+++ b/locals.tf
@@ -156,6 +156,9 @@ locals {
     }
   ]...)
 
+  agent_nodes_indices         = { for node_name, node_details in local.agent_nodes : node_name => floor(node_details.index / 10) }
+  control_plane_nodes_indices = { for node_name, node_details in local.control_plane_nodes : node_name => floor(node_details.index / 10) }
+
   use_existing_network = length(var.existing_network_id) > 0
 
   # The first two subnets are respectively the default subnet 10.0.0.0/16 use for potientially anything and 10.1.0.0/16 used for control plane nodes.


### PR DESCRIPTION
This proposes a fix for #1157.

#### Changes Made

1. **Introduction of Local Variables for Node Indices Mapping**

    - **Agent Nodes Mapping (`agent_nodes_indices`):**
      ```hcl
      locals {
        agent_nodes_indices = { for node_name, node_details in local.agent_nodes : node_name => floor(node_details.index / 10) }
      }
      ```
      This local variable creates a map where each key corresponds to an agent node, and the value is the index of the placement group it belongs to. The `floor(node_details.index / 10)` calculation ensures an even distribution of nodes across the placement groups, with each group containing no more than 10 nodes.

    - **Control Plane Nodes Mapping (`control_plane_nodes_indices`):**
      ```hcl
      locals {
        control_plane_nodes_indices = { for node_name, node_details in local.control_plane_nodes : node_name => floor(node_details.index / 10) }
      }
      ```
      Similar to agent nodes, this mapping for control plane nodes assigns each node to a placement group based on its index. This consistent indexing is crucial for maintaining the balance and order of nodes in the cluster.

2. **Updating Module Blocks to Utilize New Indices**

    - **Agent Nodes (`module "agents"` in `agents.tf`):**
      ```hcl
      module "agents" {
        # ... existing configuration ...

        placement_group_id = var.placement_group_disable ? null : hcloud_placement_group.agent[local.agent_nodes_indices[each.key]].id

        # ... remaining configuration ...
      }
      ```
      This update ensures that the placement group ID for each agent node is dynamically determined based on the new `agent_nodes_indices` mapping. It respects the `placement_group_disable` variable, allowing for flexible enablement or disablement of placement groups.

    - **Control Plane Nodes (`module "control_planes"` in `control_planes.tf`):**
      ```hcl
      module "control_planes" {
        # ... existing configuration ...

        placement_group_id = var.placement_group_disable ? null : hcloud_placement_group.control_plane[local.control_plane_nodes_indices[each.key]].id

        # ... remaining configuration ...
      }
      ```
      Similarly, each control plane node's placement group ID is assigned using the `control_plane_nodes_indices` mapping. This ensures a consistent and orderly assignment of control plane nodes to placement groups.

#### Rationale Behind the Changes

- **Scalability and Flexibility**: The introduction of local variables for node indices mapping provides a scalable and flexible approach to managing node assignments to placement groups. It allows for easy adjustments and scaling of the node count without disrupting the underlying logic.
- **Enhanced Fault Tolerance and Performance**: By evenly distributing nodes across placement groups, we enhance the fault tolerance of the cluster. It ensures that nodes are spread across different physical hardware, reducing the risk of simultaneous failures.
- **Adherence to Hetzner Cloud Constraints**: Hetzner Cloud limits the number of servers in a placement group to 10. The implemented logic strictly adheres to this constraint, ensuring compliance with Hetzner Cloud's policies and optimal utilization of resources.

---

### Conceptual Overview

Imagine you have a group of nodes (servers) that you want to distribute across several placement groups in Hetzner Cloud. Each placement group can only have up to 10 nodes for optimal performance and fault tolerance. The challenge is to assign each node to a placement group in a way that balances them evenly and respects this limit.

### The `indices` Variable

To solve this, we introduce a local variable (like `agent_nodes_indices` or `control_plane_nodes_indices`) in Terraform. This variable acts as a map, where each node is assigned an index that determines its placement group.

### Visualization

Think of `agent_nodes_indices` as a big list where each node is given a number (its index). This number is then used to decide which placement group the node belongs to.

1. **Nodes as Items in a List**:
   - Imagine you have a list of nodes: Node1, Node2, Node3, ..., Node20.
   
2. **Assigning Indices**:
   - We assign each node a number (index) based on its position in the list.
   - For example, Node1 gets 0, Node2 gets 1, ..., Node10 gets 9, Node11 gets 10, and so on.

3. **Determining Placement Groups**:
   - We use a simple math formula: `floor(index / 10)`.
   - For Node1 (index 0): `floor(0 / 10)` results in 0 → It goes to Placement Group 1.
   - For Node2 (index 1): `floor(1 / 10)` results in 0 → It also goes to Placement Group 1.
   - ...
   - For Node11 (index 10): `floor(10 / 10)` results in 1 → It goes to Placement Group 2.

### Example with 20 Nodes

- **Placement Group 1**: Nodes 1-10 (Indices 0-9)
- **Placement Group 2**: Nodes 11-20 (Indices 10-19)

Each node's index directly tells us which placement group it belongs to, ensuring no group has more than 10 nodes.

### In Terraform

In Terraform, this logic is encoded using a local variable and a loop. When Terraform processes each node, it looks at this variable to determine the node's placement group based on its index.

This method provides a clear, scalable, and automated way to distribute nodes across placement groups, adhering to constraints and optimizing for performance and reliability.