### PR TITLE
Create IPv6 reverse DNS records for dual-stack servers

### DIFF
--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -144,10 +144,18 @@ resource "null_resource" "registries" {
 }
 
 resource "hcloud_rdns" "server" {
-  count = (var.base_domain != "" && !(var.disable_ipv4 && var.disable_ipv6)) ? 1 : 0
+  count = (var.base_domain != "" && !var.disable_ipv4) ? 1 : 0
 
   server_id  = hcloud_server.server.id
-  ip_address = coalesce(hcloud_server.server.ipv4_address, hcloud_server.server.ipv6_address, try(one(hcloud_server.server.network).ip, null))
+  ip_address = coalesce(hcloud_server.server.ipv4_address, try(one(hcloud_server.server.network).ip, null))
+  dns_ptr    = format("%s.%s", local.name, var.base_domain)
+}
+
+resource "hcloud_rdns" "server_ipv6" {
+  count = (var.base_domain != "" && !var.disable_ipv6) ? 1 : 0
+
+  server_id  = hcloud_server.server.id
+  ip_address = hcloud_server.server.ipv6_address
   dns_ptr    = format("%s.%s", local.name, var.base_domain)
 }
 


### PR DESCRIPTION
## Background

The servers are dual-stack (each server has an IPv4 address and an IPv6 address).

## Observation

If there is an IPv4 address, a reverse DNS record for IPv4 is created as expected.
If there is also an IPv6 address, the corresponding resource record for the IPv6 address is missing.

## Proposed fix

Create reverse DNS records for all enabled IP protocols.