### PR TITLE
Add server location labels for load balancer targeting

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -30,7 +30,7 @@ module "agents" {
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = merge(local.labels, local.labels_agent_node)
+  labels = merge(local.labels, local.labels_agent_node, {"location": each.value.location})
 
   automatically_upgrade_os = var.automatically_upgrade_os
 

--- a/locals.tf
+++ b/locals.tf
@@ -482,8 +482,8 @@ controller:
 %{if var.lb_hostname != ""~}
       "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
 %{endif~}
-%{if var.load_balancer_label_selector != ""~}
-    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_label_selector}"
+%{if var.load_balancer_node_selector != ""~}
+    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_node_selector}"
 %{endif~}
 %{endif~}
   EOT
@@ -514,8 +514,8 @@ service:
 %{if var.lb_hostname != ""~}
     "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
 %{endif~}
-%{if var.load_balancer_label_selector != ""~}
-    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_label_selector}"
+%{if var.load_balancer_node_selector != ""~}
+    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_node_selector}"
 %{endif~}
 %{endif~}
 ports:

--- a/locals.tf
+++ b/locals.tf
@@ -482,6 +482,9 @@ controller:
 %{if var.lb_hostname != ""~}
       "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
 %{endif~}
+%{if var.load_balancer_label_selector != ""~}
+    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_label_selector}"
+%{endif~}
 %{endif~}
   EOT
 
@@ -510,6 +513,9 @@ service:
     "load-balancer.hetzner.cloud/health-check-retries": "${var.load_balancer_health_check_retries}"
 %{if var.lb_hostname != ""~}
     "load-balancer.hetzner.cloud/hostname": "${var.lb_hostname}"
+%{endif~}
+%{if var.load_balancer_label_selector != ""~}
+    "load-balancer.hetzner.cloud/node-selector": "${var.load_balancer_label_selector}"
 %{endif~}
 %{endif~}
 ports:

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,12 @@ variable "load_balancer_health_check_retries" {
   default     = 3
 }
 
+variable "load_balancer_label_selector" {
+  description = "Custom load balancer label_selector"
+  type        = string
+  default     = ""
+}
+
 variable "control_plane_nodepools" {
   description = "Number of control plane nodes."
   type = list(object({
@@ -901,10 +907,4 @@ variable "enable_local_storage" {
   type        = bool
   default     = false
   description = "Whether to enable or disable k3s local-storage."
-}
-
-variable "load_balancer_label_selector" {
-  description = "Custom load balancer label_selector"
-  type        = string
-  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -902,3 +902,9 @@ variable "enable_local_storage" {
   default     = false
   description = "Whether to enable or disable k3s local-storage."
 }
+
+variable "load_balancer_label_selector" {
+  description = "Custom load balancer label_selector"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -162,8 +162,8 @@ variable "load_balancer_health_check_retries" {
   default     = 3
 }
 
-variable "load_balancer_label_selector" {
-  description = "Custom load balancer label_selector"
+variable "load_balancer_node_selector" {
+  description = "Specifies the label selector for the load balancer."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Based on https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/1187.
Adds:
- agent_nodepools[].location as a hetzner server label for the hetzner load balancer to be able to target them.
- var.load_balancer_node_selector to extend default best practice traefik_values

**BEFORE:**
Traffic -> LB -> agent_nodepools[]

**AFTER:**
`load_balancer_node_selector = "location in (nbg1,fsn1)"`
Traffic -> LB -> agent_nodepools[] in matching location

**TODO:**
- [ ] Server labels set for autoscaler_nodepools
- [ ] Traefik nodeSelector/nodeAffinity to match load_balancer_location
- [ ] Disable default LB->[servers] and use var.load_balancer_node_selector when set.