### PR TITLE
Add audit-log feature

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -7,31 +7,33 @@ module "agents" {
 
   for_each = local.agent_nodes
 
-  name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}${try(each.value.node_name_suffix, "")}"
-  microos_snapshot_id          = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
-  base_domain                  = var.base_domain
-  ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
-  ssh_port                     = var.ssh_port
-  ssh_public_key               = var.ssh_public_key
-  ssh_private_key              = var.ssh_private_key
-  ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
-  firewall_ids                 = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
-  placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.agent[each.value.placement_group_compat_idx].id : hcloud_placement_group.agent_named[each.value.placement_group].id)
-  location                     = each.value.location
-  server_type                  = each.value.server_type
-  backups                      = each.value.backups
-  ipv4_subnet_id               = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  dns_servers                  = var.dns_servers
-  k3s_registries               = var.k3s_registries
-  k3s_registries_update_script = local.k3s_registries_update_script
-  cloudinit_write_files_common = local.cloudinit_write_files_common
-  cloudinit_runcmd_common      = local.cloudinit_runcmd_common
-  swap_size                    = each.value.swap_size
-  zram_size                    = each.value.zram_size
-  keep_disk_size               = var.keep_disk_agents
-  disable_ipv4                 = each.value.disable_ipv4
-  disable_ipv6                 = each.value.disable_ipv6
-  network_id                   = length(var.existing_network_id) > 0 ? var.existing_network_id[0] : 0
+  name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}${try(each.value.node_name_suffix, "")}"
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  base_domain                      = var.base_domain
+  ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
+  ssh_port                         = var.ssh_port
+  ssh_public_key                   = var.ssh_public_key
+  ssh_private_key                  = var.ssh_private_key
+  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  firewall_ids                     = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
+  placement_group_id               = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.agent[each.value.placement_group_compat_idx].id : hcloud_placement_group.agent_named[each.value.placement_group].id)
+  location                         = each.value.location
+  server_type                      = each.value.server_type
+  backups                          = each.value.backups
+  ipv4_subnet_id                   = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  dns_servers                      = var.dns_servers
+  k3s_registries                   = var.k3s_registries
+  k3s_registries_update_script     = local.k3s_registries_update_script
+  cloudinit_write_files_common     = local.cloudinit_write_files_common
+  k3s_audit_policy_config          = ""
+  k3s_audit_policy_update_script   = ""
+  cloudinit_runcmd_common          = local.cloudinit_runcmd_common
+  swap_size                        = each.value.swap_size
+  zram_size                        = each.value.zram_size
+  keep_disk_size                   = var.keep_disk_agents
+  disable_ipv4                     = each.value.disable_ipv4
+  disable_ipv6                     = each.value.disable_ipv6
+  network_id                       = length(var.existing_network_id) > 0 ? var.existing_network_id[0] : 0
 
   private_ipv4 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -7,31 +7,33 @@ module "control_planes" {
 
   for_each = local.control_plane_nodes
 
-  name                         = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  microos_snapshot_id          = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
-  base_domain                  = var.base_domain
-  ssh_keys                     = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
-  ssh_port                     = var.ssh_port
-  ssh_public_key               = var.ssh_public_key
-  ssh_private_key              = var.ssh_private_key
-  ssh_additional_public_keys   = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
-  firewall_ids                 = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
-  placement_group_id           = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.control_plane[each.value.placement_group_compat_idx].id : hcloud_placement_group.control_plane_named[each.value.placement_group].id)
-  location                     = each.value.location
-  server_type                  = each.value.server_type
-  backups                      = each.value.backups
-  ipv4_subnet_id               = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
-  dns_servers                  = var.dns_servers
-  k3s_registries               = var.k3s_registries
-  k3s_registries_update_script = local.k3s_registries_update_script
-  cloudinit_write_files_common = local.cloudinit_write_files_common
-  cloudinit_runcmd_common      = local.cloudinit_runcmd_common
-  swap_size                    = each.value.swap_size
-  zram_size                    = each.value.zram_size
-  keep_disk_size               = var.keep_disk_cp
-  disable_ipv4                 = each.value.disable_ipv4
-  disable_ipv6                 = each.value.disable_ipv6
-  network_id                   = length(var.existing_network_id) > 0 ? var.existing_network_id[0] : 0
+  name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  base_domain                      = var.base_domain
+  ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
+  ssh_port                         = var.ssh_port
+  ssh_public_key                   = var.ssh_public_key
+  ssh_private_key                  = var.ssh_private_key
+  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  firewall_ids                     = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
+  placement_group_id               = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.control_plane[each.value.placement_group_compat_idx].id : hcloud_placement_group.control_plane_named[each.value.placement_group].id)
+  location                         = each.value.location
+  server_type                      = each.value.server_type
+  backups                          = each.value.backups
+  ipv4_subnet_id                   = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  dns_servers                      = var.dns_servers
+  k3s_registries                   = var.k3s_registries
+  k3s_registries_update_script     = local.k3s_registries_update_script
+  k3s_audit_policy_config          = var.k3s_audit_policy_config
+  k3s_audit_policy_update_script   = local.k3s_audit_policy_update_script
+  cloudinit_write_files_common     = local.cloudinit_write_files_common
+  cloudinit_runcmd_common          = local.cloudinit_runcmd_common
+  swap_size                        = each.value.swap_size
+  zram_size                        = each.value.zram_size
+  keep_disk_size                   = var.keep_disk_cp
+  disable_ipv4                     = each.value.disable_ipv4
+  disable_ipv6                     = each.value.disable_ipv6
+  network_id                       = length(var.existing_network_id) > 0 ? var.existing_network_id[0] : 0
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
@@ -180,6 +182,36 @@ resource "null_resource" "control_plane_config" {
   ]
 }
 
+resource "null_resource" "audit_policy" {
+  for_each = local.control_plane_nodes
+
+  triggers = {
+    control_plane_id = module.control_planes[each.key].id
+    audit_policy     = sha1(var.k3s_audit_policy_config)
+  }
+
+  connection {
+    user           = "root"
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
+    host           = local.control_plane_ips[each.key]
+    port           = var.ssh_port
+  }
+
+  provisioner "file" {
+    content     = var.k3s_audit_policy_config
+    destination = "/tmp/audit-policy.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [local.k3s_audit_policy_update_script]
+  }
+
+  depends_on = [
+    null_resource.first_control_plane,
+    hcloud_network_subnet.control_plane
+  ]
+}
 
 resource "null_resource" "authentication_config" {
   for_each = local.control_plane_nodes

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -749,6 +749,41 @@ module "kube-hetzner" {
   # k3s_agent_kubelet_args = []
   # k3s_autoscaler_kubelet_args = []
 
+  # Enable Kubernetes audit logging on control plane nodes
+  # This will create an audit policy file and configure k3s to use it
+  # Audit logs will be written to /var/log/k3s-audit/audit.log by default
+  #
+  # k3s_audit_policy_config = <<-EOT
+  #   apiVersion: audit.k8s.io/v1
+  #   kind: Policy
+  #   rules:
+  #     # Log pod changes at RequestResponse level
+  #     - level: RequestResponse
+  #       omitStages:
+  #         - RequestReceived
+  #       resources:
+  #         - group: ""
+  #           resources: ["pods", "services"]
+  #       namespaces: ["default", "kube-system"]
+  #     # Log all other resources at Metadata level
+  #     - level: Metadata
+  #       omitStages:
+  #         - RequestReceived
+  #     # Don't log requests to certain non-resource URL paths
+  #     - level: None
+  #       nonResourceURLs:
+  #         - /api*
+  #         - /version
+  #         - /healthz
+  #         - /readyz
+  # EOT
+  #
+  # # Audit log configuration
+  # k3s_audit_log_path = "/var/log/k3s-audit/audit.log"  # Path to audit log file
+  # k3s_audit_log_maxage = 30     # Days to retain audit logs
+  # k3s_audit_log_maxbackup = 10  # Number of audit log files to keep
+  # k3s_audit_log_maxsize = 100   # Max size in MB before rotation
+
   # If you want to allow all outbound traffic you can set this to "false". Default is "true".
   # restrict_outbound_traffic = false
 

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -109,6 +109,16 @@ variable "k3s_registries_update_script" {
   type    = string
 }
 
+variable "k3s_audit_policy_config" {
+  description = "K3S audit-policy.yaml contents"
+  type        = string
+}
+
+variable "k3s_audit_policy_update_script" {
+  description = "Script to update audit policy configuration"
+  type        = string
+}
+
 variable "cloudinit_write_files_common" {
   default = ""
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -1105,6 +1105,36 @@ variable "k3s_registries" {
   type        = string
 }
 
+variable "k3s_audit_policy_config" {
+  description = "K3S audit-policy.yaml contents. Used to configure Kubernetes audit logging."
+  default     = ""
+  type        = string
+}
+
+variable "k3s_audit_log_path" {
+  description = "Path where audit logs will be stored on control plane nodes"
+  default     = "/var/log/k3s-audit/audit.log"
+  type        = string
+}
+
+variable "k3s_audit_log_maxage" {
+  description = "Maximum number of days to retain audit log files"
+  default     = 30
+  type        = number
+}
+
+variable "k3s_audit_log_maxbackup" {
+  description = "Maximum number of audit log files to retain"
+  default     = 10
+  type        = number
+}
+
+variable "k3s_audit_log_maxsize" {
+  description = "Maximum size in megabytes of the audit log file before rotation"
+  default     = 100
+  type        = number
+}
+
 variable "additional_tls_sans" {
   description = "Additional TLS SANs to allow connection to control-plane through it."
   default     = []


### PR DESCRIPTION
Pretty similar PR like the existing kubelet-config PR. Enables audit logs on the control plane:

```terraform
  k3s_audit_policy_config = <<-EOT
apiVersion: audit.k8s.io/v1
kind: Policy
rules: 
  - level: RequestResponse
    omitStages:
      - RequestReceived
    resources:
      - group: ""
        resources: ["pods", "services"]
    namespaces: ["default", "kube-system"] 
  - level: Metadata
    omitStages:
      - RequestReceived 
  - level: None
    nonResourceURLs:
      - /api*
      - /version
      - /healthz
      - /readyz
  EOT

  k3s_audit_log_path = "/var/log/k3s-audit/audit.log"  # Path to audit log file
  k3s_audit_log_maxage = 30     # Days to retain audit logs
  k3s_audit_log_maxbackup = 10  # Number of audit log files to keep
  k3s_audit_log_maxsize = 100   # Max size in MB before rotation
```

I tested it in a private IP cluster only, And actually upgrading an existing control plane. Maybe this PR does not handle agent nodes well in the sense of that it may trigger a restart of agents as well, when a audit-log has changed, therefore, if that can be optimized, I am all ears to improve it.