### PR TITLE
Do not schedule CSI pods on control-plane by default

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -568,6 +568,14 @@ persistence:
   EOT
 
   hetzner_csi_values = var.hetzner_csi_values != "" ? var.hetzner_csi_values : <<EOT
+node:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: DoesNotExist
   EOT
 
   nginx_values = var.nginx_values != "" ? var.nginx_values : <<EOT

--- a/locals.tf
+++ b/locals.tf
@@ -574,7 +574,7 @@ persistence:
   csi_driver_smb_values = var.csi_driver_smb_values != "" ? var.csi_driver_smb_values : <<EOT
   EOT
 
-  hetzner_csi_values = var.hetzner_csi_values != "" ? var.hetzner_csi_values : <<EOT
+  hetzner_csi_values = var.hetzner_csi_values != "" ? var.hetzner_csi_values : (!local.allow_scheduling_on_control_plane ? <<-EOT
 node:
   affinity:
     nodeAffinity:
@@ -583,7 +583,8 @@ node:
           - matchExpressions:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: DoesNotExist
-  EOT
+EOT
+  : "")
 
   nginx_values = var.nginx_values != "" ? var.nginx_values : <<EOT
 controller:


### PR DESCRIPTION
According to example in official Hetzner repo it's a good approach to follow, WDYT?

https://github.com/hetznercloud/csi-driver/blob/018e2478d98b8f81a79f3d1a2c846decb8e4de6a/chart/example-prod.values.yaml#L81


P.S.
Tried to follow contribution guide, but did not find `staging` branch
> 7. Open a Pull Request targeting the staging branch.