### PR TITLE
locals: quote var.ssh_port to provided a valid cloud-init user-data

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -833,7 +833,7 @@ EOT
 # SELinux permission for the SSH alternative port
 %{if var.ssh_port != 22}
 # SELinux permission for the SSH alternative port.
-- [semanage, port, '-a', '-t', ssh_port_t, '-p', tcp, ${var.ssh_port}]
+- [semanage, port, '-a', '-t', ssh_port_t, '-p', tcp, '${var.ssh_port}']
 %{endif}
 
 # Create and apply the necessary SELinux module for kube-hetzner


### PR DESCRIPTION
Fixes:

,----
| Found cloud-config data types: user-data, vendor-data |
| 1. user-data at /var/lib/cloud/instances/41307264/cloud-config.txt:
|   Invalid cloud-config /var/lib/cloud/instances/41307264/cloud-config.txt
|   Error: Cloud config schema errors: runcmd.1: ['semanage', 'port',
|     '-a', '-t', 'ssh_port_t', '-p', 'tcp', 60022] is not of type 'string',
|     runcmd.1: ['semanage', 'port', '-a', '-t', 'ssh_port_t', '-p', 'tcp',
|     60022] is not valid under any of the given schemas
`----