### PR TITLE
Fix LoadBalancer service using both public and private IP of LB's 

### DIFF
--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -27,3 +27,6 @@ spec:
               value: "true"
             - name: "HCLOUD_LOAD_BALANCERS_ENABLED"
               value: "${!using_klipper_lb}"
+            - name: HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS
+              value: 'true'
+

--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -27,6 +27,6 @@ spec:
               value: "true"
             - name: "HCLOUD_LOAD_BALANCERS_ENABLED"
               value: "${!using_klipper_lb}"
-            - name: HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS
-              value: 'true'
+            - name: "HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS"
+              value: "true"
 


### PR DESCRIPTION
When a new service of type LoadBalancer is requested k3s will use besides the public IPv4 & 6 of the Hetzner LB also the private ip of that LB which is wrong. 

This also fixes the external-dns updating A records with the private IP of the LB


With `HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS: true` ( this is the default value ) 
![Screenshot 2024-03-15 at 21 04 19](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6584521/ba7d086c-50d4-4956-9d89-ee9087cd27f6)


external-dns will detect external load balancer IP's and will create following A records: ( cloudflare, but with other dns providers will be the same issue )
<img width="1228" alt="Screenshot 2024-03-15 at 21 07 40" src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6584521/009ebe85-467b-4003-a344-2e84d0dc9c26">


With this new change:

With `HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS: false`
![Screenshot 2024-03-15 at 21 05 12](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/assets/6584521/ec509c10-1ab7-4e61-9a64-34e17104b27e)


With this new change external dns won't create the A record for the private iP 


