### PR TITLE
Add support for structured auhentication configuration.

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -634,6 +634,49 @@ module "kube-hetzner" {
   #   "trust anchor --store /root/ca.crt",
   # ]
 
+  # Structured authentication configuration. Multiple authentication providers support requires v1.30+ of 
+  # kubernetes.  
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration
+  #
+  # authentication_config = <<-EOT
+  #   apiVersion: apiserver.config.k8s.io/v1beta1
+  #   kind: AuthenticationConfiguration
+  #   jwt:
+  #   - issuer:
+  #       url: "https://token.actions.githubusercontent.com"
+  #       audiences:
+  #       - "https://github.com/octo-org"
+  #     claimMappings:
+  #       username:
+  #         claim: sub
+  #         prefix: "gh:"
+  #       groups:
+  #         claim: repository_owner
+  #         prefix: "gh:"
+  #     claimValidationRules:
+  #     - claim: repository
+  #       requiredValue: "octo-org/octo-repo"
+  #     - claim: "repository_visibility"
+  #       requiredValue: "public"
+  #     - claim: "ref"
+  #       requiredValue: "refs/heads/main"
+  #     - claim: "ref_type"
+  #       requiredValue: "branch"
+  #   - issuer:
+  #       url: "https://your.oidc.issuer"
+  #       audiences:
+  #       - "oidc_client_id"
+  #     claimMappings:
+  #       username:
+  #         claim: oidc_username_claim
+  #         prefix: "oidc:"
+  #       groups:
+  #         claim: oidc_groups_claim
+  #         prefix: "oidc:"
+  #   EOT
+
+
+
   # Additional flags to pass to the k3s server command (the control plane).
   # k3s_exec_server_args = "--kube-apiserver-arg enable-admission-plugins=PodTolerationRestriction,PodNodeSelector"
 

--- a/locals.tf
+++ b/locals.tf
@@ -436,6 +436,8 @@ locals {
   kube_controller_manager_arg = "flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins"
   flannel_iface               = "eth1"
 
+  kube_apiserver_arg = var.authentication_config != "" ? ["authentication-config=/etc/rancher/k3s/authentication_config.yaml"] : []
+
   cilium_values = var.cilium_values != "" ? var.cilium_values : <<EOT
 # Enable Kubernetes host-scope IPAM mode (required for K3s + Hetzner CCM)
 ipam:
@@ -798,6 +800,28 @@ else
     systemctl restart k3s || (echo "Error: Failed to restart k3s. Restoring /etc/rancher/k3s/config.yaml from backup" && cp /tmp/config_$DATE.yaml /etc/rancher/k3s/config.yaml && systemctl restart k3s)
   elif systemctl is-active --quiet k3s-agent; then
     systemctl restart k3s-agent || (echo "Error: Failed to restart k3s-agent. Restoring /etc/rancher/k3s/config.yaml from backup" && cp /tmp/config_$DATE.yaml /etc/rancher/k3s/config.yaml && systemctl restart k3s-agent)
+  else
+    echo "No active k3s or k3s-agent service found"
+  fi
+  echo "k3s service or k3s-agent service (re)started successfully"
+fi
+EOF
+
+k3s_authentication_config_update_script = <<EOF
+DATE=`date +%Y-%m-%d_%H-%M-%S`
+if cmp -s /tmp/authentication_config.yaml /etc/rancher/k3s/authentication_config.yaml; then
+  echo "No update required to the authentication_config.yaml file"
+else
+  if [ -f "/etc/rancher/k3s/authentication_config.yaml" ]; then
+    echo "Backing up /etc/rancher/k3s/authentication_config.yaml to /tmp/authentication_config_$DATE.yaml"
+    cp /etc/rancher/k3s/authentication_config.yaml /tmp/authentication_config_$DATE.yaml
+  fi
+  echo "Updated authentication_config.yaml detected, restart of k3s service required"
+  cp /tmp/authentication_config.yaml /etc/rancher/k3s/authentication_config.yaml
+  if systemctl is-active --quiet k3s; then
+    systemctl restart k3s || (echo "Error: Failed to restart k3s. Restoring /etc/rancher/k3s/authentication_config.yaml from backup" && cp /tmp/authentication_config_$DATE.yaml /etc/rancher/k3s/authentication_config.yaml && systemctl restart k3s)
+  elif systemctl is-active --quiet k3s-agent; then
+    systemctl restart k3s-agent || (echo "Error: Failed to restart k3s-agent. Restoring /etc/rancher/k3s/authentication_config.yaml from backup" && cp /tmp/authentication_config_$DATE.yaml /etc/rancher/k3s/authentication_config.yaml && systemctl restart k3s-agent)
   else
     echo "No active k3s or k3s-agent service found"
   fi

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "ssh_additional_public_keys" {
   default     = []
 }
 
+variable "authentication_config" {
+  description = "Strucutred authentication configuration. This can be used to define external authentication providers."
+  type    = string
+  default = ""
+}
+
 variable "hcloud_ssh_key_id" {
   description = "If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -59,8 +59,8 @@ variable "ssh_additional_public_keys" {
 
 variable "authentication_config" {
   description = "Strucutred authentication configuration. This can be used to define external authentication providers."
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "hcloud_ssh_key_id" {


### PR DESCRIPTION
Structured authentication configuration allows Kubernetes to support multiple identity providers. To use this feature you'll need version 1.30 of Kubernetes at-least.  


Details:
https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration

Example how to use github actions pipeline token to access cluster 
```yaml
name: 'test kubectl'
on:
  workflow_dispatch:
  workflow_call:
permissions:
  id-token: write
  contents: read
          
jobs:
  restart-services:
    name: 'Test kubectl'
    runs-on: ubuntu-latest
    environment: development
    steps:
    - name: Install OIDC Client from Core Package
      run: npm install @actions/core@1.10.1 @actions/http-client

    - name: Get Id Token
      uses: actions/github-script@v6
      id: idtoken
      with:
        script: |
            const coredemo = require('@actions/core')
            // On automatically created `github.token` "aud" claim is a string.
            // Kubernetes requires "aud" to be array of strings instead.
            let id_token = await coredemo.getIDToken(['https://github.com/kube-hetzner'])
            coredemo.setOutput('id_token', id_token)

    - name: Install kubectl
      uses: azure/setup-kubectl@v4

    - run: |
        mkdir -p $HOME/.kube/
        echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
        kubectl config set-cluster default --server=${KUBE_HOST} --certificate-authority=$HOME/.kube/certificate > /dev/null
        kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}"
        kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
        kubectl config use-context default > /dev/null
        kubectl get nodes
      env:
        KUBE_TOKEN: ${{ steps.idtoken.outputs.id_token }}
        KUBE_HOST: ${{ secrets.KUBE_HOST }}
        KUBE_CERTIFICATE: ${{ secrets.KUBE_CERTIFICATE }}
```