### PR TITLE
fix Allow setting disable_hetzner_csi = true

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -261,7 +261,12 @@ resource "null_resource" "kustomization" {
     content = templatefile(
       "${path.module}/templates/hcloud-csi.yaml.tpl",
       {
-        version = local.csi_version
+        # local.csi_version is null when disable_hetzner_csi = true
+        # In that case, we set it to "*" so that the templatefile() can handle it,
+        # because tempaltefile() does not support null values. Moreover, coalesce() doesn't
+        # support empty strings either.
+        # The entire file is ignored by kustomization.yaml anyway if disable_hetzner_csi = true.
+        version = coalesce(local.csi_version, "*")
         values  = indent(4, trimspace(local.hetzner_csi_values))
     })
     destination = "/var/post_install/hcloud-csi.yaml"


### PR DESCRIPTION
Fix `templatefile()` call to `hcloud-csi.yaml` when `disable_hetzner_csi=true`

Fixes #1586