### PR TITLE
Feat(packer): Install qemu-guest-agent

### DIFF
--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -36,7 +36,7 @@ variable "packages_to_install" {
 }
 
 locals {
-  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console audit bind-utils wireguard-tools fuse open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils bash-completion mtr tcpdump udica"], var.packages_to_install))
+  needed_packages = join(" ", concat(["restorecond policycoreutils policycoreutils-python-utils setools-console audit bind-utils wireguard-tools fuse open-iscsi nfs-client xfsprogs cryptsetup lvm2 git cifs-utils bash-completion mtr tcpdump udica qemu-guest-agent"], var.packages_to_install))
 
   # Add local variables for inline shell commands
   download_image = "wget --timeout=5 --waitretry=5 --tries=5 --retry-connrefused --inet4-only "


### PR DESCRIPTION
This tiny PR installs qemu-guest-agent, to allow the password reset to work in hetzner GUI.

It may be useful in case of emergency (ssh key lost, using console in hetzner, ...)