### PR TITLE
Bump calico version

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -31,4 +31,3 @@ jobs:
         body: "Automated changes by GitHub Actions"
         branch: "docs/update-${{ github.head_ref }}"
         labels: documentation
-        team_reviewers: Core # Specify the team Core for review

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -654,7 +654,7 @@ module "kube-hetzner" {
   # You can choose the version of Calico that you want. By default, the latest is used.
   # More info on available versions can be found at https://github.com/projectcalico/calico/releases
   # Please note that if you are getting 403s from Github, it's also useful to set the version manually. However there is rarely a need for that!
-  # calico_version = "v3.25.0"
+  # calico_version = "v3.27.2"
 
   # If you want to disable the k3s kube-proxy, use this flag. The default is "false".
   # Ensure that your CNI is capable of handling all the functionalities typically covered by kube-proxy.

--- a/locals.tf
+++ b/locals.tf
@@ -345,7 +345,7 @@ locals {
   }
 
   cni_install_resources = {
-    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${coalesce(local.calico_version, "v3.26.4")}/manifests/calico.yaml"]
+    "calico" = ["https://raw.githubusercontent.com/projectcalico/calico/${coalesce(local.calico_version, "v3.27.2")}/manifests/calico.yaml"]
     "cilium" = ["cilium.yaml"]
   }
 


### PR DESCRIPTION
Bumped calico default fallback version to upgrade to a version that supports kube v1.29, as signalled by @M4t7e in https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/pull/1239#issuecomment-1967488724