### PR TITLE
autoscaler: Add support to set HCLOUD_SERVER_CREATION_TIMEOUT 

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -34,6 +34,7 @@ locals {
       cluster_autoscaler_log_level        = var.cluster_autoscaler_log_level
       cluster_autoscaler_log_to_stderr    = var.cluster_autoscaler_log_to_stderr
       cluster_autoscaler_stderr_threshold = var.cluster_autoscaler_stderr_threshold
+      cluster_autoscaler_server_creation_timeout = var.cluster_autoscaler_server_creation_timeout
       ssh_key                             = local.hcloud_ssh_key_id
       ipv4_subnet_id                      = data.hcloud_network.k3s.id
       snapshot_id                         = local.first_nodepool_snapshot_id

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -365,6 +365,9 @@ module "kube-hetzner" {
   #   - cluster_autoscaler_log_to_stderr: Determines whether to log to stderr (--logtostderr).
   #   - cluster_autoscaler_stderr_threshold: Sets the threshold for logs that go to stderr (--stderrthreshold).
   #
+  # Server/node creation timeout variable:
+  #   - cluster_autoscaler_server_creation_timeout: Sets the timeout (in minutes) until which a newly created server/node has to come available before giving up and destroying it (defaults to 5min)
+  #
   # Example:
   #
   # cluster_autoscaler_image = "registry.k8s.io/autoscaling/cluster-autoscaler"
@@ -372,6 +375,7 @@ module "kube-hetzner" {
   # cluster_autoscaler_log_level = 4
   # cluster_autoscaler_log_to_stderr = true
   # cluster_autoscaler_stderr_threshold = "INFO"
+  # cluster_autoscaler_server_creation_timeout = "5"
 
   # Additional Cluster Autoscaler binary configuration
   #

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -194,6 +194,10 @@ spec:
             value: '${ipv4_subnet_id}'
           - name: HCLOUD_FIREWALL
             value: '${firewall_id}'
+          %{~ if cluster_autoscaler_server_creation_timeout != "" ~}
+          - name: HCLOUD_SERVER_CREATION_TIMEOUT
+            value: '${cluster_autoscaler_server_creation_timeout}'
+          %{~ endif ~}
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs

--- a/variables.tf
+++ b/variables.tf
@@ -308,6 +308,11 @@ variable "cluster_autoscaler_extra_args" {
   description = "Extra arguments for the Cluster Autoscaler deployment."
 }
 
+variable "cluster_autoscaler_server_creation_timeout" {
+  type        = string
+  description = "Timeout (in minutes) until which a newly created server/node has to come available before giving up and destroying it (defaults to 5min)"
+}
+
 variable "autoscaler_nodepools" {
   description = "Cluster autoscaler nodepools."
   type = list(object({


### PR DESCRIPTION
This PR fixes https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/1278 by exposing a variable to increase server creation timeout of `cluster-autoscaler`.