### PR TITLE
SELinux: allow RW access in /var/lib

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -872,7 +872,7 @@ cloudinit_write_files_common = <<EOT
                 >&2 echo "timeout reached"
                 exit 1
             fi
-            # run command and check return code 
+            # run command and check return code
             if $@ ; then
                 >&2 echo "break"
                 break
@@ -979,6 +979,7 @@ cloudinit_write_files_common = <<EOT
     allow container_t { cert_t container_log_t }:dir read;
     allow container_t { cert_t container_log_t }:lnk_file read;
     allow container_t cert_t:file { read open };
+    allow container_t container_var_lib_t:dir { add_name remove_name write read create };
     allow container_t container_var_lib_t:file { create open read write rename lock setattr getattr unlink };
     allow container_t etc_t:dir { add_name remove_name write create setattr watch };
     allow container_t etc_t:file { create setattr unlink write };
@@ -995,7 +996,7 @@ cloudinit_write_files_common = <<EOT
     allow container_t kernel_t:system module_request;
     allow container_t var_log_t:dir { add_name write remove_name watch read };
     allow container_t var_log_t:file { create lock open read setattr write unlink getattr };
-    allow container_t var_lib_t:dir { add_name write read };
+    allow container_t var_lib_t:dir { add_name remove_name write read create };
     allow container_t var_lib_t:file { create lock open read setattr write getattr };
     allow container_t proc_t:filesystem associate;
     allow container_t self:bpf map_create;


### PR DESCRIPTION
This is needed for example for DaemonSets that require hostPath volume mount.