### PR TITLE
chore: bump system-upgrade-controller version to 0.14.2

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -109,7 +109,7 @@ locals {
         patch = <<-EOF
           - op: replace
             path: /spec/template/spec/containers/0/image
-            value: rancher/system-upgrade-controller:v0.13.4
+            value: rancher/system-upgrade-controller:v0.14.2
         EOF
       },
       {


### PR DESCRIPTION
Should this be updated automatically in the future by dependabot/renovate?