### PR TITLE
add control_plane_nodes and agent_nodes output

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -244,8 +244,10 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_agent_nodes"></a> [agent\_nodes](#output\_agent\_nodes) | The agent nodes |
 | <a name="output_agents_public_ipv4"></a> [agents\_public\_ipv4](#output\_agents\_public\_ipv4) | The public IPv4 addresses of the agent servers. |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Shared suffix for all resources belonging to this cluster. |
+| <a name="output_control_plane_nodes"></a> [control\_plane\_nodes](#output\_control\_plane\_nodes) | The control plane nodes |
 | <a name="output_control_planes_public_ipv4"></a> [control\_planes\_public\_ipv4](#output\_control\_planes\_public\_ipv4) | The public IPv4 addresses of the controlplane servers. |
 | <a name="output_ingress_public_ipv4"></a> [ingress\_public\_ipv4](#output\_ingress\_public\_ipv4) | The public IPv4 address of the Hetzner load balancer |
 | <a name="output_ingress_public_ipv6"></a> [ingress\_public\_ipv6](#output\_ingress\_public\_ipv6) | The public IPv6 address of the Hetzner load balancer |

--- a/output.tf
+++ b/output.tf
@@ -48,6 +48,16 @@ output "k3s_token" {
   sensitive   = true
 }
 
+output "control_plane_nodes" {
+  description = "The control plane nodes"
+  value       = [for node in module.control_planes : node]
+}
+
+output "agent_nodes" {
+  description = "The agent nodes"
+  value       = [for node in module.agents : node]
+}
+
 # Keeping for backward compatibility
 output "kubeconfig_file" {
   value       = local.kubeconfig_external


### PR DESCRIPTION
This change adds new outputs `control_plane_nodes` and `agent_nodes` to output a list of objects forwarding all outputs from modules/host (ipv4_address, ipv6_address, private_ipv4_address, name and id).

Closes #1460

---

main.tf:
```terraform
module "prod-us-east-1" {
    source = "../terraform-hcloud-kube-hetzner"

    control_plane_nodepools = [
        {
            name        = "control-plane",
            server_type = "cpx21",
            location    = "ash",
            count       = 3
            labels      = []
            taints      = []
        }
    ]

    agent_nodepools = [
        {
            name        = "worker",
            server_type = "cpx21",
            location    = "ash",
            count       = 3
            labels      = []
            taints      = []
        }
    ]

    # ...
}

output "nodes" {
  value = concat(module.prod-us-east-1.agent_nodes, module.prod-us-east-1.control_plane_nodes)
}
```

output:
```
module.prod-us-east-1.null_resource.kustomization: Creation complete after 53s [id=1408305325813632907]

Apply complete! Resources: 62 added, 0 changed, 0 destroyed.

Outputs:

kubeconfig = <sensitive>
nodes = [
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "178.156.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-worker-gnu"
    "private_ipv4_address" = "10.0.0.101"
  },
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "5.161.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-worker-wbu"
    "private_ipv4_address" = "10.0.0.102"
  },
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "5.161.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-worker-pag"
    "private_ipv4_address" = "10.0.0.103"
  },
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "5.161.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-control-plane-iqd"
    "private_ipv4_address" = "10.255.0.101"
  },
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "5.161.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-control-plane-tvx"
    "private_ipv4_address" = "10.255.0.102"
  },
  {
    "id" = "XXXXXXX"
    "ipv4_address" = "5.161.XXX.XXX"
    "ipv6_address" = "2a01:4ff:f0:XXXX::1"
    "name" = "k3s-control-plane-mng"
    "private_ipv4_address" = "10.255.0.103"
  },
]
```