### PR TITLE
Remove superfluous reload of NetworkManager in cloudinit

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1010,11 +1010,6 @@ cloudinit_runcmd_common = <<EOT
 # Disable rebootmgr service as we use kured instead
 - [systemctl, disable, '--now', 'rebootmgr.service']
 
-%{if length(var.dns_servers) > 0}
-# Set the dns manually
-- [systemctl, 'reload', 'NetworkManager']
-%{endif}
-
 # Bounds the amount of logs that can survive on the system
 - [sed, '-i', 's/#SystemMaxUse=/SystemMaxUse=3G/g', /etc/systemd/journald.conf]
 - [sed, '-i', 's/#MaxRetentionSec=/MaxRetentionSec=1week/g', /etc/systemd/journald.conf]


### PR DESCRIPTION
There is already a full restart of NetworkManager at then end of cloudinit_runcmd_common. The commands between the current `reload` and the `restart` a bit longer down don't seem to need the reload.

No errors or misbehavior during my tests.