### PR TITLE
Fix `csi_version` definition when `disable_hetzner_csi = true`

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -261,7 +261,7 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/hcloud-csi.yaml.tpl",
       {
-        version = local.csi_version
+        version = coalesce(local.csi_version, "N/A") 
         values  = indent(4, trimspace(local.hetzner_csi_values))
     })
     destination = "/var/post_install/hcloud-csi.yaml"


### PR DESCRIPTION
ref #1471 

This should have been included in #1471 but it seems it was removed somehow and didn't appear in the release. See also https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/pull/1471#discussion_r1841829125

@mysticaltech 