### PR TITLE
Fix configuration when exposing additional ports

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -633,7 +633,8 @@ ports:
 %{for option in var.traefik_additional_ports~}
   ${option.name}:
     port: ${option.port}
-    expose: true
+    expose:
+      default: true
     exposedPort: ${option.exposedPort}
     protocol: TCP
 %{if !local.using_klipper_lb~}


### PR DESCRIPTION
Fixes #1335 and #1322. Notice that this depends on the Traefik version so this might not be a real fix if someone specifies a traefik version that comes before https://github.com/traefik/traefik-helm-chart/commit/7e349d4782b72c36220a1ec8dace803640e289e0