### PR TITLE
feat: allow custom configuration for agent nodes

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -51,9 +51,9 @@ locals {
       node-ip       = module.agents[k].private_ipv4_address
       node-label    = v.labels
       node-taint    = v.taints
-      selinux       = true
     },
-    var.agent_nodes_custom_config
+    var.agent_nodes_custom_config,
+    (v.selinux == true ? { selinux = true } : {})
   ) }
 }
 

--- a/agents.tf
+++ b/agents.tf
@@ -53,6 +53,7 @@ locals {
       node-taint    = v.taints
       selinux       = true
     },
+    var.agent_nodes_custom_config
   ) }
 }
 

--- a/init.tf
+++ b/init.tf
@@ -45,7 +45,6 @@ resource "null_resource" "first_control_plane" {
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels
-          selinux                     = true
           cluster-cidr                = var.cluster_ipv4_cidr
           service-cidr                = var.service_ipv4_cidr
           cluster-dns                 = var.cluster_dns_ipv4
@@ -57,7 +56,8 @@ resource "null_resource" "first_control_plane" {
           tls-san = concat([module.control_planes[keys(module.control_planes)[0]].ipv4_address], var.additional_tls_sans)
         },
         local.etcd_s3_snapshots,
-        var.control_planes_custom_config
+        var.control_planes_custom_config,
+        (local.control_plane_nodes[keys(module.control_planes)[0]].selinux == true ? { selinux = true } : {})
       )
     )
 

--- a/locals.tf
+++ b/locals.tf
@@ -132,6 +132,7 @@ locals {
         swap_size : nodepool_obj.swap_size,
         zram_size : nodepool_obj.zram_size,
         index : node_index
+        selinux: nodepool_obj.selinux
       }
     }
   ]...)
@@ -152,6 +153,7 @@ locals {
         swap_size : nodepool_obj.swap_size,
         zram_size : nodepool_obj.zram_size,
         index : node_index
+        selinux: nodepool_obj.selinux
       }
     }
   ]...)

--- a/locals.tf
+++ b/locals.tf
@@ -113,10 +113,10 @@ locals {
 
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
-  ], (var.disable_selinux ? [] : apply_k3s_selinux), local.common_post_install_k3s_commands)
+  ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
-  ], (var.disable_selinux ? [] : apply_k3s_selinux), local.common_post_install_k3s_commands)
+  ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
 
   control_plane_nodes = merge([
     for pool_index, nodepool_obj in var.control_plane_nodepools : {

--- a/locals.tf
+++ b/locals.tf
@@ -113,10 +113,10 @@ locals {
 
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
-  ], (lookup(var.control_plane_nodepools, "selinux", false) ? "" : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
+  ], (var.disable_selinux ? [] : apply_k3s_selinux), local.common_post_install_k3s_commands)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
-  ], (lookup(var.agent_nodepools, "selinux", false) ? "" : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
+  ], (var.disable_selinux ? [] : apply_k3s_selinux), local.common_post_install_k3s_commands)
 
   control_plane_nodes = merge([
     for pool_index, nodepool_obj in var.control_plane_nodepools : {

--- a/locals.tf
+++ b/locals.tf
@@ -113,10 +113,10 @@ locals {
 
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
-  ], local.apply_k3s_selinux, local.common_post_install_k3s_commands)
+  ], (lookup(var.control_plane_nodepools, "selinux", false) ? "" : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
     "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
-  ], local.apply_k3s_selinux, local.common_post_install_k3s_commands)
+  ], (lookup(var.agent_nodepools, "selinux", false) ? "" : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
 
   control_plane_nodes = merge([
     for pool_index, nodepool_obj in var.control_plane_nodepools : {

--- a/variables.tf
+++ b/variables.tf
@@ -843,6 +843,12 @@ variable "control_planes_custom_config" {
   description = "Custom control plane configuration e.g to allow etcd monitoring."
 }
 
+variable "agent_nodes_custom_config" {
+  type        = any
+  default     = {}
+  description = "Custom agent nodes configuration."
+}
+
 variable "k3s_registries" {
   description = "K3S registries.yml contents. It used to access private docker registries."
   default     = " "

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,7 @@ variable "control_plane_nodepools" {
     swap_size    = optional(string, "")
     zram_size    = optional(string, "")
     kubelet_args = optional(list(string), ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"])
+    selinux      = optional(bool, true)
   }))
   default = []
   validation {
@@ -204,6 +205,7 @@ variable "agent_nodepools" {
     swap_size            = optional(string, "")
     zram_size            = optional(string, "")
     kubelet_args         = optional(list(string), ["kube-reserved=cpu=50m,memory=300Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"])
+    selinux              = optional(bool, true)
   }))
   default = []
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -910,3 +910,9 @@ variable "enable_local_storage" {
   default     = false
   description = "Whether to enable or disable k3s local-storage."
 }
+
+variable "disable_selinux" {
+  type        = bool
+  default     = false
+  description = "Disable SELinux on all nodes."
+}


### PR DESCRIPTION
New variable : `agent_nodes_custom_config`. Works exactly like `control_planes_custom_config`.