### PR TITLE
fix: Allow any type for extra_kustomize_parameters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1047,7 +1047,7 @@ variable "extra_kustomize_deployment_commands" {
 }
 
 variable "extra_kustomize_parameters" {
-  type        = map(any)
+  type        = any
   default     = {}
   description = "All values will be passed to the `kustomization.tmp.yml` template."
 }


### PR DESCRIPTION
This change relaxes the type constraint on the 'extra_kustomize_parameters' variable from map(any) to any. This allows passing a map with mixed value types, such as strings and objects, which is a common use case for kustomize parameters. This change is fully backward compatible. Fixes #1679