### PR TITLE
fix(): placement-groups for agents

### DIFF
--- a/placement_groups.tf
+++ b/placement_groups.tf
@@ -53,7 +53,7 @@ resource "hcloud_placement_group" "control_plane_named" {
 }
 
 resource "hcloud_placement_group" "agent" {
-  count  = local.control_plane_placement_compat_groups
+  count  = local.agent_placement_compat_groups
   name   = "${var.cluster_name}-agent-${count.index + 1}"
   labels = local.labels
   type   = "spread"


### PR DESCRIPTION
This PR is suppposed to fix placement-group creation for agent node-pools.

I was struggling to get a cluster up and running with the following node-pools, because there was only 1 placement-group created for my total of 13 agents.

```terraform
  control_plane_nodepools = [
    {
      name        = "control-plane-small-1-${var.location}",
      server_type = "cpx11",
      location    = var.location,
      labels      = [],
      taints      = [],
      count       = 3
    }
  ]

  agent_nodepools = [
    {
      name        = "agent-medium-1-${var.location}",
      server_type = "cpx31",
      location    = var.location,
      labels      = [],
      taints      = [],
      count       = 10
    },
    {
      name        = "agent-large-1-${var.location}",
      server_type = "cpx41",
      location    = var.location,
      labels      = [],
      taints      = [],
      count       = 3
    }
  ]
```