### PR TITLE
Fix custom DNS servers

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -50,8 +50,6 @@ locals {
       hcloud_servers.autoscaled_nodes : [for v in v.servers : v]
     ]...) : v.name => v
   }
-
-  has_dns_servers = length(var.dns_servers) > 0 ? true : false
 }
 
 resource "null_resource" "configure_autoscaler" {

--- a/variables.tf
+++ b/variables.tf
@@ -1000,6 +1000,11 @@ variable "dns_servers" {
     condition     = length(var.dns_servers) <= 3
     error_message = "The list must have no more than 3 items."
   }
+
+  validation {
+    condition     = alltrue([for ip in var.dns_servers : provider::assert::ip(ip)])
+    error_message = "Some IP addresses are incorrect."
+  }
 }
 
 variable "address_for_connectivity_test" {

--- a/versions.tf
+++ b/versions.tf
@@ -17,5 +17,9 @@ terraform {
       source  = "tenstad/remote"
       version = ">= 0.1.3"
     }
+    assert = {
+      source  = "hashicorp/assert"
+      version = ">= 0.16.0"
+    }
   }
 }


### PR DESCRIPTION
Previously the DNS servers were set in the cloud-init only, which worked for the initial server bootstrap, but later these DNS servers get replaced by NetworkManager.

This patch fixes this behaviour by saving the custom DNS servers in NetworkManager which has the added benefit of enabling user to change it after deployment.