### PR TITLE
fix(hccm): custom args are ignored

### DIFF
--- a/templates/ccm.yaml.tpl
+++ b/templates/ccm.yaml.tpl
@@ -9,11 +9,11 @@ spec:
     spec:
       containers:
         - name: hcloud-cloud-controller-manager
-          command:
-            - "/bin/hcloud-cloud-controller-manager"
+          args:
             - "--cloud-provider=hcloud"
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
+            - "--route-reconciliation-period=30s"
             - "--allocate-node-cidrs=true"
             - "--cluster-cidr=${cluster_cidr_ipv4}"
             - "--webhook-secure-port=0"


### PR DESCRIPTION
Closes #1477

Fix the issue described by overriding `args` instead of `command`. In addition, I also added an argument (`--route-reconciliation-period=30s`) that was added in HCCM v1.14.2.