### PR TITLE
Update Traefik web port redirection configuration

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1034,8 +1034,11 @@ service:
 
 ports:
   web:
-    redirectTo:
-      port: websecure
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
 
     proxyProtocol:
       trustedIPs:


### PR DESCRIPTION
Fixes #1634 

Modify web port redirection to use new entryPoint syntax with explicit HTTPS permanent redirect