### PR TITLE
chore(SECURITY.md): add emails

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,7 @@
 ## Reporting a Vulnerability
 
 Please report any vulnerability findings privately via email to the top three contributors to the projects. You can find our emails by grepping the git logs.
+
+In case you can't find the emails:
+
+- [aleksasiriski](https://github.com/aleksasiriski): [sir@tmina.org](mailto:kube-hetzner@sir.tmina.org)


### PR DESCRIPTION
Maybe we should add some emails here so people don't have to grep the git log, in case somebody doesn't know how? Also, I believe that my commits contain only the github's no-reply email so you wouldn't get my email from the git logs.