### PR TITLE
fix hcloud-csi.yaml if csi is disabled (disable_hetzner_csi)

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -253,12 +253,12 @@ resource "null_resource" "kustomization" {
     destination = "/var/post_install/longhorn.yaml"
   }
 
-  # Upload the csi-driver-smb config
+  # Upload the csi-driver config (ignored if csi is disabled)
   provisioner "file" {
     content = templatefile(
       "${path.module}/templates/hcloud-csi.yaml.tpl",
       {
-        version = local.csi_version
+        version = coalesce(local.csi_version, "N/A")
         values  = indent(4, trimspace(var.hetzner_csi_values))
     })
     destination = "/var/post_install/hcloud-csi.yaml"


### PR DESCRIPTION
This PR fixes https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/1470 which was introduced with https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/pull/1417. 


- If `disable_hetzner_csi = false` then `csi_version` will always be set (either from `hetzner_csi_version` or using the latest github release).
- If `disable_hetzner_csi = true` then `csi_version` will not be automatically be inferred from the latest github release. This is why rendering the `templatefile` fails, even though the file is not needed and ignored. This PR fixes rendering the template using `coalesce`. This way the file will be generated but is still not used since csi is disabled. 
