### PR TITLE
autoscaler formatting documentation fix

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -321,23 +321,24 @@ module "kube-hetzner" {
   #
   # * Example below:
   # autoscaler_nodepools = [
-  #   {
-  #     name        = "autoscaled-small"
-  #     server_type = "cx32"
-  #     location    = "fsn1"
-  #     min_nodes   = 0
-  #     max_nodes   = 5
-  #     labels      = {
-  #       "node.kubernetes.io/role": "peak-workloads"
-  #     }
-  #     taints      =
-  #     [{
-  #        key: "node.kubernetes.io/role"
-  #        value: "peak-workloads"
-  #        effect: "NoExecute"
-  #     }]
-  #     # kubelet_args = ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"]
-  #   }
+  #  {
+  #    name        = "autoscaled-small"
+  #    server_type = "cx32"
+  #    location    = "fsn1"
+  #    min_nodes   = 0
+  #    max_nodes   = 5
+  #    labels      = {
+  #      "node.kubernetes.io/role": "peak-workloads"
+  #    }
+  #    taints      = [
+  #      {
+  #       key= "node.kubernetes.io/role"
+  #       value= "peak-workloads"
+  #       effect= "NoExecute"
+  #      }
+  #    ]
+  #    # kubelet_args = ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"]
+  #  }
   # ]
 
   # ⚠️ Deprecated, will be removed after a new Cluster Autoscaler version has been released which support the new way of setting labels and taints. See above.


### PR DESCRIPTION
There was an error in the documentatio about the example file.
Resulting in error when using autoscaler:
Error: Invalid expression                                                                                                                                                │                                                                                                                                                                         
│   on kube.tf line 333, in module "kube-hetzner":                                                                                                                        
│  333:       taints      =                                                                                                                                               
│  334:       [{                                                                                                                                                          
│                                                                                                                                                                         
│ Expected the start of an expression, but found an invalid expression token.
Solution: 
1. change position of "[" and "]" bracket
2. change format of listed taints: key="value", not key:"value"