### PR TITLE
Use a specific commit of system-upgrade-controller.yaml 

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -77,7 +77,7 @@ locals {
       [
         "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml",
         "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-dockerhub.yaml",
-        "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml",
+        "https://raw.githubusercontent.com/rancher/system-upgrade-controller/9e7e45c1bdd528093da36be1f1f32472469005e6/manifests/system-upgrade-controller.yaml",
       ],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),


### PR DESCRIPTION
See issue https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/1252

Kustomize currently failes to install, system-upgrade-controller has not enough permission to access kube-system namespace. This is caused by system-upgrade-controller.yaml fetched from master branch of rancher repo.

This pull requests uses the last working commit of this file.

BTW: Would love to become a official contributor to this project