### PR TITLE
Strip carriage return from ssh_client_identity

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -55,7 +55,7 @@ resource "hcloud_server" "server" {
   provisioner "local-exec" {
     command = <<-EOT
       install -b -m 600 /dev/null /tmp/${random_string.identity_file.id}
-      echo "${local.ssh_client_identity}" > /tmp/${random_string.identity_file.id}
+      echo "${local.ssh_client_identity}" | sed 's/\r$//' > /tmp/${random_string.identity_file.id}
     EOT
   }
 


### PR DESCRIPTION
There are situations where the ssh key contains carriage return chars, for example when generating the key using 1password.

The change ensures that the carriage return character (`\r`) is removed from the ssh_client_identity variable using sed. This will prevent authentication issues during `terraform apply`.