### PR TITLE
30m lock-ttl default added for kured_options

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -756,7 +756,8 @@ kured_options = merge({
   "pre-reboot-node-labels" : "kured=rebooting",
   "post-reboot-node-labels" : "kured=done",
   "period" : "5m",
-  "reboot-sentinel" : "/sentinel/reboot-required"
+  "reboot-sentinel" : "/sentinel/reboot-required",
+  "lock-ttl" : "30m"
 }, var.kured_options)
 
 k3s_registries_update_script = <<EOF


### PR DESCRIPTION
#1362 
added default value for kured_options.lock-ttl= 30m