### PR TITLE
Enable gradual roll-out on Cilium config update

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -485,6 +485,9 @@ ipv4NativeRoutingCIDR: "${local.cilium_ipv4_native_routing_cidr}"
 installNoConntrackIptablesRules: true
 %{endif~}
 
+# Perform a gradual roll out on config update.
+rollOutCiliumPods: true
+
 endpointRoutes:
   # Enable use of per endpoint routes instead of routing via the cilium_host interface.
   enabled: true


### PR DESCRIPTION
This ensures automatic pod restart with a new configuration in case of changed values, which makes the deployment easier to manage.

Noted as the way to go when modifying configuration with Helm (https://docs.cilium.io/en/stable/configuration/index.html#making-changes).