### PR TITLE
Fix swap creation issue

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -18,7 +18,7 @@ module "kube-hetzner" {
 
   # * For local dev, path to the git repo
   # source = "../../kube-hetzner/"
-  # If you want to use the latest master branch
+  # If you want to use the latest master branch, see https://developer.hashicorp.com/terraform/language/modules/sources#github
   # source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner"
   # For normal use, this is the path to the terraform registry
   source = "kube-hetzner/kube-hetzner/hcloud"
@@ -632,6 +632,8 @@ module "kube-hetzner" {
   # k3s_exec_agent_args = "--kubelet-arg kube-reserved=cpu=100m,memory=200Mi,ephemeral-storage=1Gi"
 
   # The vars below here passes it to the k3s config.yaml. This way it persist across reboots
+  # Make sure you set "feature-gates=NodeSwap=true,CloudDualStackNodeIPs=true" if want to use swap_size
+  # see https://github.com/k3s-io/k3s/issues/8811#issuecomment-1856974516
   # k3s_global_kubelet_args = ["kube-reserved=cpu=100m,ephemeral-storage=1Gi", "system-reserved=cpu=memory=200Mi", "image-gc-high-threshold=50", "image-gc-low-threshold=40"]
   # k3s_control_plane_kubelet_args = []
   # k3s_agent_kubelet_args = []

--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -25,9 +25,12 @@ runcmd:
 ${cloudinit_runcmd_common}
 
 %{if swap_size != ""~}
-- [fallocate, '-l', '${swap_size}', '/var/swapfile']
-- [chmod, '600', '/var/swapfile']
-- [mkswap, '/var/swapfile']
-- [swapon, '/var/swapfile']
-- ["sh", "-c", "echo '/var/swapfile swap swap defaults 0 0' >> /etc/fstab"]
+- |
+  transactional-update --continue shell <<- EOF
+    fallocate -l ${swap_size} /var/swapfile
+    chmod 600 /var/swapfile
+    mkswap /var/swapfile
+    swapon /var/swapfile
+    echo '/var/swapfile swap swap defaults 0 0' >> /etc/fstab
+  EOF
 %{endif~}

--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -35,7 +35,7 @@ ${cloudinit_runcmd_common}
   chmod 700 /var/lib/swap
   truncate -s 0 /var/lib/swap/swapfile
   chattr +C /var/lib/swap/swapfile
-  fallocate -l 4G /var/lib/swap/swapfile
+  fallocate -l ${swap_size} /var/lib/swap/swapfile
   chmod 600 /var/lib/swap/swapfile
   mkswap /var/lib/swap/swapfile
   swapon /var/lib/swap/swapfile

--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -24,11 +24,6 @@ runcmd:
 
 ${cloudinit_runcmd_common}
 
-# See https://en.opensuse.org/SDB:Partitioning#Creating_a_btrfs_swapfile
-# And https://en.opensuse.org/openSUSE:Snapper_Tutorial#Swapfile
-# according to https://btrfs.readthedocs.io/en/latest/Swapfile.html we need to somehow run swapon -a after reboot
-# Due to some `swapon: /var/lib/swap/swapfile: swapon failed: Read-only file system`
-# I use separate systemd script
 %{if swap_size != ""~}
 - |
   btrfs subvolume create /var/lib/swap


### PR DESCRIPTION
wrap swap creation with transactional-update --continue shell to fix the issue of missing swap after node reboot fix for https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/1399

I see the proper transaction with 4Gb used for swap

```
# snapper list
 # │ Type   │ Pre # │ Date                     │ User │ Used Space │ Cleanup │ Description           │ Userdata
───┼────────┼───────┼──────────────────────────┼──────┼────────────┼─────────┼───────────────────────┼─────────
0  │ single │       │                          │ root │            │         │ current               │
1  │ single │       │ Sat Jun 29 19:42:50 2024 │ root │  80.40 MiB │         │ first root filesystem │
2  │ single │       │ Tue Jul  2 06:03:26 2024 │ root │  14.76 MiB │ number  │ Snapshot Update of #1 │
3- │ single │       │ Tue Jul  2 06:04:01 2024 │ root │ 352.00 KiB │ number  │ Snapshot Update of #2 │
4+ │ single │       │ Tue Jul  9 07:04:59 2024 │ root │   4.00 GiB │ number  │ Snapshot Update of #3 │
```

More info about swap creation in micros

[Creating_a_btrfs_swapfile](https://en.opensuse.org/SDB:Partitioning#Creating_a_btrfs_swapfile) and [openSUSE:Snapper_Tutorial#Swapfile](https://en.opensuse.org/openSUSE:Snapper_Tutorial#Swapfile)

Due  to [issue](https://btrfs.readthedocs.io/en/latest/Swapfile.html) we need to somehow run `swapon -a` after reboot
to solve
```
swapon: /var/lib/swap/swapfile: swapon failed: Read-only file system
```
I use systemd script