### PR TITLE
Fix regeneration and rendering of hetzner_csi_values

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,13 +13,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_github"></a> [github](#provider\_github) | >= 5.44.0 |
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.43.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_remote"></a> [remote](#provider\_remote) | >= 0.1.2 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.5 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.2.3 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.48.1 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_remote"></a> [remote](#provider\_remote) | 0.1.3 |
 
 ### Modules
 
@@ -172,7 +172,6 @@
 | <a name="input_ingress_replica_count"></a> [ingress\_replica\_count](#input\_ingress\_replica\_count) | Number of replicas per ingress controller. 0 means autodetect based on the number of agent nodes. | `number` | `0` | no |
 | <a name="input_ingress_target_namespace"></a> [ingress\_target\_namespace](#input\_ingress\_target\_namespace) | The namespace to deploy the ingress controller to. Defaults to ingress name. | `string` | `""` | no |
 | <a name="input_initial_k3s_channel"></a> [initial\_k3s\_channel](#input\_initial\_k3s\_channel) | Allows you to specify an initial k3s channel. | `string` | `"v1.29"` | no |
-| <a name="input_install_k3s_version"></a> [install\_k3s\_version](#input\_install\_k3s\_version) | Allows you to specify the k3s version (Example: v1.29.6+k3s2). Supersedes initial\_k3s\_channel. | `string` | `""` | no |
 | <a name="input_k3s_agent_kubelet_args"></a> [k3s\_agent\_kubelet\_args](#input\_k3s\_agent\_kubelet\_args) | Kubelet args for agent nodes. | `list(string)` | `[]` | no |
 | <a name="input_k3s_autoscaler_kubelet_args"></a> [k3s\_autoscaler\_kubelet\_args](#input\_k3s\_autoscaler\_kubelet\_args) | Kubelet args for autoscaler nodes. | `list(string)` | `[]` | no |
 | <a name="input_k3s_control_plane_kubelet_args"></a> [k3s\_control\_plane\_kubelet\_args](#input\_k3s\_control\_plane\_kubelet\_args) | Kubelet args for control plane nodes. | `list(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,13 +13,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.5 |
-| <a name="provider_github"></a> [github](#provider\_github) | 6.2.3 |
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.48.1 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
-| <a name="provider_remote"></a> [remote](#provider\_remote) | 0.1.3 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 5.44.0 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.43.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_remote"></a> [remote](#provider\_remote) | >= 0.1.2 |
 
 ### Modules
 

--- a/init.tf
+++ b/init.tf
@@ -123,7 +123,8 @@ resource "null_resource" "kustomization" {
       local.longhorn_values,
       local.csi_driver_smb_values,
       local.cert_manager_values,
-      local.rancher_values
+      local.rancher_values,
+      local.hetzner_csi_values
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
@@ -259,7 +260,7 @@ resource "null_resource" "kustomization" {
       "${path.module}/templates/hcloud-csi.yaml.tpl",
       {
         version = local.csi_version
-        values  = indent(4, trimspace(var.hetzner_csi_values))
+        values  = indent(4, trimspace(local.hetzner_csi_values))
     })
     destination = "/var/post_install/hcloud-csi.yaml"
   }

--- a/locals.tf
+++ b/locals.tf
@@ -544,6 +544,9 @@ persistence:
   csi_driver_smb_values = var.csi_driver_smb_values != "" ? var.csi_driver_smb_values : <<EOT
   EOT
 
+  hetzner_csi_values = var.hetzner_csi_values != "" ? var.hetzner_csi_values : <<EOT
+  EOT
+
   nginx_values = var.nginx_values != "" ? var.nginx_values : <<EOT
 controller:
   watchIngressWithoutClass: "true"


### PR DESCRIPTION
Using `hetzner_csi_values` didn't actually do anything. Now it does.