### PR TITLE
Allow cluster with empty agent pool

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -220,7 +220,7 @@ locals {
 
   # if we are in a single cluster config, we use the default klipper lb instead of Hetzner LB
   control_plane_count    = sum([for v in var.control_plane_nodepools : v.count])
-  agent_count            = sum([for v in var.agent_nodepools : length(coalesce(v.nodes, {})) + coalesce(v.count, 0)])
+  agent_count            = length(var.agent_nodepools) > 0 ? sum([for v in var.agent_nodepools : length(coalesce(v.nodes, {})) + coalesce(v.count, 0)]) : 0
   autoscaler_max_count   = length(var.autoscaler_nodepools) > 0 ? sum([for v in var.autoscaler_nodepools : v.max_nodes]) : 0
   is_single_node_cluster = (local.control_plane_count + local.agent_count + local.autoscaler_max_count) == 1
 

--- a/variables.tf
+++ b/variables.tf
@@ -261,7 +261,7 @@ variable "agent_nodepools" {
   }
 
   validation {
-    condition = sum([for agent_nodepool in var.agent_nodepools : length(coalesce(agent_nodepool.nodes, {})) + coalesce(agent_nodepool.count, 0)]) <= 100
+    condition = length(var.agent_nodepools) == 0 ? true : sum([for agent_nodepool in var.agent_nodepools : length(coalesce(agent_nodepool.nodes, {})) + coalesce(agent_nodepool.count, 0)]) <= 100
     # 154 because the private ip is derived from tonumber(key) + 101. See private_ipv4 in agents.tf
     error_message = "Hetzner does not support networks with more than 100 servers."
   }


### PR DESCRIPTION
I only want autoscaler nodes, no fixed agent pools.

Currently, the count logic in the validation for agent_nodepools errors if agent_nodepools is empty (which is the default). The validation doesn't _fail_, it gives an _error_. The logic for calculating local.agent_count errors the same way.

However, there is not reason why empty agent pools wouldn't work. I used this patch a while in different combinations (single and multiple control planes, with our without autoscaler_nodepools) and everything looks great.