### PR TITLE
Add installation commands & TOC to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,31 +96,16 @@ Follow those simple steps, and your world's cheapest Kubernetes cluster will be 
 First and foremost, you need to have a Hetzner Cloud account. You can sign up for free [here](https://hetzner.com/cloud/).
 
 Then you'll need to have [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tofu](https://opentofu.org/docs/intro/install/), [packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#installing-packer) (for the initial snapshot creation only, no longer needed once that's done), [kubectl](https://kubernetes.io/docs/tasks/tools/) cli and [hcloud](https://github.com/hetznercloud/cli) the Hetzner cli for convenience.  
-The easiest way is to use the [homebrew](https://brew.sh/) package manager to install them (available on Linux, MacOS, and Windows Linux Subsystem). The timeout command is also used, which is part of coreutils on MacOS.
+The easiest way is to use the [homebrew](https://brew.sh/) package manager to install them (available on MacOS, Linux and Windows Linux Subsystem). The timeout command is also used, which is part of coreutils on MacOS.
 
-<details open>
-<summary>Brew (Linux, MacOS, Windows Linux Subsystem)</summary>
-
-```sh
-brew tap hashicorp/tap
-brew install hashicorp/tap/terraform # OR brew install opentofu
-brew install hashicorp/tap/packer
-brew install kubectl
-brew install hcloud
-brew install coreutils
-```
-</details>
-
-<details>
-<summary>Yay (Arch Linux)</summary>
-
-```sh
-yay terraform # OR yay opentofu
-yay packer
-yay kubectl
-yay hcloud
-```
-</details>
+|        **Tool**        |                              **Installation Command**                              |
+|:----------------------:|:----------------------------------------------------------------------------------:|
+| Homebrew (macOS/Linux) | brew install terraform packer kubectl hcloud                                       |
+| Yay/Paru (Arch-based)  | yay -S terraform packer kubectl hcloud<br> paru -S terraform packer kubectl hcloud |
+| APT (Debian-based)     | sudo apt install terraform packer kubectl                                          |
+| DNF (Red Hat-based)    | sudo dnf install terraform packer kubectl                                          |
+| Snap                   | sudo snap install terraform kubectl --classic && snap install packer               |
+| Chocolatey (Windows)   | choco install terraform packer kubernetes-cli hetzner-cli                          |
 
 ### 💡 [Do not skip] Creating your kube.tf file and the OpenSUSE MicroOS snapshot
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@
   <hr />
 </p>
 
+- [About The Project](#about-the-project)
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+- [CNI](#cni)
+- [Scaling Nodes](#scaling-nodes)
+- [Autoscaling Node Pools](#autoscaling-node-pools)
+- [High Availability](#high-availability)
+- [Automatic Upgrade](#automatic-upgrade)
+- [Customizing the Cluster Components](#customizing-the-cluster-components)
+- [Adding Hetzner Robot / Dedicated Servers](#adding-hetzner-robot--dedicated-servers)
+- [Adding Extras](#adding-extras)
+- [Examples](#examples)
+- [Debugging](#debugging)
+- [Takedown](#takedown)
+- [Upgrading the Module](#upgrading-the-module)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+
+---
+
 ## About The Project
 
 [Hetzner Cloud](https://hetzner.com) is a good cloud provider that offers very affordable prices for cloud instances, with data center locations in both Europe and the US.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ Follow those simple steps, and your world's cheapest Kubernetes cluster will be 
 
 First and foremost, you need to have a Hetzner Cloud account. You can sign up for free [here](https://hetzner.com/cloud/).
 
-Then you'll need to have [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tofu](https://opentofu.org/docs/intro/install/), [packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#installing-packer) (for the initial snapshot creation only, no longer needed once that's done), [kubectl](https://kubernetes.io/docs/tasks/tools/) cli and [hcloud](https://github.com/hetznercloud/cli) the Hetzner cli for convenience. The easiest way is to use the [homebrew](https://brew.sh/) package manager to install them (available on Linux, Mac, and Windows Linux Subsystem). Timeout command is also used, which is a part of coreutils on MacOS.
+Then you'll need to have [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tofu](https://opentofu.org/docs/intro/install/), [packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#installing-packer) (for the initial snapshot creation only, no longer needed once that's done), [kubectl](https://kubernetes.io/docs/tasks/tools/) cli and [hcloud](https://github.com/hetznercloud/cli) the Hetzner cli for convenience.  
+The easiest way is to use the [homebrew](https://brew.sh/) package manager to install them (available on Linux, MacOS, and Windows Linux Subsystem). The timeout command is also used, which is part of coreutils on MacOS.
+
+<details open>
+<summary>Brew (Linux, MacOS, Windows Linux Subsystem)</summary>
 
 ```sh
 brew tap hashicorp/tap
@@ -85,6 +89,18 @@ brew install kubectl
 brew install hcloud
 brew install coreutils
 ```
+</details>
+
+<details>
+<summary>Yay (Arch Linux)</summary>
+
+```sh
+yay terraform # OR yay opentofu
+yay packer
+yay kubectl
+yay hcloud
+```
+</details>
 
 ### 💡 [Do not skip] Creating your kube.tf file and the OpenSUSE MicroOS snapshot
 


### PR DESCRIPTION
I've added tool installation commands for yay (Arch Linux) as an alternative to brew (referring to #1802).

Furthermore there's now a table of contents of the high-level headings for finding things much faster in the README, because at this point the README is pretty huge.  
If not wanted, however, I will revert that commit.