### PR TITLE
Revert "30m lock-ttl default added for kured_options"

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -757,8 +757,7 @@ kured_options = merge({
   "pre-reboot-node-labels" : "kured=rebooting",
   "post-reboot-node-labels" : "kured=done",
   "period" : "5m",
-  "reboot-sentinel" : "/sentinel/reboot-required",
-  "lock-ttl" : "30m"
+  "reboot-sentinel" : "/sentinel/reboot-required"
 }, var.kured_options)
 
 k3s_registries_update_script = <<EOF


### PR DESCRIPTION
Reverts kube-hetzner/terraform-hcloud-kube-hetzner#1420 because ttl on the lock can have cascading effects in some instances and take the whole cluster down.