### PR TITLE
Fix: Output public ipv6 on single-node-clusters

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -28,13 +28,13 @@ output "agents_public_ipv4" {
 }
 
 output "ingress_public_ipv4" {
-  description = "The public IPv4 address of the Hetzner load balancer"
+  description = "The public IPv4 address of the Hetzner load balancer (with fallback to first control plane node)"
   value       = local.has_external_load_balancer ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : hcloud_load_balancer.cluster[0].ipv4
 }
 
 output "ingress_public_ipv6" {
-  description = "The public IPv6 address of the Hetzner load balancer"
-  value       = (local.has_external_load_balancer || var.load_balancer_disable_ipv6) ? null : hcloud_load_balancer.cluster[0].ipv6
+  description = "The public IPv6 address of the Hetzner load balancer (with fallback to first control plane node)"
+  value       = local.has_external_load_balancer ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : (var.load_balancer_disable_ipv6 ? null : hcloud_load_balancer.cluster[0].ipv6)
 }
 
 output "k3s_endpoint" {


### PR DESCRIPTION
For testing purposes I started the implementation of my cluster setup with a single-node cluster and added Hetzner DNS Api to update a domain to the cluster ingress ip. However for the single node setup, the IPv6 was not set, because the conditions were not met.

This PR fixes setting the IPv6 Addresses in the module output for single-node clusters (that do not have an external loadbalancer).