### PR TITLE
Add missing version variables to kustomization triggers

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -163,6 +163,11 @@ resource "null_resource" "kustomization" {
       coalesce(var.traefik_version, "N/A"),
       coalesce(var.nginx_version, "N/A"),
       coalesce(var.haproxy_version, "N/A"),
+      coalesce(var.cert_manager_version, "N/A"),
+      coalesce(var.csi_driver_smb_version, "N/A"),
+      coalesce(var.longhorn_version, "N/A"),
+      coalesce(var.rancher_version, "N/A"),
+      coalesce(var.sys_upgrade_controller_version, "N/A"),
     ])
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"


### PR DESCRIPTION
## Background

I explicitly pin certain versions. When I changed `var.longhorn_version` from `v1.8.0` to `v1.8.1`, I noticed that the new version was not deployed.

## Observation

`var.longhorn_version` and other version variables are not part of the deployment triggers.

## Proposed fix

Add any missing version variables to the list of deployment triggers.