### PR TITLE
Upgrade terraform provider versions

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1134,7 +1134,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.43.0"
+      version = ">= 1.49.1"
     }
   }
 }

--- a/modules/host/versions.tf
+++ b/modules/host/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.43.0"
+      version = ">= 1.49.1"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,19 +3,19 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.44.0"
+      version = ">= 6.4.0"
     }
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = ">= 1.43.0"
+      version = ">= 1.49.1"
     }
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4.0"
+      version = ">= 2.5.2"
     }
     remote = {
       source  = "tenstad/remote"
-      version = ">= 0.1.2"
+      version = ">= 0.1.3"
     }
   }
 }


### PR DESCRIPTION
I was running into a one-off bug where the firewall could not be deleted after running terraform destroy (I was also unable to delete the firewall via the `hcloud` cli and had to delete the entire project in the hetzner cloud UI to get rid of it).

I tried upgrading the terraform provider versions and things seemed to work smoothly on the next apply/destroy, however I'm not sure if it was just a fluke.

It may still be worth upgrading these anyway as the hcloud provider has had a number of bug fixes since `1.43.0` ([releases](https://github.com/hetznercloud/terraform-provider-hcloud/releases)).

