### PR TITLE
Fix: SSH firewall rule not disabled when set to null

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -304,17 +304,6 @@ locals {
         source_ips  = var.firewall_ssh_source
       },
     ],
-    var.ssh_port != null &&
-    var.firewall_ssh_source == null ? [
-      # Allow all traffic to the ssh port
-      {
-        description = "Allow Incoming SSH Traffic"
-        direction   = "in"
-        protocol    = "tcp"
-        port        = var.ssh_port
-        source_ips  = ["0.0.0.0/0", "::/0"]
-      },
-    ] : [],
     var.firewall_kube_api_source == null ? [] : [
       {
         description = "Allow Incoming Requests to Kube API Server"


### PR DESCRIPTION
This PR fixes issue #1707.

The previous logic in `locals.tf` incorrectly added a default firewall rule for SSH even when `firewall_ssh_source` was explicitly set to `null`. This exposed the SSH port unintentionally.

This change removes the redundant and incorrect block, ensuring that setting `firewall_ssh_source = null` correctly disables the SSH firewall rule, as was the original intention. The default behavior of allowing SSH from all sources when the variable is not set remains unchanged.