### PR TITLE
add var `disable_hetzner_ccm`

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,5 @@
 data "github_release" "hetzner_ccm" {
-  count       = var.hetzner_ccm_version == null ? 1 : 0
+  count       = var.hetzner_ccm_version == null && !var.disable_hetzner_ccm ? 1 : 0
   repository  = "hcloud-cloud-controller-manager"
   owner       = "hetznercloud"
   retrieve_by = "latest"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -457,6 +457,8 @@ module "kube-hetzner" {
 
   # To disable Hetzner CSI storage, you can set the following to "true", default is "false".
   # disable_hetzner_csi = true
+  # To disable Hetzner Cloud Controller Manager, you can set the following to "true", default is "false".
+  # disable_hetzner_ccm = true
 
   # If you want to use a specific Hetzner CCM and CSI version, set them below; otherwise, leave them as-is for the latest versions.
   # hetzner_ccm_version = ""

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
   # if given as a variable, we want to use the given token. This is needed to restore the cluster
   k3s_token = var.k3s_token == null ? random_password.k3s_token.result : var.k3s_token
 
-  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
+  ccm_version    = length(data.github_release.hetzner_ccm) == 0 ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version    = length(data.github_release.hetzner_csi) == 0 ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
   kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
   calico_version = length(data.github_release.calico) == 0 ? var.calico_version : data.github_release.calico[0].release_tag
@@ -74,11 +74,12 @@ locals {
     kind       = "Kustomization"
     resources = concat(
       [
-        "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml",
         "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-dockerhub.yaml",
         "https://raw.githubusercontent.com/rancher/system-upgrade-controller/9e7e45c1bdd528093da36be1f1f32472469005e6/manifests/system-upgrade-controller.yaml",
       ],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
+      var.disable_hetzner_ccm ? [] : ["ccm.yaml"],
+      var.disable_hetzner_ccm ? [] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       lookup(local.cni_install_resources, var.cni_plugin, []),
       var.enable_longhorn ? ["longhorn.yaml"] : [],
@@ -87,38 +88,38 @@ locals {
       var.enable_rancher ? ["rancher.yaml"] : [],
       var.rancher_registration_manifest_url != "" ? [var.rancher_registration_manifest_url] : []
     ),
-    patches = [
-      {
-        target = {
-          group     = "apps"
-          version   = "v1"
-          kind      = "Deployment"
-          name      = "system-upgrade-controller"
-          namespace = "system-upgrade"
+    patches = concat(
+      [
+        {
+          target = {
+            group     = "apps"
+            version   = "v1"
+            kind      = "Deployment"
+            name      = "system-upgrade-controller"
+            namespace = "system-upgrade"
+          }
+          patch = file("${path.module}/kustomize/system-upgrade-controller.yaml")
+        },
+        {
+          target = {
+            group     = "apps"
+            version   = "v1"
+            kind      = "Deployment"
+            name      = "system-upgrade-controller"
+            namespace = "system-upgrade"
+          }
+          patch = <<-EOF
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: rancher/system-upgrade-controller:v0.13.4
+          EOF
+        },
+        {
+          path = "kured.yaml"
         }
-        patch = file("${path.module}/kustomize/system-upgrade-controller.yaml")
-      },
-      {
-        target = {
-          group     = "apps"
-          version   = "v1"
-          kind      = "Deployment"
-          name      = "system-upgrade-controller"
-          namespace = "system-upgrade"
-        }
-        patch = <<-EOF
-          - op: replace
-            path: /spec/template/spec/containers/0/image
-            value: rancher/system-upgrade-controller:v0.13.4
-        EOF
-      },
-      {
-        path = "kured.yaml"
-      },
-      {
-        path = "ccm.yaml"
-      }
-    ]
+      ],
+      var.disable_hetzner_ccm ? [] : [{ path = "ccm.yaml" }]
+    )
   })
 
   apply_k3s_selinux = ["/sbin/semodule -v -i /usr/share/selinux/packages/k3s.pp"]

--- a/variables.tf
+++ b/variables.tf
@@ -767,6 +767,12 @@ variable "disable_hetzner_csi" {
   description = "Disable hetzner csi driver."
 }
 
+variable "disable_hetzner_ccm" {
+  type        = bool
+  default     = false
+  description = "Disable hetzner Cloud Controller Manager."
+}
+
 variable "enable_csi_driver_smb" {
   type        = bool
   default     = false


### PR DESCRIPTION
This is needed to allow deploying HCCM standalone which is required when one wants to include robot servers, which is only possible when deploying HCCM using the helm chart due to some helm chart magic.