### PR TITLE
feat: enable nodeEncryption in cilium_values when wireguard is enabled

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -498,6 +498,7 @@ bpf:
 %{if var.enable_wireguard}
 encryption:
   enabled: true
+  # Enable node encryption for node-to-node traffic
   nodeEncryption: true
   type: wireguard
 %{endif~}

--- a/locals.tf
+++ b/locals.tf
@@ -498,6 +498,7 @@ bpf:
 %{if var.enable_wireguard}
 encryption:
   enabled: true
+  nodeEncryption: true
   type: wireguard
 %{endif~}
 %{if var.cilium_egress_gateway_enabled}


### PR DESCRIPTION
The change enables encryption for pure node to node traffic when WireGuard is in Cilium.