### PR TITLE
feat: add support & docs for adding Hetzner Robot servers as nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To achieve this, we built up on the shoulders of giants by choosing [openSUSE Mi
 - [x] Optional use of **Floating IPs** for use via Cilium's Egress Gateway.
 - [x] Proper IPv6 support for inbound/outbound traffic.
 - [x] **Flexible configuration options** via variables and an extra Kustomization option.
+- [x] Ability to add Hetzner "Robot" / Dedicated servers as nodes
 
 _It uses Terraform to deploy as it's easy to use, and Hetzner has a great [Hetzner Terraform Provider](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs)._
 
@@ -287,6 +288,10 @@ Most cluster components of Kube-Hetzner are deployed with the Rancher [Helm Char
 By default, we strive to give you optimal defaults, but if you wish, you can customize them.
 
 For Traefik, Nginx, HAProxy, Rancher, Cilium, Traefik, and Longhorn, for maximum flexibility, we give you the ability to configure them even better via helm values variables (e.g. `cilium_values`, see the advanced section in the kube.tf.example for more).
+
+## Adding Hetzner Robot / Dedicated Servers
+
+See the [guide on adding robot servers](docs/add-robot-server.md)
 
 ## Adding Extras
 

--- a/docs/add-robot-server.md
+++ b/docs/add-robot-server.md
@@ -41,22 +41,25 @@ It covers configuration for both k3s and Robot nodes, including networking, conf
 
 Assumptions (change these to your values!):
 - vSwitch subnet: `10.1.0.0/24`
-- vSwitch ID: `4022`
+- vSwitch ID: `9999` # arbitrary value, replace with your vSwitch ID
 - Main interface: `enp6s0`
 
-```bash
-nmcli connection add type vlan con-name vlan4022 ifname vlan4022 vlan.parent enp6s0 vlan.id 4022
+> [!CAUTION]
+> The routes and CIDR notations depend on your local setup and may vary depending on your network configuration.
 
-nmcli connection modify vlan4022 802-3-ethernet.mtu 1400
-nmcli connection modify vlan4022 ipv4.addresses '10.1.0.2/24'
-nmcli connection modify vlan4022 ipv4.gateway '10.1.0.1'
-nmcli connection modify vlan4022 ipv4.method manual
+```bash
+nmcli connection add type vlan con-name vlan9999 ifname vlan9999 vlan.parent enp6s0 vlan.id 9999
+
+nmcli connection modify vlan9999 802-3-ethernet.mtu 1400
+nmcli connection modify vlan9999 ipv4.addresses '10.1.0.2/24'
+nmcli connection modify vlan9999 ipv4.gateway '10.1.0.1'
+nmcli connection modify vlan9999 ipv4.method manual
 # Route all 10.x IPs through the vSwitch gateway
-nmcli connection modify vlan4022 +ipv4.routes "10.0.0.0/8 10.1.0.1"
+nmcli connection modify vlan9999 +ipv4.routes "10.0.0.0/8 10.1.0.1"
 
 # Apply the config
-nmcli connection down vlan4022
-nmcli connection up vlan4022
+nmcli connection down vlan9999
+nmcli connection up vlan9999
 ```
 
 </details>

--- a/docs/add-robot-server.md
+++ b/docs/add-robot-server.md
@@ -1,0 +1,175 @@
+# Hetzner Robot Server Integration using HCCM v1.19+
+
+This guide describes how to add Hetzner **robot servers** to a Kubernetes cluster with help of the [hcloud-cloud-controller-manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager), version 1.19 or newer.
+It covers configuration for both k3s and Robot nodes, including networking, configuration, and caveats.
+
+---
+
+## Prerequisites
+
+- **vSwitch** set up for private networking between Cloud and Robot nodes
+- **Webservice User** created in Hetzner Robot account settings (for API access)
+- `hccm` version **1.19 or newer**
+
+---
+
+## 1. Networking: Private Communication
+
+- **Robot and Cloud servers communication happens over a private network.**
+    - The recommended way is using a **vSwitch**.
+    - Alternatives like WireGuard exist, but are not covered here.
+    - Ensure all nodes can reach each other via internal IPs (e.g., `10.x.x.x`).
+
+---
+
+## 2. Hetzner Robot API Access
+
+- Create a **Webservice User** in your Hetzner Robot account.
+- This is required for `hccm` to list robot servers via the metadata endpoint:
+    - `https://169.254.169.254/hetzner/v1/metadata/instance-id`
+
+---
+
+## 3. Robot Node Network Configuration
+
+- **Manually configure** the network interface and routes on the robot server.
+- For Ubuntu, see [Hetzner docs](https://docs.hetzner.com/cloud/networks/connect-dedi-vswitch#persistent-example-configurations).
+- For RHEL-based systems (e.g., AlmaLinux), use the following `nmcli` commands:
+
+<details>
+<summary>RHEL/AlmaLinux nmcli Example</summary>
+
+Assumptions (change these to your values!):
+- vSwitch subnet: `10.1.0.0/24`
+- vSwitch ID: `4022`
+- Main interface: `enp6s0`
+
+```bash
+nmcli connection add type vlan con-name vlan4022 ifname vlan4022 vlan.parent enp6s0 vlan.id 4022
+
+nmcli connection modify vlan4022 802-3-ethernet.mtu 1400
+nmcli connection modify vlan4022 ipv4.addresses '10.1.0.2/24'
+nmcli connection modify vlan4022 ipv4.gateway '10.1.0.1'
+nmcli connection modify vlan4022 ipv4.method manual
+# Route all 10.x IPs through the vSwitch gateway
+nmcli connection modify vlan4022 +ipv4.routes "10.0.0.0/8 10.1.0.1"
+
+# Apply the config
+nmcli connection down vlan4022
+nmcli connection up vlan4022
+```
+
+</details>
+
+---
+
+## 4. HCCM Helm Chart Configuration
+
+- **Update the `hcloud` Kubernetes secret** with your `robot-user` and `robot-password`.
+- Set `networking.enabled: true` in `hetzner_ccm_values`.
+- Set the correct `cluster-cidr` (the pod subnet for your cluster).
+- Deploy `hccm` version **1.19 or newer**.
+
+Example `hetzner_ccm_values` for Helm:
+
+```yaml
+networking:
+  enabled: true
+robot:
+  enabled: true
+
+args:
+  allocate-node-cidrs: "true"
+  cluster-cidr: "10.42.0.0/16" # Adjust to your pod subnet
+
+env:
+  HCLOUD_LOAD_BALANCERS_ENABLED:
+    value: "true"
+  HCLOUD_LOAD_BALANCERS_LOCATION:
+    value: "fsn1"  # Adjust to your LB region
+  HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+    value: "true"
+  HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
+    value: "true"
+  HCLOUD_NETWORK_ROUTES_ENABLED:
+    value: "false"
+
+  HCLOUD_TOKEN:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: token
+
+  ROBOT_USER:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-user
+        optional: true
+  ROBOT_PASSWORD:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-password
+        optional: true
+```
+
+---
+
+## 5. Robot Node: k3s Agent Configuration
+
+1. **Create `/etc/rancher/k3s/config.yaml`** on the robot node:
+
+    ```yaml
+    "flannel-iface": "enp6s0" # Set to your main interface
+    "prefer-bundled-bin": "true"
+    "kubelet-arg":
+      - "cloud-provider=external"
+      - "volume-plugin-dir=/var/lib/kubelet/volumeplugins"
+      - "kube-reserved=cpu=50m,memory=300Mi,ephemeral-storage=1Gi"
+      - "system-reserved=cpu=250m,memory=6000Mi" # Optional: reserve some space for system
+    "node-label":
+      - "k3s_upgrade=true"
+    "node-taint": []
+    "selinux": true
+    "server": "https://$IP:6443" # Replace with your API server IP
+    "token": "$TOKEN"            # Replace with your cluster token
+    ```
+
+2. **Before starting the agent**, verify network connectivity:
+    - You must be able to `ping` other nodes' internal IPs (e.g., `ping 10.255.0.101`).
+
+---
+
+## 6. Storage and Scheduling Notes
+
+- **Hetzner Cloud Volumes** do **not** work on robot servers (CSI driver limitation).
+    - Use [Longhorn](https://longhorn.io/) or other external storage.
+    - Pods using cloud volumes cannot be scheduled on robot nodes.
+- **Longhorn**: Install `open-iscsi` and start the service:
+    ```bash
+    sudo dnf install -y iscsi-initiator-utils
+    sudo systemctl start iscsid
+    ```
+- **Node Scheduling**:
+    - Use taints and labels to control pod placement.
+    - To prevent Hetzner CSI pods from being scheduled on robot nodes, apply the label:
+        ```
+        instance.hetzner.cloud/provided-by=robot
+        ```
+      [Reference](https://github.com/hetznercloud/csi-driver/blob/main/docs/kubernetes/README.md#integration-with-root-servers)
+
+---
+
+## 7. Caveats & Warnings
+
+- This setup may not cover all edge cases (e.g., other CNIs, non-wireguard clusters, complex private networks).
+- **Test your network thoroughly** before adding robot nodes to production clusters.
+
+---
+
+## References
+
+- [Hetzner Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager)
+- [Hetzner vSwitch & Robot Networking](https://docs.hetzner.com/cloud/networks/connect-dedi-vswitch)
+- [Hetzner CSI Driver: Root Server Integration](https://github.com/hetznercloud/csi-driver/blob/main/docs/kubernetes/README.md#integration-with-root-servers)

--- a/init.tf
+++ b/init.tf
@@ -175,7 +175,9 @@ resource "null_resource" "kustomization" {
       local.csi_driver_smb_values,
       local.cert_manager_values,
       local.rancher_values,
-      local.hetzner_csi_values
+      local.hetzner_csi_values,
+      local.hetzner_ccm_values,
+
     ])
     # Redeploy when versions of addons need to be updated
     versions = join("\n", [
@@ -275,10 +277,10 @@ resource "null_resource" "kustomization" {
     content = var.hetzner_ccm_use_helm ? templatefile(
       "${path.module}/templates/hcloud-ccm-helm.yaml.tpl",
       {
+        values              = indent(4, local.hetzner_ccm_values)
         version             = coalesce(local.ccm_version, "*")
         using_klipper_lb    = local.using_klipper_lb
         default_lb_location = var.load_balancer_location
-
       }
     ) : ""
     destination = "/var/post_install/hcloud-ccm-helm.yaml"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -977,9 +977,6 @@ module "kube-hetzner" {
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   cilium_values = <<EOT
 
-  # Hetzner Cloud Controller Manager, all Hetzner Cloud Controller Manager helm values can be found at https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
-  /* hetzner_ccm_values = <<EOT
-
 ipam:
   mode: kubernetes
 k8s:

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -976,6 +976,10 @@ module "kube-hetzner" {
   # Be careful when maintaining your own cilium_values, as the choice of available settings depends on the Cilium version used. See also the cilium_version setting to fix a specific version.
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   cilium_values = <<EOT
+
+  # Hetzner Cloud Controller Manager, all Hetzner Cloud Controller Manager helm values can be found at https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
+  /* hetzner_ccm_values = <<EOT
+
 ipam:
   mode: kubernetes
 k8s:

--- a/locals.tf
+++ b/locals.tf
@@ -618,6 +618,9 @@ controller:
 %{endif~}
   EOT
 
+  hetzner_ccm_values = var.hetzner_ccm_values != "" ? var.hetzner_ccm_values : <<EOT
+  EOT
+
   haproxy_values = var.haproxy_values != "" ? var.haproxy_values : <<EOT
 controller:
   kind: "Deployment"

--- a/values-export.tf
+++ b/values-export.tf
@@ -19,13 +19,6 @@ resource "local_file" "hetzner_ccm_values" {
   file_permission = "600"
 }
 
-resource "local_file" "cilium_values" {
-  count           = var.export_values && var.cni_plugin == "cilium" ? 1 : 0
-  content         = local.cilium_values
-  filename        = "cilium_values.yaml"
-  file_permission = "600"
-}
-
 resource "local_file" "csi_driver_smb_values" {
   count           = var.export_values && var.enable_csi_driver_smb ? 1 : 0
   content         = local.csi_driver_smb_values

--- a/values-export.tf
+++ b/values-export.tf
@@ -13,7 +13,7 @@ resource "local_file" "cert_manager_values" {
 }
 
 resource "local_file" "hetzner_ccm_values" {
-  count           = var.export_values && var.cni_plugin == "cilium" ? 1 : 0
+  count           = var.export_values && var.hetzner_ccm_use_helm ? 1 : 0
   content         = local.hetzner_ccm_values
   filename        = "hetzner_ccm_values.yaml"
   file_permission = "600"

--- a/values-export.tf
+++ b/values-export.tf
@@ -12,6 +12,20 @@ resource "local_file" "cert_manager_values" {
   file_permission = "600"
 }
 
+resource "local_file" "hetzner_ccm_values" {
+  count           = var.export_values && var.cni_plugin == "cilium" ? 1 : 0
+  content         = local.hetzner_ccm_values
+  filename        = "hetzner_ccm_values.yaml"
+  file_permission = "600"
+}
+
+resource "local_file" "cilium_values" {
+  count           = var.export_values && var.cni_plugin == "cilium" ? 1 : 0
+  content         = local.cilium_values
+  filename        = "cilium_values.yaml"
+  file_permission = "600"
+}
+
 resource "local_file" "csi_driver_smb_values" {
   count           = var.export_values && var.enable_csi_driver_smb ? 1 : 0
   content         = local.csi_driver_smb_values

--- a/variables.tf
+++ b/variables.tf
@@ -1209,3 +1209,9 @@ variable "sys_upgrade_controller_version" {
   default     = "v0.14.2"
   description = "Version of the System Upgrade Controller for automated upgrades of k3s. See https://github.com/rancher/system-upgrade-controller/releases for the available versions."
 }
+
+variable "hetzner_ccm_values" {
+  type        = string
+  default     = ""
+  description = "Additional helm values file to pass to Hetzner Controller Manager as 'valuesContent' at the HelmChart."
+}


### PR DESCRIPTION
After HCCM is now integrated via helm, there's only the ability missing to configure its values.

I've extracted the instructions from https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/1311#discussioncomment-11160315, which I am using since its existence.

As this config conflicts with my custom HCCM install right now, I haven't tested it yet - maybe somebody else will? ;)

close #1405 #1311 #283