### PR TITLE
fix: use load balancer network IP for private-only deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ CLAUDE.md
 
 # Misc
 .DS_Store
+
+requirements/*

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -33,7 +33,7 @@ locals {
     (
       var.control_plane_lb_enable_public_interface ?
       hcloud_load_balancer.control_plane.*.ipv4[0]
-      : hcloud_load_balancer.control_plane.*.network_ip[0]
+      : hcloud_load_balancer_network.control_plane.*.ip[0]
     )
     :
     (can(local.first_control_plane_ip) ? local.first_control_plane_ip : "unknown")


### PR DESCRIPTION
## Summary
- Fixes the kubeconfig generation error when using private-only deployments
- Changes the reference from deprecated `network_ip` to the correct `hcloud_load_balancer_network` IP
- Ensures backward compatibility by only affecting the private IP configuration path

Fixes #1809