### PR TITLE
fix: correct cert-manager extraArgs format to use array syntax

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -840,7 +840,7 @@ crds:
   keep: true
 %{if var.ingress_controller == "nginx"~}
 extraArgs:
-  --feature-gates: ACMEHTTP01IngressPathTypeExact=false
+  - --feature-gates=ACMEHTTP01IngressPathTypeExact=false
 %{endif~}
   EOT
 


### PR DESCRIPTION
## Summary
- Fixes cert-manager helm chart installation failure due to incorrect extraArgs format
- Changes from object format to array format as expected by the chart's values schema

## Problem
The cert-manager helm chart was failing to install with the error:
```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
cert-manager:
- extraArgs: Invalid type. Expected: array, given: object
```

This was happening because we were providing extraArgs as a key-value object instead of an array of strings.

## Solution
Changed the extraArgs format in `locals.tf` from:
```yaml
extraArgs:
  --feature-gates: ACMEHTTP01IngressPathTypeExact=false
```

To the correct array format:
```yaml
extraArgs:
  - --feature-gates=ACMEHTTP01IngressPathTypeExact=false
```

## Test plan
- [x] Run `terraform plan` to verify the changes are valid
- [x] Deploy to a test cluster with nginx ingress controller to confirm cert-manager installs successfully

This is a corrective fix for the changes made in PR #1834.
