### PR TITLE
Add output with domain associations to IPs

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -264,6 +264,7 @@
 | <a name="output_control_planes_public_ipv4"></a> [control\_planes\_public\_ipv4](#output\_control\_planes\_public\_ipv4) | The public IPv4 addresses of the controlplane servers. |
 | <a name="output_control_planes_public_ipv6"></a> [control\_planes\_public\_ipv6](#output\_control\_planes\_public\_ipv6) | The public IPv6 addresses of the controlplane servers. |
 | <a name="output_csi_driver_smb_values"></a> [csi\_driver\_smb\_values](#output\_csi\_driver\_smb\_values) | Helm values.yaml used for SMB CSI driver |
+| <a name="output_domain_assignments"></a> [domain\_assignments](#output\_domain\_assignments) | Assignments of domains to IPs based on reverse DNS |
 | <a name="output_haproxy_values"></a> [haproxy\_values](#output\_haproxy\_values) | Helm values.yaml used for HAProxy |
 | <a name="output_ingress_public_ipv4"></a> [ingress\_public\_ipv4](#output\_ingress\_public\_ipv4) | The public IPv4 address of the Hetzner load balancer (with fallback to first control plane node) |
 | <a name="output_ingress_public_ipv6"></a> [ingress\_public\_ipv6](#output\_ingress\_public\_ipv6) | The public IPv6 address of the Hetzner load balancer (with fallback to first control plane node) |

--- a/modules/host/out.tf
+++ b/modules/host/out.tf
@@ -17,3 +17,13 @@ output "name" {
 output "id" {
   value = hcloud_server.server.id
 }
+
+output "domain_assignments" {
+  description = "Assignment of domain to the primary IP of the server"
+  value = [
+    for rdns in hcloud_rdns.server : {
+      domain = rdns.dns_ptr
+      ips    = [rdns.ip_address]
+    }
+  ]
+}

--- a/output.tf
+++ b/output.tf
@@ -83,6 +83,22 @@ output "agent_nodes" {
   value       = [for node in module.agents : node]
 }
 
+output "domain_assignments" {
+  description = "Assignments of domains to IPs based on reverse DNS"
+  value = concat(
+    # Propagate domain assignments from control plane and agent nodes.
+    flatten([
+      for node in concat(values(module.control_planes), values(module.agents)) :
+      node.domain_assignments
+    ]),
+    # Get assignments from floating IPs.
+    [for rdns in hcloud_rdns.agents : {
+      domain = rdns.dns_ptr
+      ips    = [rdns.ip_address]
+    }]
+  )
+}
+
 # Keeping for backward compatibility
 output "kubeconfig_file" {
   value       = local.kubeconfig_external


### PR DESCRIPTION
It allows for easy integration with DNS terraform module to dynamically create DNS records based on the current cluster configuration.

It will be extended with IPv6 once #1704 gets addressed and #1739 gets merged.