### PR TITLE
feat: Add k3s_prefer_bundled_bin option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ issue_fix.patch
 
 # AI related files
 CLAUDE.md
+
+# Misc
+.DS_Store

--- a/agents.tf
+++ b/agents.tf
@@ -64,6 +64,7 @@ locals {
       node-taint    = v.taints
     },
     var.agent_nodes_custom_config,
+    local.prefer_bundled_bin_config,
     # Force selinux=false if disable_selinux = true.
     var.disable_selinux
     ? { selinux = false }

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -116,7 +116,8 @@ data "cloudinit_config" "autoscaler_config" {
             node-taint    = concat(local.default_agent_taints, [for taint in var.autoscaler_nodepools[count.index].taints : "${taint.key}=${tostring(taint.value)}:${taint.effect}"])
             selinux       = !var.disable_selinux
           },
-          var.agent_nodes_custom_config
+          var.agent_nodes_custom_config,
+          local.prefer_bundled_bin_config
         ))
         install_k3s_agent_script     = join("\n", concat(local.install_k3s_agent, ["systemctl start k3s-agent"]))
         cloudinit_write_files_common = local.cloudinit_write_files_common
@@ -154,7 +155,8 @@ data "cloudinit_config" "autoscaler_legacy_config" {
             node-taint    = concat(local.default_agent_taints, var.autoscaler_taints)
             selinux       = !var.disable_selinux
           },
-          var.agent_nodes_custom_config
+          var.agent_nodes_custom_config,
+          local.prefer_bundled_bin_config
         ))
         install_k3s_agent_script     = join("\n", concat(local.install_k3s_agent, ["systemctl start k3s-agent"]))
         cloudinit_write_files_common = local.cloudinit_write_files_common

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -143,7 +143,8 @@ locals {
       var.additional_tls_sans)
     },
     local.etcd_s3_snapshots,
-    var.control_planes_custom_config
+    var.control_planes_custom_config,
+    local.prefer_bundled_bin_config
   ) }
 }
 

--- a/init.tf
+++ b/init.tf
@@ -109,7 +109,8 @@ resource "null_resource" "first_control_plane" {
         },
         local.etcd_s3_snapshots,
         var.control_planes_custom_config,
-        (local.control_plane_nodes[keys(module.control_planes)[0]].selinux == true ? { selinux = true } : {})
+        (local.control_plane_nodes[keys(module.control_planes)[0]].selinux == true ? { selinux = true } : {}),
+        local.prefer_bundled_bin_config
       )
     )
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -732,7 +732,8 @@ module "kube-hetzner" {
   #         prefix: "oidc:"
   #   EOT
 
-
+  # Set to true if util-linux breaks on the OS (temporary regression fixed in util-linux v2.41.1).
+  # k3s_prefer_bundled_bin = true
 
   # Additional flags to pass to the k3s server command (the control plane).
   # k3s_exec_server_args = "--kube-apiserver-arg enable-admission-plugins=PodTolerationRestriction,PodNodeSelector"

--- a/locals.tf
+++ b/locals.tf
@@ -430,6 +430,8 @@ locals {
     "cilium" = ["cilium.yaml"]
   }
 
+  prefer_bundled_bin_config = var.k3s_prefer_bundled_bin ? { "prefer-bundled-bin" = true } : {}
+
   cni_install_resource_patches = {
     "calico" = ["calico.yaml"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1129,6 +1129,12 @@ variable "k3s_exec_agent_args" {
   description = "Agents nodes are started with `k3s agent {k3s_exec_agent_args}`. Use this to add kubelet-arg for example."
 }
 
+variable "k3s_prefer_bundled_bin" {
+  type        = bool
+  default     = false
+  description = "Whether to use the bundled k3s mount binary instead of the one from the distro's util-linux package."
+}
+
 variable "k3s_global_kubelet_args" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
This pull request introduces a new boolean variable `k3s_prefer_bundled_bin` (defaulting to `false`).

When set to `true`, it adds `prefer-bundled-bin: true` to the `config.yaml` for all k3s nodes (control-plane, agents, and autoscaler nodes).

This resolves an issue with `util-linux`'s mount binary on some operating systems, as discussed in issue #1780.

The `kube.tf.example` file has been updated to document this new option.