### PR TITLE
Fixed Traefik-Values for https redirection.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -654,8 +654,11 @@ service:
 ports:
   web:
 %{if var.traefik_redirect_to_https~}
-    redirectTo:
-      port: websecure
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
 %{endif~}
 %{if !local.using_klipper_lb~}
     proxyProtocol:


### PR DESCRIPTION
The value RedirectTo does not exist anymore.

Using setting `traefik_redirect_to_https = true` Results in following error

`ERROR: redirectTo syntax has been removed in v34 of this Chart. See Release notes or EXAMPLES.md for new syntax.`

Also See: https://github.com/traefik/traefik-helm-chart/pull/1301