### PR TITLE
Update SELinux policy to support linkerd-cni

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -776,7 +776,8 @@ EOF
     allow container_t cert_t:lnk_file read;
     allow container_t cert_t:file { read open };
     allow container_t container_var_lib_t:file { create open read write rename lock };
-    allow container_t etc_t:dir { add_name remove_name write create setattr };
+    allow container_t etc_t:dir { add_name remove_name write create setattr watch };
+    allow container_t etc_t:file { create setattr unlink write };
     allow container_t etc_t:sock_file { create unlink };
     allow container_t usr_t:dir { add_name create getattr link lock read rename remove_name reparent rmdir setattr unlink search write };
     allow container_t usr_t:file { append create execute getattr link lock read rename setattr unlink write };


### PR DESCRIPTION
Found some issues with the SELinux policy when trying to chain the [Linkerd CNI plugin](https://linkerd.io/2.14/features/cni/) with Cilium. Determined additional required policy statements by running `grep "denied" /var/log/audit/audit.log | audit2allow -M linkerd` until no more denied errors logged. Patched in the additional statements to existing SELinux module.

For reference, generated module was:
```module linkerd 1.0;
require {
        type etc_t;
        type container_t;
        class file { create setattr unlink write };
        class dir watch;
}

#============= container_t ==============

#!!!! This avc is allowed in the current policy
allow container_t etc_t:dir watch;

#!!!! This avc is allowed in the current policy
allow container_t etc_t:file { create setattr unlink write };```