### PR TITLE
Automatically set ssh_public_key and ssh_private_key from local id_ed25519 keypair

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -12,8 +12,8 @@ module "agents" {
   base_domain                  = var.base_domain
   ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                     = var.ssh_port
-  ssh_public_key               = var.ssh_public_key
-  ssh_private_key              = var.ssh_private_key
+  ssh_public_key               = var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key
+  ssh_private_key              = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
   placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.agent[each.value.placement_group_compat_idx].id : hcloud_placement_group.agent_named[each.value.placement_group].id)

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -60,7 +60,7 @@ resource "null_resource" "configure_autoscaler" {
   }
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port
@@ -97,7 +97,7 @@ data "cloudinit_config" "autoscaler_config" {
       "${path.module}/templates/autoscaler-cloudinit.yaml.tpl",
       {
         hostname          = "autoscaler"
-        sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys = concat([var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key], var.ssh_additional_public_keys)
         k3s_config = yamlencode({
           server        = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
           token         = local.k3s_token
@@ -129,7 +129,7 @@ data "cloudinit_config" "autoscaler_legacy_config" {
       "${path.module}/templates/autoscaler-cloudinit.yaml.tpl",
       {
         hostname          = "autoscaler"
-        sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys = concat([var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key], var.ssh_additional_public_keys)
         k3s_config = yamlencode({
           server        = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
           token         = local.k3s_token
@@ -160,7 +160,7 @@ resource "null_resource" "autoscaled_nodes_registries" {
 
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = each.value.ipv4_address
     port           = var.ssh_port

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -12,8 +12,8 @@ module "control_planes" {
   base_domain                  = var.base_domain
   ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                     = var.ssh_port
-  ssh_public_key               = var.ssh_public_key
-  ssh_private_key              = var.ssh_private_key
+  ssh_public_key               = var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key
+  ssh_private_key              = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
   ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
   firewall_ids                 = [hcloud_firewall.k3s.id]
   placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.control_plane[each.value.placement_group_compat_idx].id : hcloud_placement_group.control_plane_named[each.value.placement_group].id)

--- a/init.tf
+++ b/init.tf
@@ -23,7 +23,7 @@ resource "hcloud_load_balancer" "cluster" {
 resource "null_resource" "first_control_plane" {
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = module.control_planes[keys(module.control_planes)[0]].ipv4_address
     port           = var.ssh_port

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,10 @@ locals {
   # Otherwise, a new one will be created by the module.
   hcloud_ssh_key_id = var.hcloud_ssh_key_id == null ? hcloud_ssh_key.k3s[0].id : var.hcloud_ssh_key_id
 
+  # Grab local ssh keys if no key is passed (ssh-keygen -t id_ed25519 to generate one if there are still no keys in ~/.ssh)
+  ssh_public_key  = file("~/.ssh/id_ed25519.pub")
+  ssh_private_key = file("~/.ssh/id_ed25519")
+
   # if given as a variable, we want to use the given token. This is needed to restore the cluster
   k3s_token = var.k3s_token == null ? random_password.k3s_token.result : var.k3s_token
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "hcloud_image" "microos_arm_snapshot" {
 resource "hcloud_ssh_key" "k3s" {
   count      = var.hcloud_ssh_key_id == null ? 1 : 0
   name       = var.cluster_name
-  public_key = var.ssh_public_key
+  public_key = var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key
   labels     = local.labels
 }
 

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -1,13 +1,15 @@
 locals {
+  ssh_public_key  = file("~/.ssh/id_ed25519.pub")
+  ssh_private_key = file("~/.ssh/id_ed25519")
   # ssh_agent_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
-  ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
+  ssh_agent_identity = var.ssh_private_key == null ? local.ssh_private_key : var.ssh_public_key != null ? var.ssh_public_key : null
   # shared flags for ssh to ignore host keys for all connections during provisioning.
   ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PubkeyAuthentication=yes"
 
   # ssh_client_identity is used for ssh "-i" flag, its the private key if that is set, or a public key
   # if an ssh agent is used.
-  ssh_client_identity = var.ssh_private_key == null ? var.ssh_public_key : var.ssh_private_key
+  ssh_client_identity = var.ssh_private_key == null ? local.ssh_private_key : var.ssh_private_key == null ? local.ssh_private_key : var.ssh_public_key
 
   # the hosts name with its unique suffix attached
   name = "${var.name}-${random_string.server.id}"

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -45,7 +45,7 @@ resource "hcloud_server" "server" {
 
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = self.ipv4_address
     port           = var.ssh_port
@@ -100,7 +100,7 @@ resource "null_resource" "registries" {
 
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = hcloud_server.server.ipv4_address
     port           = var.ssh_port
@@ -144,7 +144,7 @@ data "cloudinit_config" "config" {
       "${path.module}/templates/cloudinit.yaml.tpl",
       {
         hostname                     = local.name
-        sshAuthorizedKeys            = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys            = concat([var.ssh_public_key != null ? var.ssh_public_key : local.ssh_public_key], var.ssh_additional_public_keys)
         cloudinit_write_files_common = var.cloudinit_write_files_common
         cloudinit_runcmd_common      = var.cloudinit_runcmd_common
         swap_size                    = var.swap_size
@@ -160,7 +160,7 @@ resource "null_resource" "zram" {
 
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
+    private_key    = var.ssh_private_key != null ? var.ssh_private_key : local.ssh_private_key
     agent_identity = local.ssh_agent_identity
     host           = hcloud_server.server.ipv4_address
     port           = var.ssh_port

--- a/variables.tf
+++ b/variables.tf
@@ -37,12 +37,14 @@ variable "ssh_port" {
 variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string
+  default = null
 }
 
 variable "ssh_private_key" {
   description = "SSH private Key."
   type        = string
   sensitive   = true
+  default = null
 }
 
 variable "ssh_hcloud_key_label" {


### PR DESCRIPTION
# Automatically set ssh_public_key and ssh_private_key from local id_ed25519 keypair

Provided that the user has previously generated ssh id_ed25519 keys within `ssh-keygen -t ed25519`, these will automatically be added to the cluster so that it is accessible right away from the local machine.