### PR TITLE
Fix external load balancer configuration for agent-less clusters

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -23,7 +23,11 @@ resource "hcloud_load_balancer_network" "cluster" {
   count = local.has_external_load_balancer ? 0 : 1
 
   load_balancer_id = hcloud_load_balancer.cluster.*.id[0]
-  subnet_id        = hcloud_network_subnet.agent.*.id[0]
+  subnet_id = (
+    length(hcloud_network_subnet.agent) > 0
+    ? hcloud_network_subnet.agent.*.id[0]
+    : hcloud_network_subnet.control_plane.*.id[0]
+  )
 }
 
 resource "hcloud_load_balancer_target" "cluster" {


### PR DESCRIPTION
For small but HA clusters (i.e., 3 control plane nodes with `allow_scheduling_on_control_plane=true`) it was not possible to create external load balancer.

1. The first patch fixes an issue where the external load balancer couldn't be created because of wrong subnet association. Previously it tried to take a subnet from the first agent node, but as in this configuration there are no agents, there was an error during LB declaration.

2. Second issue was with the LB node association due to wrong label selector. Previously control plane nodes were omitted from external load balancer label selector as the "role" tag was overwritten by agent node. It resulted in the following label selector:

   `cluster=...,engine=k3s,provisioner=terraform,role=agent_node`

   The patch fixes the selector to include the control plane nodes thus fixing the load balancer association in case of agent-less HA clusters. Hetzner allows "or" selector in the following form:

   `cluster=...,engine=k3s,provisioner=terraform,role in (control_plane_node,agent_node)`


