### PR TITLE
autoscaler: allow to set kubelet-arg for autoscaler nodes

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -100,7 +100,7 @@ data "cloudinit_config" "autoscaler_config" {
         k3s_config = yamlencode({
           server        = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
           token         = local.k3s_token
-          kubelet-arg   = local.kubelet_arg
+          kubelet-arg   = concat(local.kubelet_arg, var.k3s_global_kubelet_args, var.k3s_autoscaler_kubelet_args, var.autoscaler_nodepools[count.index].kubelet_args)
           flannel-iface = local.flannel_iface
           node-label    = concat(local.default_agent_labels, [for k, v in var.autoscaler_nodepools[count.index].labels : "${k}=${v}"])
           node-taint    = concat(local.default_agent_taints, [for taint in var.autoscaler_nodepools[count.index].taints : "${taint.key}=${taint.value}:${taint.effect}"])

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -336,6 +336,7 @@ module "kube-hetzner" {
   #        value: "peak-workloads"
   #        effect: "NoExecute"
   #     }]
+  #     # kubelet_args = ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"]
   #   }
   # ]
 
@@ -616,6 +617,7 @@ module "kube-hetzner" {
   # k3s_global_kubelet_args = ["kube-reserved=cpu=100m,ephemeral-storage=1Gi", "system-reserved=cpu=memory=200Mi", "image-gc-high-threshold=50", "image-gc-low-threshold=40"]
   # k3s_control_plane_kubelet_args = []
   # k3s_agent_kubelet_args = []
+  # k3s_autoscaler_kubelet_args = []
 
   # If you want to allow all outbound traffic you can set this to "false". Default is "true".
   # restrict_outbound_traffic = false

--- a/variables.tf
+++ b/variables.tf
@@ -311,13 +311,14 @@ variable "cluster_autoscaler_extra_args" {
 variable "autoscaler_nodepools" {
   description = "Cluster autoscaler nodepools."
   type = list(object({
-    name        = string
-    server_type = string
-    location    = string
-    min_nodes   = number
-    max_nodes   = number
-    labels      = optional(map(string), {})
-    taints = optional(list(object({
+    name         = string
+    server_type  = string
+    location     = string
+    min_nodes    = number
+    max_nodes    = number
+    labels       = optional(map(string), {})
+    kubelet_args = optional(list(string), ["kube-reserved=cpu=50m,memory=300Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"])
+    taints       = optional(list(object({
       key    = string
       value  = string
       effect = string
@@ -945,6 +946,12 @@ variable "k3s_agent_kubelet_args" {
   type        = list(string)
   default     = []
   description = "Kubelet args for agent nodes."
+}
+
+variable "k3s_autoscaler_kubelet_args" {
+  type        = list(string)
+  default     = []
+  description = "Kubelet args for autoscaler nodes."
 }
 
 variable "ingress_target_namespace" {


### PR DESCRIPTION
This PR allows to set `kubelet` arguments (through `kubelet_args`) for each autoscaler pool individually or globally (`k3s_autoscaler_kubelet_args`).

Fixes https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/1281