### PR TITLE
Expose controle plane load balancer ipv4 and ipv6

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -37,6 +37,17 @@ output "ingress_public_ipv6" {
   value       = local.has_external_load_balancer ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : (var.load_balancer_disable_ipv6 ? null : hcloud_load_balancer.cluster[0].ipv6)
 }
 
+output "lb_controle_plane_ipv4" {
+  description = "The public IPv4 address of the Hetzner controle plane load balancer"
+  value       = var.use_control_plane_lb ? hcloud_load_balancer.control_plane[0].ipv4 : null
+}
+
+output "lb_controle_plane_ipv6" {
+  description = "The public IPv6 address of the Hetzner controle plane load balancer"
+  value       = var.use_control_plane_lb ? hcloud_load_balancer.control_plane[0].ipv6 : null
+}
+
+
 output "k3s_endpoint" {
   description = "A controller endpoint to register new nodes"
   value       = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"


### PR DESCRIPTION
`ingress_public_ipv4` and `ingress_public_ipv6` are exposed, but the controle plane load balancer ipv4 and ipv6 are not.
