### PR TITLE
fix: wait for NetworkManager before setting DNS to prevent race condition

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -71,8 +71,7 @@ locals {
     local.has_dns_servers ? [
       join("\n", compact([
         "# Wait for NetworkManager to be ready",
-        "timeout 60 bash -c 'while ! systemctl is-active --quiet NetworkManager; do echo \"Waiting for NetworkManager to be ready...\"; sleep 2; done'",
-        "if ! systemctl is-active --quiet NetworkManager; then",
+        "if ! timeout 60 bash -c 'until systemctl is-active --quiet NetworkManager; do echo \"Waiting for NetworkManager to be ready...\"; sleep 2; done'; then",
         "  echo \"ERROR: NetworkManager is not active after timeout\" >&2",
         "  exit 0  # Don't fail cloud-init",
         "fi",

--- a/locals.tf
+++ b/locals.tf
@@ -70,6 +70,12 @@ locals {
     ],
     local.has_dns_servers ? [
       join("\n", compact([
+        "# Wait for NetworkManager to be ready",
+        "timeout 60 bash -c 'while ! systemctl is-active --quiet NetworkManager; do echo \"Waiting for NetworkManager to be ready...\"; sleep 2; done'",
+        "if ! systemctl is-active --quiet NetworkManager; then",
+        "  echo \"ERROR: NetworkManager is not active after timeout\" >&2",
+        "  exit 0  # Don't fail cloud-init",
+        "fi",
         "# Get the default interface",
         "IFACE=$(ip route show default 2>/dev/null | awk '/^default/ && /dev/ {for(i=1;i<=NF;i++) if($i==\"dev\") {print $(i+1); exit}}')",
         "if [ -z \"$IFACE\" ]; then",


### PR DESCRIPTION
## Summary
- Fixes #1798 where nmcli commands would hang during cloud-init if NetworkManager wasn't ready yet
- This caused cloud-final.service to timeout and prevented k3s-agent from starting on new autoscaled nodes
- Adds a 60-second wait loop for NetworkManager to be active before attempting DNS configuration

## Details
The issue occurred because:
1. cloud-final.service runs the DNS configuration script
2. The nmcli commands hang if NetworkManager isn't ready yet (can take ~50 seconds on some nodes)
3. This causes cloud-final.service to timeout
4. The timeout kills the entire k3s-agent installation process

The fix:
- Waits up to 60 seconds for NetworkManager to be active using `systemctl is-active`
- If NetworkManager doesn't start within the timeout, exits gracefully (exit 0) without failing cloud-init
- Only then proceeds with the DNS configuration using nmcli