### PR TITLE
Prevent Hetzner default nameservers from being added to /etc/resolv.conf

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -72,8 +72,8 @@ locals {
       join("\n", compact([
         "IFACE=$(ip route show default | awk '{print $5; exit}')",
         "if [ -n \"$IFACE\" ]; then",
-        length(local.dns_servers_ipv4) > 0 ? "  nmcli con mod \"$IFACE\" ipv4.dns ${join(",", local.dns_servers_ipv4)}" : "",
-        length(local.dns_servers_ipv6) > 0 ? "  nmcli con mod \"$IFACE\" ipv6.dns ${join(",", local.dns_servers_ipv6)}" : "",
+        length(local.dns_servers_ipv4) > 0 ? "  nmcli con mod \"$IFACE\" ipv4.ignore-auto-dns yes ipv4.dns ${join(",", local.dns_servers_ipv4)}" : "",
+        length(local.dns_servers_ipv6) > 0 ? "  nmcli con mod \"$IFACE\" ipv6.ignore-auto-dns yes ipv6.dns ${join(",", local.dns_servers_ipv6)}" : "",
         "fi"
       ]))
     ] : [],

--- a/locals.tf
+++ b/locals.tf
@@ -79,13 +79,15 @@ locals {
         "IFACE=$(ip route show default 2>/dev/null | awk '/^default/ && /dev/ {for(i=1;i<=NF;i++) if($i==\"dev\") {print $(i+1); exit}}')",
         "if [ -z \"$IFACE\" ]; then",
         "  # Fallback: try to get any interface that's up and has an IP",
-        "    IFACE=$(ip route show 2>/dev/null | awk '!/^default/ && /dev/ {for(i=1;i<=NF;i++) if($i==\"dev\") {print $(i+1); exit}}')",
+        "  IFACE=$(ip route show 2>/dev/null | awk '!/^default/ && /dev/ {for(i=1;i<=NF;i++) if($i==\"dev\") {print $(i+1); exit}}')",
         "fi",
         "if [ -n \"$IFACE\" ]; then",
         "  CONNECTION=$(nmcli -g GENERAL.CONNECTION device show \"$IFACE\" 2>/dev/null | head -1)",
         "  if [ -n \"$CONNECTION\" ]; then",
-        length(local.dns_servers_ipv4) > 0 ? "    nmcli con mod \"$CONNECTION\" ipv4.ignore-auto-dns yes ipv4.dns ${join(",", local.dns_servers_ipv4)}" : "",
-        length(local.dns_servers_ipv6) > 0 ? "    nmcli con mod \"$CONNECTION\" ipv6.ignore-auto-dns yes ipv6.dns ${join(",", local.dns_servers_ipv6)}" : "",
+        "    # Disable auto-DNS for both protocols when custom DNS servers are provided",
+        "    nmcli con mod \"$CONNECTION\" ipv4.ignore-auto-dns yes ipv6.ignore-auto-dns yes",
+        length(local.dns_servers_ipv4) > 0 ? "    nmcli con mod \"$CONNECTION\" ipv4.dns ${join(",", local.dns_servers_ipv4)}" : "",
+        length(local.dns_servers_ipv6) > 0 ? "    nmcli con mod \"$CONNECTION\" ipv6.dns ${join(",", local.dns_servers_ipv6)}" : "",
         "  fi",
         "fi"
       ]))


### PR DESCRIPTION
Currently, NetworkManager generates /etc/resolv.conf based on the provided dns_servers list. However, when the connection method is set to auto (the default), Hetzner’s default nameservers are also appended.

For example, with the following configuration:

```yaml
dns_servers = [
    "1.1.1.1",
    "8.8.8.8",
    "2606:4700:4700::1111",
]
```

The resulting /etc/resolv.conf contains:

```
# Generated by NetworkManager
nameserver 1.1.1.1
nameserver 8.8.8.8
nameserver 185.12.64.1
# NOTE: the libc resolver may not support more than 3 nameservers.
# The nameservers listed below may not be recognized.
nameserver 185.12.64.2
nameserver 2606:4700:4700::1111
```

Relevant section from /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection:

```
[ipv4]
dns=1.1.1.1;8.8.8.8;
may-fail=false
method=auto

[ipv6]
address1=2a01:4f8:c012:16f3::1/64
dns=2606:4700:4700::1111;
gateway=fe80::1
may-fail=false
method=manual
```

To ensure only the explicitly provided DNS servers are used, set ignore-auto-dns=yes in the connection configuration. This prevents NetworkManager from appending the provider’s default DNS entries.

With ignore-auto-dns=yes, /etc/resolv.conf becomes:

```
# Generated by NetworkManager
nameserver 1.1.1.1
nameserver 8.8.8.8
nameserver 2606:4700:4700::1111
```
