### PR TITLE
fix: https port in single node cluster (closes #1790)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -719,8 +719,8 @@ ports:
 %{endfor~}
 %{endif~}
 %{endif~}
-  websecure:
 %{if !local.using_klipper_lb~}
+  websecure:
     proxyProtocol:
       trustedIPs:
         - 127.0.0.1/32


### PR DESCRIPTION
Should fix #1790 and I don't see any side effects, but please bear in mind that I only tested this in single cluster mode. 