### PR TITLE
fix too many colons error due to ipv6

### DIFF
--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -1,10 +1,6 @@
-locals {
-  is_ipv6_address = strcontains(local.first_control_plane_ip, ":") && !strcontains(local.first_control_plane_ip, ".")
-}
-
 data "remote_file" "kubeconfig" {
   conn {
-    host        = local.is_ipv6_address ? "[${local.first_control_plane_ip}]" : local.first_control_plane_ip
+    host        = can(ipv6(local.first_control_plane_ip)) ? "[${local.first_control_plane_ip}]" : local.first_control_plane_ip
     port        = var.ssh_port
     user        = "root"
     private_key = var.ssh_private_key

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -4,11 +4,11 @@ locals {
 
 data "remote_file" "kubeconfig" {
   conn {
-    host = local.is_ipv6_address ? "[${local.first_control_plane_ip}]" : local.first_control_plane_ip
-    port = var.ssh_port
-    user = "root"
+    host        = local.is_ipv6_address ? "[${local.first_control_plane_ip}]" : local.first_control_plane_ip
+    port        = var.ssh_port
+    user        = "root"
     private_key = var.ssh_private_key
-    agent = var.ssh_private_key == null
+    agent       = var.ssh_private_key == null
   }
   path = "/etc/rancher/k3s/k3s.yaml"
 

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -1,10 +1,14 @@
+locals {
+  is_ipv6_address = strcontains(local.first_control_plane_ip, ":") && !strcontains(local.first_control_plane_ip, ".")
+}
+
 data "remote_file" "kubeconfig" {
   conn {
-    host        = local.first_control_plane_ip
-    port        = var.ssh_port
-    user        = "root"
+    host = local.is_ipv6_address ? "[${local.first_control_plane_ip}]" : local.first_control_plane_ip
+    port = var.ssh_port
+    user = "root"
     private_key = var.ssh_private_key
-    agent       = var.ssh_private_key == null
+    agent = var.ssh_private_key == null
   }
   path = "/etc/rancher/k3s/k3s.yaml"
 


### PR DESCRIPTION
With an ipv6-only node, I received this error after trying to apply a change which needed to destroy a node in the cluster.

```
│ Error: unable to open remote client: couldn't establish a connection to the remote server 'root@<redacted_ip>:1:22': dial tcp: address <redacted_ip>:1:22: too many colons in address
│ 
│   with module.kube-hetzner.data.remote_file.kubeconfig,
│   on .terraform/modules/kube-hetzner/kubeconfig.tf line 1, in data "remote_file" "kubeconfig":
│    1: data "remote_file" "kubeconfig" {
```