### PR TITLE
add variable to enable Hubble relay and ui in Cilium

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -103,6 +103,7 @@
 | <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Version of Calico. | `string` | `null` | no |
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Additional helm values file to pass to Cert-Manager as 'valuesContent' at the HelmChart. | `string` | `""` | no |
 | <a name="input_cilium_egress_gateway_enabled"></a> [cilium\_egress\_gateway\_enabled](#input\_cilium\_egress\_gateway\_enabled) | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. | `bool` | `false` | no |
+| <a name="input_cilium_hubble_enabled"></a> [cilium\_hubble\_enabled](#input\_cilium\_hubble\_enabled) | Enables Hubble observability in HelmChart values. | `bool` | `false` | no |
 | <a name="input_cilium_ipv4_native_routing_cidr"></a> [cilium\_ipv4\_native\_routing\_cidr](#input\_cilium\_ipv4\_native\_routing\_cidr) | Used when Cilium is configured in native routing mode. The CNI assumes that the underlying network stack will forward packets to this destination without the need to apply SNAT. Default: value of "cluster\_ipv4\_cidr" | `string` | `null` | no |
 | <a name="input_cilium_routing_mode"></a> [cilium\_routing\_mode](#input\_cilium\_routing\_mode) | Set native-routing mode ("native") or tunneling mode ("tunnel"). | `string` | `"tunnel"` | no |
 | <a name="input_cilium_values"></a> [cilium\_values](#input\_cilium\_values) | Additional helm values file to pass to Cilium as 'valuesContent' at the HelmChart. | `string` | `""` | no |

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -651,6 +651,9 @@ module "kube-hetzner" {
   # Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. Default: false
   # cilium_egress_gateway_enabled = true
 
+  # Enables cilium's Hubble observability tool. Default: false
+  # cilium_hubble_enabled = true
+
   # You can choose the version of Calico that you want. By default, the latest is used.
   # More info on available versions can be found at https://github.com/projectcalico/calico/releases
   # Please note that if you are getting 403s from Github, it's also useful to set the version manually. However there is rarely a need for that!

--- a/locals.tf
+++ b/locals.tf
@@ -426,6 +426,13 @@ encryption:
 egressGateway:
   enabled: true
 %{endif~}
+%{if var.cilium_hubble_enabled}
+hubble:
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+%{endif~}
 
 MTU: 1450
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -556,6 +556,12 @@ variable "cilium_egress_gateway_enabled" {
   description = "Enables egress gateway to redirect and SNAT the traffic that leaves the cluster."
 }
 
+variable "cilium_hubble_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables Hubble observability in HelmChart values."
+}
+
 variable "cilium_ipv4_native_routing_cidr" {
   type        = string
   default     = null


### PR DESCRIPTION
Adding `cilium_hubble_enabled` variable with default to `false`.
When setting to `true`, Cilium Hubble relay and UI is enabled by adding parameters to default `cilium_values` variable.