### PR TITLE
Update Brew Terraform installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ First and foremost, you need to have a Hetzner Cloud account. You can sign up fo
 Then you'll need to have [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tofu](https://opentofu.org/docs/intro/install/), [packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#installing-packer) (for the initial snapshot creation only, no longer needed once that's done), [kubectl](https://kubernetes.io/docs/tasks/tools/) cli and [hcloud](https://github.com/hetznercloud/cli) the Hetzner cli for convenience. The easiest way is to use the [homebrew](https://brew.sh/) package manager to install them (available on Linux, Mac, and Windows Linux Subsystem).
 
 ```sh
-brew install terraform # or brew install opentofu
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
 brew install packer
 brew install kubectl
 brew install hcloud


### PR DESCRIPTION
I went around in circles a little trying to work out why I couldn't get some new Terraform features to deploy. Turns out I had installed Terraform with Brew from a community maintained version, which is quite out of date. 

Terraform recommend using their signed maintained installation instead: https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli

