### PR TITLE
Allow empty agent_nodepools

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -164,7 +164,7 @@ locals {
 
   # if we are in a single cluster config, we use the default klipper lb instead of Hetzner LB
   control_plane_count    = sum([for v in var.control_plane_nodepools : v.count])
-  agent_count            = sum([for v in var.agent_nodepools : v.count])
+  agent_count            = length(var.agent_nodepools)
   is_single_node_cluster = (local.control_plane_count + local.agent_count) == 1
 
   using_klipper_lb = var.enable_klipper_metal_lb || local.is_single_node_cluster


### PR DESCRIPTION

When declaring an empty agent_nodepools list an error was thrown.

```
│ Error: Invalid function argument
│
│   on ../terraform-hcloud-kube-hetzner/locals.tf line 167, in locals:
│  167:   agent_count            = sum([for v in var.agent_nodepools : v.count])
│     ├────────────────
│     │ while calling sum(list)
│     │ var.agent_nodepools is empty list of object
│
│ Invalid value for "list" parameter: cannot sum an empty list.
```

Replacing sum w/ list fixes the issue.