### PR TITLE
Add timeout to "waiting for microos to become available"

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -63,11 +63,13 @@ resource "hcloud_server" "server" {
   # Wait for MicroOS to reboot and be ready.
   provisioner "local-exec" {
     command = <<-EOT
-      until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
-      do
-        echo "Waiting for MicroOS to become available..."
-        sleep 3
-      done
+      timeout 600 bash <<EOF
+        until ssh ${local.ssh_args} -i /tmp/${random_string.identity_file.id} -o ConnectTimeout=2 -p ${var.ssh_port} root@${self.ipv4_address} true 2> /dev/null
+        do
+          echo "Waiting for MicroOS to become available..."
+          sleep 3
+        done
+      EOF
     EOT
   }
 


### PR DESCRIPTION
This is a local exec, pinging the server to come up after the installation of microos. Once in a while this goes wrong, and the local script hangs eternally.