### PR TITLE
cloud-init: Remove invalid "debug" key

### DIFF
--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -1,7 +1,5 @@
 #cloud-config
 
-debug: True
-
 write_files:
 
 ${cloudinit_write_files_common}


### PR DESCRIPTION
Fixes issue that resulted in cloud-init not running:

>  Error: Cloud config schema errors: debug: Additional properties are not allowed ('debug' was unexpected)