### PR TITLE
Update doc, default values and kube.tf with recent changes to cluster_autoscaler_version, initial_k3s_channel and var sys_upgrade_controller_version

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -423,6 +423,8 @@ module "kube-hetzner" {
 
   # To enable Hetzner Storage Box support, you can enable csi-driver-smb, default is "false".
   # enable_csi_driver_smb = true
+  # If you want to specify the version for csi-driver-smb, set it below - otherwise it'll use the latest version available.
+  # csi_driver_smb_version = "v1.16.0"
 
   # To enable iscid without setting enable_longhorn = true, set enable_iscsid = true. You will need this if
   # you install your own version of longhorn outside of this module.

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -603,6 +603,9 @@ module "kube-hetzner" {
   # The default is "stable".
   # initial_k3s_channel = "stable"
 
+  # Allows to specify the version of the System Upgrade Controller for automated upgrades of k3s
+  # sys_upgrade_controller_version = "v0.14.2"
+
   # The cluster name, by default "k3s"
   # cluster_name = ""
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -373,7 +373,7 @@ module "kube-hetzner" {
   # Example:
   #
   # cluster_autoscaler_image = "registry.k8s.io/autoscaling/cluster-autoscaler"
-  # cluster_autoscaler_version = "v1.30.1"
+  # cluster_autoscaler_version = "v1.30.3"
   # cluster_autoscaler_log_level = 4
   # cluster_autoscaler_log_to_stderr = true
   # cluster_autoscaler_stderr_threshold = "INFO"

--- a/variables.tf
+++ b/variables.tf
@@ -1135,5 +1135,5 @@ variable "keep_disk_cp" {
 variable "sys_upgrade_controller_version" {
   type        = string
   default     = "v0.14.2"
-  description = "Whether to keep OS disks of nodes the same size when upgrading a control-plane node"
+  description = "Version of the System Upgrade Controller for automated upgrades of k3s"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -276,7 +276,7 @@ variable "cluster_autoscaler_image" {
 
 variable "cluster_autoscaler_version" {
   type        = string
-  default     = "v1.31.1"
+  default     = "v1.30.3"
   description = "Version of Kubernetes Cluster Autoscaler for Hetzner Cloud. Should be aligned with Kubernetes version"
 }
 


### PR DESCRIPTION
#1512 introduced a new var `sys_upgrade_controller_version`.
- Corrected the description, which was an incorrect copy-paste from another var.
- Added the var to kube.tf.example

#1506 reverted cluster-autoscaler back to the community version. However, the default version for var `cluster_autoscaler_version` (1.31.1), does not correspond to the new default `initial_k3s_channel` ("stable", which is currently still 1.30) and the doc says these versions *should* correspond. So I put version 1.30.3 as default. This is in line with the initial_k3s_channel and includes the patch for the Hetzner deprecation of CX11.

Added `csi_driver_smb_version` to kube.tf.example