### PR TITLE
Replace deprecated cert-manager value "installCRDs" by "crds.enabled" and "crds.keep"

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -939,6 +939,7 @@ MTU: 1450
 
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
+  # For cert-manager versions < v1.15.0, you need to set installCRDs: true instead of crds.enabled and crds.keep.
   /*   cert_manager_values = <<EOT
 crds:
   enabled: true

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -940,7 +940,9 @@ MTU: 1450
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   cert_manager_values = <<EOT
-installCRDs: true
+crds:
+  enabled: true
+  keep: true
 replicaCount: 3
 webhook:
   replicaCount: 3

--- a/locals.tf
+++ b/locals.tf
@@ -750,7 +750,9 @@ global:
   EOT
 
 cert_manager_values = var.cert_manager_values != "" ? var.cert_manager_values : <<EOT
-installCRDs: true
+crds:
+  enabled: true
+  keep: true
   EOT
 
 kured_options = merge({

--- a/variables.tf
+++ b/variables.tf
@@ -823,8 +823,12 @@ variable "cert_manager_helmchart_bootstrap" {
 
 variable "cert_manager_values" {
   type        = string
-  default     = ""
-  description = "Additional helm values file to pass to Cert-Manager as 'valuesContent' at the HelmChart."
+  default     = <<EOT
+crds:
+  enabled: true
+  keep: true
+  EOT
+  description = "Additional helm values file to pass to Cert-Manager as 'valuesContent' at the HelmChart. Warning, the default value is only valid from cert-manager v1.15.0 onwards. For older versions, you need to set 'installCRDs: true'."
 }
 
 variable "enable_rancher" {


### PR DESCRIPTION
See https://artifacthub.io/packages/helm/cert-manager/cert-manager/#installcrds-~-bool.

The new crds.enabled and keep were introduced in v1.15: https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0