### PR TITLE
fix: correct Hetzner CCM helm integration for Robot server support

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1027,6 +1027,29 @@ cainjector:
   replicaCount: 3
   EOT */
 
+  # Hetzner Cloud Controller Manager, all Hetzner Cloud Controller Manager helm values can be found at https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
+  # We advise you to not touch this and to let the defaults that are already set under the hood.
+  # For advanced use cases like adding Hetzner Robot servers, see: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/docs/add-robot-server.md
+  # The following is an example, please note that the current indentation inside the EOT is important.
+  /*   hetzner_ccm_values = <<EOT
+networking:
+  enabled: true
+args:
+  cloud-provider: hcloud
+  allow-untagged-cloud: ""
+  route-reconciliation-period: 30s
+  webhook-secure-port: "0"
+env:
+  HCLOUD_LOAD_BALANCERS_LOCATION:
+    value: "fsn1"
+  HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+    value: "true"
+  HCLOUD_LOAD_BALANCERS_ENABLED:
+    value: "true"
+  HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
+    value: "true"
+  EOT */
+
   # csi-driver-smb, all csi-driver-smb helm values can be found at https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/latest/csi-driver-smb/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   csi_driver_smb_values = <<EOT

--- a/locals.tf
+++ b/locals.tf
@@ -654,6 +654,25 @@ controller:
   EOT
 
   hetzner_ccm_values = var.hetzner_ccm_values != "" ? var.hetzner_ccm_values : <<EOT
+networking:
+  enabled: true
+args:
+  cloud-provider: hcloud
+  allow-untagged-cloud: ""
+  route-reconciliation-period: 30s
+  webhook-secure-port: "0"
+%{if local.using_klipper_lb~}
+  secure-port: "10288"
+%{endif~}
+env:
+  HCLOUD_LOAD_BALANCERS_LOCATION:
+    value: "${var.load_balancer_location}"
+  HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
+    value: "true"
+  HCLOUD_LOAD_BALANCERS_ENABLED:
+    value: "${!local.using_klipper_lb}"
+  HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
+    value: "true"
   EOT
 
   haproxy_values = var.haproxy_values != "" ? var.haproxy_values : <<EOT

--- a/templates/hcloud-ccm-helm.yaml.tpl
+++ b/templates/hcloud-ccm-helm.yaml.tpl
@@ -11,20 +11,4 @@ spec:
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-
-    networking:
-      enabled: "true"
-    args:
-      cloud-provider: hcloud
-      allow-untagged-cloud: ""
-      route-reconciliation-period: 30s
-      webhook-secure-port: "0"
-      ${using_klipper_lb ? "secure-port: \"10288\"" : ""}
-    env:
-      HCLOUD_LOAD_BALANCERS_LOCATION:
-        value: "${default_lb_location}"
-      HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP:
-        value: "true"
-      HCLOUD_LOAD_BALANCERS_ENABLED:
-        value: "${!using_klipper_lb}"
-      HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
-        value: "true"
+    ${values}


### PR DESCRIPTION
## Summary

This PR fixes critical issues introduced in #1792 that prevented the Hetzner CCM helm values customization from working properly, which is essential for Robot server integration.

## Issues Fixed

1. **Template not using values parameter**: The `hcloud-ccm-helm.yaml.tpl` had hardcoded values instead of using the `${values}` parameter
2. **Missing default values**: Default CCM values were in the template instead of `locals.tf`
3. **Missing documentation**: Added proper example in `kube.tf.example`
4. **Documentation improvements**: Enhanced Robot server guide with OS recommendations and MTU warnings

## Changes

- ✅ Fixed `hcloud-ccm-helm.yaml.tpl` to use `${values}` parameter (aligns with other helm charts)
- ✅ Moved default CCM values from template to `locals.tf` 
- ✅ Added `hetzner_ccm_values` example to `kube.tf.example`
- ✅ Enhanced Robot server documentation:
  - Added MicroOS as preferred OS
  - Documented MTU issues (vSwitch requires 1400 or lower)
  - Fixed YAML formatting issues
  - Clarified CNI-specific settings

## Test Plan

- [x] Tested with `terraform plan` - no errors
- [x] Deployed test cluster - works correctly
- [x] Verified CCM values can now be customized
- [x] Documentation is clear and accurate