### PR TITLE
Automatic updating fixes (README and Kured options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ kubectl delete plan k3s-server -n system-upgrade
 Also, note that after turning off node upgrades, you will need to manually upgrade the nodes when needed. You can do so by SSH'ing into each node and running the following commands (and don't forget to drain the node before with `kubectl drain <node-name>`):
 
 ```sh
-transactional-update
+systemctl start transactional-update.service
 reboot
 ```
 

--- a/README.md
+++ b/README.md
@@ -222,21 +222,25 @@ _If you wish to turn off automatic MicroOS upgrades (Important if you are not la
 automatically_upgrade_os = false
 ```
 
-_Alternatively ssh into each node and issue the following command:_
+Alternatively ssh into each node and issue the following command:
 
 ```sh
 systemctl --now disable transactional-update.timer
 ```
 
-_If you wish to turn off automatic k3s upgrades, you need to set:_
+If you wish to turn off automatic k3s upgrades, you need to set:
 
 ```terraform
 automatically_upgrade_k3s = false
 ```
 
-_Alternatively, you can either remove the `k3s_upgrade=true` label or set it to `false`. This needs to happen for all the nodes too! To remove the node label completely, apply `-` at the end of the label:
+_Once disabled this way you selectively can enable the upgrade by setting the node label `k3s_update=true` and later disable it by removing the label or set it to `false` again._
 
 ```sh
+# Enable upgrade for a node (use --all for all nodes)
+kubectl label --overwrite node <node-name> k3s_upgrade=true
+
+# Later disable upgrade by removing the label (use --all for all nodes)
 kubectl label node <node-name> k3s_upgrade-
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -621,6 +621,7 @@ installCRDs: true
     "pre-reboot-node-labels" : "kured=rebooting",
     "post-reboot-node-labels" : "kured=done",
     "period" : "5m",
+    "reboot-sentinel" : "/sentinel/reboot-required"
   }, var.kured_options)
 
   k3s_registries_update_script = <<EOF


### PR DESCRIPTION
This PR contains a Kured configuration fix and README improvements and fixes regarding automatic and manual updating.

- The sentinel path of Kured needs to be adjusted to point to the mountpoint in the container and not the original host path
- Don't start `transactional-update` directly from the console, instead trigger the systemd service
- Clarify control of automatic k3s updating

Fixes #1204.
