### PR TITLE
feat: add support for node-to-node encryption in cilium

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -420,6 +420,7 @@ bpf:
 %{if var.enable_wireguard}
 encryption:
   enabled: true
+  nodeEncryption: true
   type: wireguard
 %{endif~}
 %{if var.cilium_egress_gateway_enabled}


### PR DESCRIPTION
WireGuard-based encryption only encrypts traffic between Cilium-managed pods by default.

With this change Cilium also enables node-to-node encryption, which additionally also encrypts node-to-node, pod-to-node and node-to-pod traffic.