### PR TITLE
fix: add enable_ipv4 and enable_ipv6 flags to autoscaler configuration

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -44,6 +44,8 @@ locals {
       node_pools                                 = var.autoscaler_nodepools
       disable_ipv4                               = var.autoscaler_disable_ipv4 || local.use_nat_router
       disable_ipv6                               = var.autoscaler_disable_ipv6 || local.use_nat_router
+      enable_ipv4                                = !(var.autoscaler_disable_ipv4 || local.use_nat_router)
+      enable_ipv6                                = !(var.autoscaler_disable_ipv6 || local.use_nat_router)
   })
   # A concatenated list of all autoscaled nodes
   autoscaled_nodes = length(var.autoscaler_nodepools) == 0 ? {} : {


### PR DESCRIPTION
## Summary

This PR adds explicit `enable_ipv4` and `enable_ipv6` flags to the autoscaler configuration in `autoscaler-agents.tf`.

## Changes

- Added `enable_ipv4` flag as the negation of `disable_ipv4 || local.use_nat_router`
- Added `enable_ipv6` flag as the negation of `disable_ipv6 || local.use_nat_router`

## Rationale

The autoscaler configuration needs explicit enable flags for IPv4 and IPv6 to properly configure network settings for autoscaled nodes. These flags ensure that:
- When `disable_ipv4` is true or NAT router is enabled, `enable_ipv4` is false
- When `disable_ipv6` is true or NAT router is enabled, `enable_ipv6` is false

This provides a clearer and more explicit configuration for the autoscaler's network settings.

## Testing

Successfully tested with:
- `terraform init -upgrade` in the test directory
- `terraform apply` completed successfully

The changes have been verified to work correctly with the existing infrastructure.