### PR TITLE
Add option to use "cordon" instead of "drain" for k3s upgrades

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -234,6 +234,7 @@ resource "null_resource" "kustomization" {
       {
         channel          = var.initial_k3s_channel
         disable_eviction = !var.system_upgrade_enable_eviction
+        drain            = var.system_upgrade_use_drain
     })
     destination = "/var/post_install/plans.yaml"
   }

--- a/init.tf
+++ b/init.tf
@@ -234,7 +234,6 @@ resource "null_resource" "kustomization" {
       {
         channel          = var.initial_k3s_channel
         disable_eviction = !var.system_upgrade_enable_eviction
-        drain            = var.system_upgrade_use_drain
     })
     destination = "/var/post_install/plans.yaml"
   }

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -558,10 +558,17 @@ module "kube-hetzner" {
   # The default is "true" (in HA setup i.e. at least 3 control plane nodes & 2 agents, just keep it enabled since it works flawlessly).
   # automatically_upgrade_k3s = false
 
+  # By default nodes are drained before k3s upgrade, which will delete and transfer all pods to other nodes.
+  # Set this to false to cordon nodes instead, which just prevents scheduling new pods on the node during upgrade
+  # and keeps all pods running. This may be useful if you have pods which are known to be slow to start e.g.
+  # because they have to mount volumes with many files which require to get the right security context applied.
+  system_upgrade_use_drain = true
+
   # During k3s via system-upgrade-manager pods are evicted by default.
   # On small clusters this can lead to hanging upgrades and indefinitely unschedulable nodes,
   # in that case, set this to false to immediately delete pods before upgrading.
   # NOTE: Turning this flag off might lead to downtimes of services (which may be acceptable for your use case)
+  # NOTE: This flag takes effect only when system_upgrade_use_drain is set to true.
   # system_upgrade_enable_eviction = false
 
   # The default is "true" (in HA setup it works wonderfully well, with automatic roll-back to the previous snapshot in case of an issue).

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -558,17 +558,10 @@ module "kube-hetzner" {
   # The default is "true" (in HA setup i.e. at least 3 control plane nodes & 2 agents, just keep it enabled since it works flawlessly).
   # automatically_upgrade_k3s = false
 
-  # By default nodes are drained before k3s upgrade, which will delete and transfer all pods to other nodes.
-  # Set this to false to cordon nodes instead, which just prevents scheduling new pods on the node during upgrade
-  # and keeps all pods running. This may be useful if you have pods which are known to be slow to start e.g.
-  # because they have to mount volumes with many files which require to get the right security context applied.
-  system_upgrade_use_drain = true
-
   # During k3s via system-upgrade-manager pods are evicted by default.
   # On small clusters this can lead to hanging upgrades and indefinitely unschedulable nodes,
   # in that case, set this to false to immediately delete pods before upgrading.
   # NOTE: Turning this flag off might lead to downtimes of services (which may be acceptable for your use case)
-  # NOTE: This flag takes effect only when system_upgrade_use_drain is set to true.
   # system_upgrade_enable_eviction = false
 
   # The default is "true" (in HA setup it works wonderfully well, with automatic roll-back to the previous snapshot in case of an issue).

--- a/templates/plans.yaml.tpl
+++ b/templates/plans.yaml.tpl
@@ -24,11 +24,10 @@ spec:
   prepare:
     image: rancher/k3s-upgrade
     args: ["prepare", "k3s-server"]
-  %{ if drain }drain:
+  drain:
     force: true
     disableEviction: ${disable_eviction}
-    skipWaitForDeleteTimeout: 60%{ endif }
-  %{ if !drain }cordon: true%{ endif }
+    skipWaitForDeleteTimeout: 60
   upgrade:
     image: rancher/k3s-upgrade
 ---

--- a/templates/plans.yaml.tpl
+++ b/templates/plans.yaml.tpl
@@ -24,10 +24,11 @@ spec:
   prepare:
     image: rancher/k3s-upgrade
     args: ["prepare", "k3s-server"]
-  drain:
+  %{ if drain }drain:
     force: true
     disableEviction: ${disable_eviction}
-    skipWaitForDeleteTimeout: 60
+    skipWaitForDeleteTimeout: 60%{ endif }
+  %{ if !drain }cordon: true%{ endif }
   upgrade:
     image: rancher/k3s-upgrade
 ---

--- a/variables.tf
+++ b/variables.tf
@@ -551,12 +551,6 @@ variable "system_upgrade_enable_eviction" {
   description = "Whether to directly delete pods during system upgrade (k3s) or evict them. Defaults to true. Disable this on small clusters to avoid system upgrades hanging since pods resisting eviction keep node unschedulable forever. NOTE: turning this off, introduces potential downtime of services of the upgraded nodes."
 }
 
-variable "system_upgrade_use_drain" {
-  type        = bool
-  default     = true
-  description = "Wether using drain (true, the default), which will deletes and transfers all pods to other nodes before a node is being upgraded, or cordon (false), which just prevents schedulung new pods on the node during upgrade and keeps all pods running"
-}
-
 variable "automatically_upgrade_k3s" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -551,6 +551,12 @@ variable "system_upgrade_enable_eviction" {
   description = "Whether to directly delete pods during system upgrade (k3s) or evict them. Defaults to true. Disable this on small clusters to avoid system upgrades hanging since pods resisting eviction keep node unschedulable forever. NOTE: turning this off, introduces potential downtime of services of the upgraded nodes."
 }
 
+variable "system_upgrade_use_drain" {
+  type        = bool
+  default     = true
+  description = "Wether using drain (true, the default), which will deletes and transfers all pods to other nodes before a node is being upgraded, or cordon (false), which just prevents schedulung new pods on the node during upgrade and keeps all pods running"
+}
+
 variable "automatically_upgrade_k3s" {
   type        = bool
   default     = true


### PR DESCRIPTION
This PR adds a new variable `system_upgrade_use_drain` (default `true`), which represents the current default behaviour to advise system-upgrade-controller to drain nodes before performing a k3s upgrade.

When set to `false` the agent plan will be configured to cordon nodes during upgrades, which prevents that new pods are scheduled but keeps all existing pods running on that node.

This may be useful if you have pods which are known to start slowly, e.g. because they have to mount volumes with many files which require to get the right security context applied.

Nothing has changed for the server plan, which uses cordon anyway.