### PR TITLE
fix(traefik): Correctly handle web entrypoint for single-node clusters

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -682,6 +682,7 @@ service:
 %{endif~}
 %{endif~}
 ports:
+%{if var.traefik_redirect_to_https || !local.using_klipper_lb~}
   web:
 %{if var.traefik_redirect_to_https~}
     redirections:
@@ -705,7 +706,10 @@ ports:
 %{for ip in var.traefik_additional_trusted_ips~}
         - "${ip}"
 %{endfor~}
+%{endif~}
+%{endif~}
   websecure:
+%{if !local.using_klipper_lb~}
     proxyProtocol:
       trustedIPs:
         - 127.0.0.1/32


### PR DESCRIPTION
This PR fixes the issue reported in #1721.

In single-node clusters, or any cluster using klipper-lb instead of a Hetzner Load Balancer, the Traefik `web` entrypoint configuration was being generated as an empty block if HTTPS redirection was disabled. This caused Traefik to fail to listen on port 80.

This fix makes the generation of the `web` entrypoint conditional. It will now only be created if HTTPS redirection is enabled OR if the cluster is not using klipper-lb. This ensures a valid configuration in all scenarios and is fully backward-compatible.