### PR TITLE
Allows specifying k3s version

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -128,6 +128,7 @@ resource "null_resource" "kustomization" {
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
       coalesce(var.initial_k3s_channel, "N/A"),
+      coalesce(var.install_k3s_version, "N/A"),
       coalesce(var.cluster_autoscaler_version, "N/A"),
       coalesce(var.hetzner_ccm_version, "N/A"),
       coalesce(var.hetzner_csi_version, "N/A"),
@@ -233,6 +234,7 @@ resource "null_resource" "kustomization" {
       "${path.module}/templates/plans.yaml.tpl",
       {
         channel          = var.initial_k3s_channel
+        version          = var.install_k3s_version
         disable_eviction = !var.system_upgrade_enable_eviction
     })
     destination = "/var/post_install/plans.yaml"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -590,6 +590,10 @@ module "kube-hetzner" {
   # The default is "v1.29".
   # initial_k3s_channel = "stable"
 
+  # Allows you to specify the k3s version. If defined, supersedes initial_k3s_channel.
+  # See https://github.com/k3s-io/k3s/releases
+  # install_k3s_version = "v1.30.2+k3s2"
+
   # The cluster name, by default "k3s"
   # cluster_name = ""
 

--- a/locals.tf
+++ b/locals.tf
@@ -125,10 +125,18 @@ locals {
   swap_node_label   = ["node.kubernetes.io/server-swap=enabled"]
 
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
-    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
+    var.install_k3s_version == "" ? (
+      "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
+    ) : (
+      "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=${var.install_k3s_version} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
+    )
   ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
-    "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
+    var.install_k3s_version == "" ? (
+      "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
+    ) : (
+      "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=${var.install_k3s_version} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
+    )
   ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
 
   control_plane_nodes = merge([

--- a/locals.tf
+++ b/locals.tf
@@ -127,14 +127,14 @@ locals {
   install_k3s_server = concat(local.common_pre_install_k3s_commands, [
     var.install_k3s_version == "" ? (
       "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
-    ) : (
+      ) : (
       "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=${var.install_k3s_version} INSTALL_K3S_EXEC='server ${var.k3s_exec_server_args}' sh -"
     )
   ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)
   install_k3s_agent = concat(local.common_pre_install_k3s_commands, [
     var.install_k3s_version == "" ? (
       "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_CHANNEL=${var.initial_k3s_channel} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
-    ) : (
+      ) : (
       "curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=${var.install_k3s_version} INSTALL_K3S_EXEC='agent ${var.k3s_exec_agent_args}' sh -"
     )
   ], (var.disable_selinux ? [] : local.apply_k3s_selinux), local.common_post_install_k3s_commands)

--- a/templates/plans.yaml.tpl
+++ b/templates/plans.yaml.tpl
@@ -10,7 +10,11 @@ metadata:
     k3s_upgrade: agent
 spec:
   concurrency: 1
+  %{~ if version == "" ~}
   channel: https://update.k3s.io/v1-release/channels/${channel}
+  %{~ else ~}
+  version: ${version}
+  %{~ endif ~}
   serviceAccountName: system-upgrade
   nodeSelector:
     matchExpressions:
@@ -41,7 +45,11 @@ metadata:
     k3s_upgrade: server
 spec:
   concurrency: 1
+  %{~ if version == "" ~}
   channel: https://update.k3s.io/v1-release/channels/${channel}
+  %{~ else ~}
+  version: ${version}
+  %{~ endif ~}
   serviceAccountName: system-upgrade
   nodeSelector:
     matchExpressions:

--- a/variables.tf
+++ b/variables.tf
@@ -546,8 +546,8 @@ variable "initial_k3s_channel" {
 }
 
 variable "install_k3s_version" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Allows you to specify the k3s version (Example: v1.29.6+k3s2). Supersedes initial_k3s_channel."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -545,6 +545,12 @@ variable "initial_k3s_channel" {
   }
 }
 
+variable "install_k3s_version" {
+  type = string
+  default = ""
+  description = "Allows you to specify the k3s version (Example: v1.29.6+k3s2). Supersedes initial_k3s_channel."
+}
+
 variable "system_upgrade_enable_eviction" {
   type        = bool
   default     = true


### PR DESCRIPTION
Sometimes a cluster operator might prefer to specify the k3s version (e.g. `v1.29.6+k3s2`) instead of the channel (e.g. `v1.29`, `stable` etc.)

Reasons for that could be not wanting the system upgrade controller to run at unpredictable times, or having more fine-grained control over the running version.

This PR introduces a new variable `install_k3s_version` in `kube.tf`. If undefined, the present behavior is preserved such that current installations are not affected. However, when defined, this variable takes precedence over `initial_k3s_channel`.

The mechanism for upgrades in either case continues to be the system upgrade controller.