### PR TITLE
Make Kustomization folder configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For Traefik, Nginx, HAProxy, Rancher, Cilium, Traefik, and Longhorn, for maximum
 
 If you need to install additional Helm charts or Kubernetes manifests that are not provided by default, you can easily do so by using [Kustomize](https://kustomize.io). This is done by creating one or more `extra-manifests/kustomization.yaml.tpl` files beside your `kube.tf`.
 
+If you'd like to use a different folder name, you can configure it using the `extra_kustomize_folder` variable. By default, it is set to `extra-manifests`. This can be useful when working with multiple environments, allowing you to deploy different manifests for each one.
+
 These files need to be valid `Kustomization` manifests, additionally supporting terraform templating! (The templating parameters can be passed via the `extra_kustomize_parameters` variable (via a map) to the module).
 
 All files in the `extra-manifests` directory and its subdirectories including the rendered versions of the `*.yaml.tpl` will be applied to k3s with `kubectl apply -k` (which will be executed after and independently of the basic cluster configuration).

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -1,5 +1,5 @@
 locals {
-  user_kustomization_templates = try(fileset("extra-manifests", "**/*.yaml.tpl"), toset([]))
+  user_kustomization_templates = try(fileset(var.extra_kustomize_folder, "**/*.yaml.tpl"), toset([]))
 }
 
 resource "null_resource" "kustomization_user" {
@@ -20,12 +20,12 @@ resource "null_resource" "kustomization_user" {
   }
 
   provisioner "file" {
-    content     = templatefile("extra-manifests/${each.key}", var.extra_kustomize_parameters)
+    content     = templatefile("${var.extra_kustomize_folder}/${each.key}", var.extra_kustomize_parameters)
     destination = replace("/var/user_kustomize/${each.key}", ".yaml.tpl", ".yaml")
   }
 
   triggers = {
-    manifest_sha1 = "${sha1(templatefile("extra-manifests/${each.key}", var.extra_kustomize_parameters))}"
+    manifest_sha1 = "${sha1(templatefile("${var.extra_kustomize_folder}/${each.key}", var.extra_kustomize_parameters))}"
   }
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -1033,6 +1033,12 @@ variable "extra_kustomize_parameters" {
   description = "All values will be passed to the `kustomization.tmp.yml` template."
 }
 
+variable "extra_kustomize_folder" {
+  type        = string
+  default     = "extra-manifests"
+  description = "Folder from where to upload extra manifests"
+}
+
 variable "create_kubeconfig" {
   type        = bool
   default     = true


### PR DESCRIPTION
If you'd like to use a different folder name, you can configure it using the extra_kustomize_folder variable. By default, it is set to extra-manifests. This can be useful when working with multiple environments, allowing you to deploy different manifests for each one.