### PR TITLE
Feature(CCM): Provide a flag to install CCM using helm

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -219,9 +219,9 @@ resource "null_resource" "kustomization" {
     destination = "/var/post_install/haproxy_ingress.yaml"
   }
 
-  # Upload the CCM patch config
+  # Upload the CCM patch config using the legacy deployment
   provisioner "file" {
-    content = templatefile(
+    content = var.hetzner_ccm_use_helm ? "" : templatefile(
       "${path.module}/templates/ccm.yaml.tpl",
       {
         cluster_cidr_ipv4   = var.cluster_ipv4_cidr
@@ -229,6 +229,20 @@ resource "null_resource" "kustomization" {
         using_klipper_lb    = local.using_klipper_lb
     })
     destination = "/var/post_install/ccm.yaml"
+  }
+
+  # Upload the CCM patch config using helm
+  provisioner "file" {
+    content = var.hetzner_ccm_use_helm ? templatefile(
+      "${path.module}/templates/hcloud-ccm-helm.yaml.tpl",
+      {
+        version             = coalesce(local.ccm_version, "*")
+        using_klipper_lb    = local.using_klipper_lb
+        default_lb_location = var.load_balancer_location
+
+      }
+    ) : ""
+    destination = "/var/post_install/hcloud-ccm-helm.yaml"
   }
 
   # Upload the calico patch config, for the kustomization of the calico manifest

--- a/init.tf
+++ b/init.tf
@@ -394,7 +394,7 @@ resource "null_resource" "kustomization" {
         "echo 'Remove legacy ccm manifests if they exist'",
         "kubectl delete serviceaccount,deployment -n kube-system --field-selector 'metadata.name=hcloud-cloud-controller-manager' --selector='app.kubernetes.io/managed-by!=Helm'",
         "kubectl delete clusterrolebinding -n kube-system --field-selector 'metadata.name=system:hcloud-cloud-controller-manager' --selector='app.kubernetes.io/managed-by!=Helm'",
-      ] : [
+        ] : [
         "echo 'Uninstall helm ccm manifests if they exist'",
         "kubectl delete --ignore-not-found -n kube-system helmchart.helm.cattle.io/hcloud-cloud-controller-manager",
       ],

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -487,6 +487,10 @@ module "kube-hetzner" {
   # If you want to use a specific Hetzner CCM and CSI version, set them below; otherwise, leave them as-is for the latest versions.
   # See https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases for the available versions.
   # hetzner_ccm_version = ""
+
+  # By default, new installationsπ use Helm to install Hetzner CCM. You can use the legacy deployment method (using `kubectl apply`) by setting `hetzner_ccm_use_helm = false`.
+  hetzner_ccm_use_helm = true
+
   # See https://github.com/hetznercloud/csi-driver/releases for the available versions.
   # hetzner_csi_version = ""
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -488,7 +488,7 @@ module "kube-hetzner" {
   # See https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases for the available versions.
   # hetzner_ccm_version = ""
 
-  # By default, new installationsπ use Helm to install Hetzner CCM. You can use the legacy deployment method (using `kubectl apply`) by setting `hetzner_ccm_use_helm = false`.
+  # By default, new installations use Helm to install Hetzner CCM. You can use the legacy deployment method (using `kubectl apply`) by setting `hetzner_ccm_use_helm = false`.
   hetzner_ccm_use_helm = true
 
   # See https://github.com/hetznercloud/csi-driver/releases for the available versions.

--- a/templates/hcloud-ccm-helm.yaml.tpl
+++ b/templates/hcloud-ccm-helm.yaml.tpl
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  chart: hcloud-cloud-controller-manager
+  repo: https://charts.hetzner.cloud
+  version: "${version}"
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    networking:
+      enabled: "true"
+    args:
+      cloud-provider: hcloud
+      allow-untagged-cloud: ""
+      route-reconciliation-period: 30s
+      webhook-secure-port: "0"
+      ${using_klipper_lb ? "secure-port: \"10288\"" : ""}
+    env:
+      HCLOUD_LOAD_BALANCERS_LOCATION:
+        value: "${default_lb_location}"
+      HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+        value: "true"
+      HCLOUD_LOAD_BALANCERS_ENABLED:
+        value: "${!using_klipper_lb}"
+      HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
+        value: "true"

--- a/variables.tf
+++ b/variables.tf
@@ -365,6 +365,12 @@ variable "hetzner_ccm_version" {
   description = "Version of Kubernetes Cloud Controller Manager for Hetzner Cloud. See https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases for the available versions."
 }
 
+variable "hetzner_ccm_use_helm" {
+  type        = bool
+  default     = false
+  description = "Whether to use the helm chart for the Hetzner CCM or the legacy manifest which is the default."
+}
+
 variable "hetzner_csi_version" {
   type        = string
   default     = null


### PR DESCRIPTION
The `kubectl apply` to install ccm is [considered legacy](https://github.com/hetznercloud/hcloud-cloud-controller-manager/?tab=readme-ov-file#deployment) and using the helm version seems to be on the path forward supporting robots servers in this project.
This pull request adds a flag to use the helm version instead of `kubectl apply`. I'm not sure if we can provide a smooth upgrade or if that should be leaved to the end user.