### PR TITLE
docs: fix typo and improve readability of `examples/kustomization_user_deploy/README.md`

### DIFF
--- a/examples/kustomization_user_deploy/README.md
+++ b/examples/kustomization_user_deploy/README.md
@@ -7,11 +7,9 @@ Pretty sure I butchered a lot ;)
 
 ### Assuming you followed the `DO not Skip` part of the installation
 
-In the project folder, where the `kube.tf` is located.<br>
-Create a folder named `extra-manifests`<br>
-In it create a file named `kustomization.yaml.tpl`<br>
-and **your** manifest file(s), there names must be listed in the `kustomization.yaml.tpl` `recources` without the `.tpl`<br>
-e.g. `some-random-name.yaml.tpl`
+In the project folder, where the `kube.tf` is located:
+1. Create a folder named `extra-manifests`.
+2. In it create a file named `kustomization.yaml.tpl` and **your** manifest file(s). Be sure to use the `resources` field, in the `kustomization.yaml` file, to define the list of resources to include in a configuration.
 
 ## Apply the kustomized configuration
 
@@ -22,13 +20,17 @@ Assuming no errors have been made, apply this by run `terraform apply`<br>
 In the highly unlikely case that an actual error has occurred...<br>
 Anyway, you can rerun just the kustomization part like this:
 
-    terraform apply -replace='module.kube-hetzner.null_resource.kustomization_user["kustomization.yaml.tpl"]' --auto-approve
+```sh
+terraform apply -replace='module.kube-hetzner.null_resource.kustomization_user["kustomization.yaml.tpl"]' --auto-approve
+```
 
 Check what kustomization exists:
 
-    (⎈|dev3:default)➜ dev3-cluster (main) ✗ terraform state list | grep kustom
-    ...
-    module.kube-hetzner.null_resource.kustomization
-    module.kube-hetzner.null_resource.kustomization_user["some-random-name.yaml.tpl"]
-    module.kube-hetzner.null_resource.kustomization_user["kustomization.yaml.tpl"]
-    ...
+```sh
+(⎈|dev3:default)➜ dev3-cluster (main) ✗ terraform state list | grep kustom
+...
+module.kube-hetzner.null_resource.kustomization
+module.kube-hetzner.null_resource.kustomization_user["some-random-name.yaml.tpl"]
+module.kube-hetzner.null_resource.kustomization_user["kustomization.yaml.tpl"]
+...
+```


### PR DESCRIPTION
Fix typo in the `resources` configuration field and improve readability using numbered lists.