### PR TITLE
Fix missing `volumeattachments` permission for autoscaler clusterrole

### DIFF
--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -40,6 +40,7 @@ rules:
       - "replicationcontrollers"
       - "persistentvolumeclaims"
       - "persistentvolumes"
+      - "volumeattachments"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["extensions"]
     resources: ["replicasets", "daemonsets"]


### PR DESCRIPTION
fix #1694

ref: https://github.com/kubernetes/autoscaler/pull/7904