### PR TITLE
fix: change default connectivity test address to 8.8.8.8

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1021,9 +1021,9 @@ variable "dns_servers" {
 }
 
 variable "address_for_connectivity_test" {
+  description = "The address to test for external connectivity before proceeding with the installation. Defaults to Cloudflare's public DNS."
   type        = string
-  default     = "1.1.1.1"
-  description = "Before installing k3s, we actually verify that there is internet connectivity. By default we ping 1.1.1.1, but if you use a proxy, you may simply want to ping that proxy instead (assuming that the proxy has its own checks for internet connectivity)."
+  default     = "8.8.8.8"
 }
 
 variable "additional_k3s_environment" {

--- a/variables.tf
+++ b/variables.tf
@@ -1021,7 +1021,7 @@ variable "dns_servers" {
 }
 
 variable "address_for_connectivity_test" {
-  description = "The address to test for external connectivity before proceeding with the installation. Defaults to Cloudflare's public DNS."
+  description = "The address to test for external connectivity before proceeding with the installation. Defaults to Google's public DNS."
   type        = string
   default     = "8.8.8.8"
 }


### PR DESCRIPTION
## Description

This PR changes the default `address_for_connectivity_test` from `1.1.1.1` to `8.8.8.8` to resolve timeout issues in the `nbg1` location.

## Problem

Users were experiencing `remote-exec provisioner error` with exit code 124 when provisioning servers in the `nbg1` location. The error occurs during the connectivity test that pings `1.1.1.1` before downloading k3s.

## Solution

- Changed the default value of `address_for_connectivity_test` from `1.1.1.1` (Cloudflare DNS) to `8.8.8.8` (Google DNS)
- This should provide better connectivity reliability in the `nbg1` datacenter

## Testing

This change maintains backward compatibility as users can still override the variable if needed.

Fixes #1762