### PR TITLE
Fix: Apply var.agent_nodes_custom_config to autoscale nodes

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -289,13 +289,19 @@ module "kube-hetzner" {
       }
     },
   ]
-  # Add custom control plane configuration options here.
+  # Add additional configuration options for control planes here.
   # E.g to enable monitoring for etcd, proxy etc:
   # control_planes_custom_config = {
   #  etcd-expose-metrics = true,
   #  kube-controller-manager-arg = "bind-address=0.0.0.0",
   #  kube-proxy-arg ="metrics-bind-address=0.0.0.0",
   #  kube-scheduler-arg = "bind-address=0.0.0.0",
+  # }
+
+  # Add additional configuration options for agent nodes and autoscaler nodes here.
+  # E.g to enable monitoring for proxy:
+  # agent_nodes_custom_config = {
+  #  kube-proxy-arg ="metrics-bind-address=0.0.0.0",
   # }
 
   # You can enable encrypted wireguard for the CNI by setting this to "true". Default is "false".

--- a/variables.tf
+++ b/variables.tf
@@ -1072,13 +1072,13 @@ variable "enable_wireguard" {
 variable "control_planes_custom_config" {
   type        = any
   default     = {}
-  description = "Custom control plane configuration e.g to allow etcd monitoring."
+  description = "Additional configuration for control planes that will be added to k3s's config.yaml. E.g to allow etcd monitoring."
 }
 
 variable "agent_nodes_custom_config" {
   type        = any
   default     = {}
-  description = "Custom agent nodes configuration. Applied to the agend nodes and the autoscaler nodes."
+  description = "Additional configuration for agent nodes and autoscaler nodes that will be added to k3s's config.yaml. E.g to allow kube-proxy monitoring."
 }
 
 variable "k3s_registries" {

--- a/variables.tf
+++ b/variables.tf
@@ -1078,7 +1078,7 @@ variable "control_planes_custom_config" {
 variable "agent_nodes_custom_config" {
   type        = any
   default     = {}
-  description = "Custom agent nodes configuration."
+  description = "Custom agent nodes configuration. Applied to the agend nodes and the autoscaler nodes."
 }
 
 variable "k3s_registries" {


### PR DESCRIPTION
`var.agent_nodes_custom_config` is applied to the k3s config.yaml for nodes created for the `agent_nodepools`. However, it was not applied to nodes created by the autoscaler. So it was impossible to configure autoscaler nodes to expose their kube-proxy metrics.

This PR applies `var.agent_nodes_custom_config` to nodes created by the autoscaler as well. I think we don't need a separate variable for that: worker nodes are worker nodes, whether they are created by static `agent_nodepools` or dynamically at runtime by `autoscaler_nodepools`.

I added `agent_nodepools` to `kube.tf.example` as well and slightly improved the doc.