### PR TITLE
fix(placement_groups)!: remove old idx logic and added validations

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -16,7 +16,7 @@ module "agents" {
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
-  placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.agent[each.value.placement_group_compat_idx].id : hcloud_placement_group.agent_named[each.value.placement_group].id)
+  placement_group_id           = var.placement_group_disable || !each.value.use_placement_group ? null : hcloud_placement_group.control_plane[each.value.placement_group_name].id
   location                     = each.value.location
   server_type                  = each.value.server_type
   backups                      = each.value.backups

--- a/agents.tf
+++ b/agents.tf
@@ -16,7 +16,7 @@ module "agents" {
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
-  placement_group_id           = var.placement_group_disable || !each.value.use_placement_group ? null : hcloud_placement_group.control_plane[each.value.placement_group_name].id
+  placement_group_id           = var.placement_group_disable || !each.value.use_placement_group ? null : hcloud_placement_group.agent[each.value.placement_group_name].id
   location                     = each.value.location
   server_type                  = each.value.server_type
   backups                      = each.value.backups

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -16,7 +16,7 @@ module "control_planes" {
   ssh_private_key              = var.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
-  placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.control_plane[each.value.placement_group_compat_idx].id : hcloud_placement_group.control_plane_named[each.value.placement_group].id)
+  placement_group_id           = var.placement_group_disable || !each.value.use_placement_group ? null : hcloud_placement_group.control_plane[each.value.placement_group_name].id
   location                     = each.value.location
   server_type                  = each.value.server_type
   backups                      = each.value.backups

--- a/locals.tf
+++ b/locals.tf
@@ -133,7 +133,7 @@ locals {
         zram_size : nodepool_obj.zram_size,
         index : node_index,
         use_placement_group : nodepool_obj.use_placement_group,
-        placement_group_name : nodepool_obj.placement_group_name == null ? format("%s-%s", var.cluster_name, nodepool_obj.name) : nodepool_obj.placement_group_name
+        placement_group_name : !nodepool_obj.use_placement_group ? null : nodepool_obj.placement_group_name == null ? nodepool_obj.name : nodepool_obj.placement_group_name
       }
     }
   ]...)
@@ -155,7 +155,7 @@ locals {
         zram_size : nodepool_obj.zram_size,
         index : node_index,
         use_placement_group : nodepool_obj.use_placement_group,
-        placement_group_name : nodepool_obj.placement_group_name == null ? format("%s-%s", var.cluster_name, nodepool_obj.name) : nodepool_obj.placement_group_name
+        placement_group_name : !nodepool_obj.use_placement_group ? null : nodepool_obj.placement_group_name == null ? nodepool_obj.name : nodepool_obj.placement_group_name
       }
     }
   ]...)

--- a/locals.tf
+++ b/locals.tf
@@ -132,8 +132,8 @@ locals {
         swap_size : nodepool_obj.swap_size,
         zram_size : nodepool_obj.zram_size,
         index : node_index,
-        placement_group_compat_idx : nodepool_obj.placement_group_compat_idx,
-        placement_group : nodepool_obj.placement_group
+        use_placement_group : nodepool_obj.use_placement_group,
+        placement_group_name : nodepool_obj.placement_group_name == null ? format("%s-%s", var.cluster_name, nodepool_obj.name) : nodepool_obj.placement_group_name
       }
     }
   ]...)
@@ -154,8 +154,8 @@ locals {
         swap_size : nodepool_obj.swap_size,
         zram_size : nodepool_obj.zram_size,
         index : node_index,
-        placement_group_compat_idx : nodepool_obj.placement_group_compat_idx,
-        placement_group : nodepool_obj.placement_group
+        use_placement_group : nodepool_obj.use_placement_group,
+        placement_group_name : nodepool_obj.placement_group_name == null ? format("%s-%s", var.cluster_name, nodepool_obj.name) : nodepool_obj.placement_group_name
       }
     }
   ]...)

--- a/placement_groups.tf
+++ b/placement_groups.tf
@@ -1,23 +1,9 @@
 locals {
-  control_plane_placement_compat_groups = max(
-    0,
-    [
-      for cp_pool in var.control_plane_nodepools :
-      cp_pool.placement_group_compat_idx + 1 if cp_pool.placement_group_compat_idx != null && cp_pool.placement_group == null
-    ]...
-  )
   control_plane_groups = toset(
     [
       for cp_pool in var.control_plane_nodepools :
       cp_pool.placement_group if cp_pool.placement_group != null
     ]
-  )
-  agent_placement_compat_groups = max(
-    0,
-    [
-      for ag_pool in var.agent_nodepools :
-      ag_pool.placement_group_compat_idx + 1 if ag_pool.placement_group_compat_idx != null && ag_pool.placement_group == null
-    ]...
   )
   agent_placement_groups = toset(
     [
@@ -28,13 +14,6 @@ locals {
 }
 
 resource "hcloud_placement_group" "control_plane" {
-  count  = local.control_plane_placement_compat_groups
-  name   = "${var.cluster_name}-control-plane-${count.index + 1}"
-  labels = local.labels
-  type   = "spread"
-}
-
-resource "hcloud_placement_group" "control_plane_named" {
   for_each = local.control_plane_groups
   name     = "${var.cluster_name}-control-plane-${each.key}"
   labels   = local.labels
@@ -42,13 +21,6 @@ resource "hcloud_placement_group" "control_plane_named" {
 }
 
 resource "hcloud_placement_group" "agent" {
-  count  = local.control_plane_placement_compat_groups
-  name   = "${var.cluster_name}-agent-${count.index + 1}"
-  labels = local.labels
-  type   = "spread"
-}
-
-resource "hcloud_placement_group" "agent_named" {
   for_each = local.agent_placement_groups
   name     = "${var.cluster_name}-agent-${each.key}"
   labels   = local.labels

--- a/placement_groups.tf
+++ b/placement_groups.tf
@@ -2,13 +2,13 @@ locals {
   control_plane_groups = toset(
     [
       for cp_pool in var.control_plane_nodepools :
-      cp_pool.placement_group if cp_pool.placement_group != null
+      cp_pool.placement_group_name if cp_pool.placement_group_name != null
     ]
   )
   agent_placement_groups = toset(
     [
       for ag_pool in var.agent_nodepools :
-      ag_pool.placement_group if ag_pool.placement_group != null
+      ag_pool.placement_group_name if ag_pool.placement_group_name != null
     ]
   )
 }

--- a/placement_groups.tf
+++ b/placement_groups.tf
@@ -1,14 +1,14 @@
 locals {
   control_plane_groups = toset(
     [
-      for cp_pool in var.control_plane_nodepools :
-      cp_pool.placement_group_name if cp_pool.placement_group_name != null
+      for node in local.control_plane_nodes :
+      node.placement_group_name if node.placement_group_name != null
     ]
   )
   agent_placement_groups = toset(
     [
-      for ag_pool in var.agent_nodepools :
-      ag_pool.placement_group_name if ag_pool.placement_group_name != null
+      for node in local.agent_nodes :
+      node.placement_group_name if node.placement_group_name != null
     ]
   )
 }


### PR DESCRIPTION
- [x] Removes old "compatibility" mode for placement groups (since it's not really a breaking change, changing placement groups is safe from node state perspective)
- [x] Added option to disable placement groups per node, alongside the old global var
- [x] Default placement group is named after the nodepool
- [x] Added validation that forbids using a placement group in a nodepool that has count greater than 10 (this requires old setups that used the global variable to disable placement groups to also disable them on the nodepool level)
- [x] Added validation that forbids count to be negative