### PR TITLE
Add Udica for easy SELinux

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -732,6 +732,11 @@ module "kube-hetzner" {
   # Ideally you would set your IP there. And if it changes after cluster deploy, you can always update this variable and apply again.
   # firewall_ssh_source = ["1.2.3.4/32"]
 
+  # By default, SELinux is enabled in enforcing mode on all nodes. For container-specific SELinux issues,
+  # consider using the pre-installed 'udica' tool to create custom, targeted SELinux policies instead of 
+  # disabling SELinux globally. See the "Fix SELinux issues with udica" example in the README for details.
+  # disable_selinux = false
+
   # Adding extra firewall rules, like opening a port
   # More info on the format here https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/firewall
   # extra_firewall_rules = [

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -36,7 +36,7 @@ variable "packages_to_install" {
 }
 
 locals {
-  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console audit bind-utils wireguard-tools fuse open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils bash-completion mtr tcpdump"], var.packages_to_install))
+  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console audit bind-utils wireguard-tools fuse open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils bash-completion mtr tcpdump udica"], var.packages_to_install))
 
   # Add local variables for inline shell commands
   download_image = "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only "


### PR DESCRIPTION
- Added detailed instructions in README.md for using the 'udica' tool to create custom SELinux policies, promoting better security practices.
- Updated kube.tf.example to include a note on SELinux enforcement and the use of 'udica' for targeted policies.
- Included 'udica' in the list of needed packages in packer-template/hcloud-microos-snapshots.pkr.hcl to ensure availability during image creation.

Part of #697 

Thanks for the hint @carolosf. 