### PR TITLE
open autoscaler pod port to enable monitoring via port 8085

### DIFF
--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -164,6 +164,8 @@ spec:
             requests:
               cpu: 100m
               memory: 300Mi
+          ports:
+            - containerPort: 8085
           command:
             - ./cluster-autoscaler
             - --v=${cluster_autoscaler_log_level}


### PR DESCRIPTION
Enable monitoring for cluster autoscaler by opening pod port 8085
More infos: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-monitor-cluster-autoscaler