### PR TITLE
fix: add explicit routing configuration for Hetzner DHCP changes

### DIFF
--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -34,9 +34,33 @@ ${cloudinit_runcmd_common}
 
 # Configure default route based on public ip availability
 %{if private_network_only~}
-- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0']
+# Private-only setup: eth0 is the private interface
+- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0', metric, '100']
 %{else~}
-- [ip, route, add, default, via, '172.31.1.1', dev, 'eth0']
+# Standard setup: eth0 is public, eth1 is private
+- [ip, route, add, default, via, '172.31.1.1', dev, 'eth0', metric, '100']
+
+# Ensure private network has default route (protection against DHCP changes)
+- |
+  set +e  # Don't fail if route exists
+  # Wait for private interface to be ready
+  for i in {1..30}; do
+    if ip link show eth1 &>/dev/null; then
+      # Add default route via private network with high metric
+      ip route add default via 10.0.0.1 dev eth1 metric 20101 2>/dev/null || true
+      
+      # Configure NetworkManager to ignore DHCP default route on private interface
+      if systemctl is-active --quiet NetworkManager; then
+        NM_CONN=$(nmcli -g GENERAL.CONNECTION device show eth1 2>/dev/null | head -1)
+        if [ -n "$NM_CONN" ]; then
+          nmcli connection modify "$NM_CONN" ipv4.never-default yes 2>/dev/null || true
+        fi
+      fi
+      break
+    fi
+    sleep 1
+  done
+  set -e
 %{endif~}
 
 %{if swap_size != ""~}

--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -44,9 +44,33 @@ ${cloudinit_runcmd_common}
 
 # Configure default route based on public ip availability
 %{if private_network_only~}
-- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0']
+# Private-only setup: eth0 is the private interface
+- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0', metric, '100']
 %{else~}
-- [ip, route, add, default, via, '172.31.1.1', dev, 'eth0']
+# Standard setup: eth0 is public, eth1 is private
+- [ip, route, add, default, via, '172.31.1.1', dev, 'eth0', metric, '100']
+
+# Ensure private network has default route (protection against DHCP changes)
+- |
+  set +e  # Don't fail if route exists
+  # Wait for private interface to be ready
+  for i in {1..30}; do
+    if ip link show eth1 &>/dev/null; then
+      # Add default route via private network with high metric
+      ip route add default via 10.0.0.1 dev eth1 metric 20101 2>/dev/null || true
+      
+      # Configure NetworkManager to ignore DHCP default route on private interface
+      if systemctl is-active --quiet NetworkManager; then
+        NM_CONN=$(nmcli -g GENERAL.CONNECTION device show eth1 2>/dev/null | head -1)
+        if [ -n "$NM_CONN" ]; then
+          nmcli connection modify "$NM_CONN" ipv4.never-default yes 2>/dev/null || true
+        fi
+      fi
+      break
+    fi
+    sleep 1
+  done
+  set -e
 %{endif~}
 
 # Start the install-k3s-agent service


### PR DESCRIPTION
## Summary

This PR adds explicit routing configuration to protect against Hetzner's upcoming DHCP changes on August 11, 2025. Currently, nodes rely on DHCP to provide default routes on the private network interface. When Hetzner stops providing these routes, nodes would lose private network routing.

Fixes #1797

## Changes

- Add static default route via 10.0.0.1 on private interface (eth1) with metric 20101
- Configure NetworkManager to ignore DHCP default routes on private interface  
- Ensure backward compatibility with zero disruption to existing clusters

### Technical Details

For standard deployments (public + private IPs):
- Adds explicit route that matches current DHCP-provided route
- Configures NetworkManager to ignore future DHCP default route changes

For private-only deployments:
- Already have static routes, just added proper metrics for consistency

## Test Plan

- [ ] Deploy test cluster with these changes
- [ ] Verify routing table matches current production setup
- [ ] Test node-to-node communication
- [ ] Test pod networking
- [ ] Verify no disruption to existing clusters on update

## Impact

This change ensures zero impact when Hetzner stops providing default routes via DHCP. The routing behavior remains identical to current setup, just explicitly configured rather than DHCP-managed.

🤖 Generated with [Claude Code](https://claude.ai/code)