### PR TITLE
fix: restore backward compatibility for subnet allocation (Fixes #1852, #1853)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -303,11 +303,7 @@ locals {
 
   # The first two subnets are respectively the default subnet 10.0.0.0/16 use for potientially anything and 10.1.0.0/16 used for control plane nodes.
   # the rest of the subnets are for agent nodes in each nodepools.
-
-  network_ipv4_subnets                     = [for index in range(4) : cidrsubnet(var.network_ipv4_cidr, 2, index)]
-  network_ipv4_subnets_agent_pools         = [for index in range(256) : cidrsubnet(local.network_ipv4_subnets[0], 8, index)]
-  network_ipv4_subnets_control_plane_pools = [for index in range(256) : cidrsubnet(local.network_ipv4_subnets[1], 8, index)]
-  network_ipv4_subnet_peripherals          = local.network_ipv4_subnets[2]
+  network_ipv4_subnets = [for index in range(256) : cidrsubnet(var.network_ipv4_cidr, 8, index)]
 
   # By convention the DNS service (usually core-dns) is assigned the 10th IP address in the service CIDR block
   cluster_dns_ipv4 = var.cluster_dns_ipv4 != null ? var.cluster_dns_ipv4 : cidrhost(var.service_ipv4_cidr, 10)

--- a/modules/host/out.tf
+++ b/modules/host/out.tf
@@ -7,7 +7,7 @@ output "ipv6_address" {
 }
 
 output "private_ipv4_address" {
-  value = one(hcloud_server.server.network).ip
+  value = try(one(hcloud_server.server.network).ip, "")
 }
 
 output "name" {

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -1,5 +1,5 @@
 locals {
-  nat_router_ip = cidrhost(resource.hcloud_network_subnet.peripherals.ip_range, 1)
+  nat_router_ip = var.nat_router != null ? cidrhost(hcloud_network_subnet.nat_router[0].ip_range, 1) : ""
   nat_router_data_center = var.nat_router != null ? {
     "fsn1" : "fsn1-dc14",
     "nbg1" : "nbg1-dc3",
@@ -82,7 +82,7 @@ resource "hcloud_server" "nat_router" {
   }
 
   network {
-    network_id = resource.hcloud_network_subnet.peripherals.network_id
+    network_id = data.hcloud_network.k3s.id
     ip         = local.nat_router_ip
     alias_ips  = []
   }

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,17 @@ variable "nat_router" {
   }
 }
 
+variable "nat_router_subnet_index" {
+  type        = number
+  default     = 200
+  description = "Subnet index (0-255) for NAT router. Default 200 is safe for most deployments. Must not conflict with control plane (counting down from 255) or agent pools (counting up from 0)."
+  
+  validation {
+    condition     = var.nat_router_subnet_index >= 0 && var.nat_router_subnet_index <= 255
+    error_message = "NAT router subnet index must be between 0 and 255."
+  }
+}
+
 
 variable "load_balancer_location" {
   description = "Default load balancer location."


### PR DESCRIPTION
## Summary

This PR fixes two critical issues that prevent users from upgrading to v2.18.0:
- Fixes #1853: CIDR range calculation errors due to subnet scheme changes
- Fixes #1852: Load balancer import failures during upgrade

The NAT router feature in v2.18.0 unnecessarily changed the entire subnet allocation scheme from 256 x /24 subnets to a complex /18→/26 scheme, breaking ALL existing deployments.

## Breaking Change in v2.18.0

**Before (working):**
- 256 x /24 subnets (254 usable IPs each)
- Control planes: subnets 255, 254, 253... (counting down)
- Agent pools: subnets 0, 1, 2... (counting up)

**v2.18.0 (broken):**
- 4 x /18 subnets subdivided into /26 (only 62 usable IPs)
- Tries to assign IP .101 but /26 only has 62 IPs
- Immediate terraform plan failures

## Solution

1. **Complete reversion** to the original subnet allocation scheme
2. **NAT router** now uses subnet 200 by default (configurable via `nat_router_subnet_index`)
3. **Full backward compatibility** - existing clusters can upgrade safely
4. **Load balancer import** issue fixed with safe network access

## Changes

- `locals.tf`: Restored original 256 x /24 subnet calculation
- `main.tf`: Restored original subnet allocation, added NAT router subnet
- `variables.tf`: Added `nat_router_subnet_index` variable (default: 200)
- `nat-router.tf`: Updated to use dedicated NAT subnet
- `modules/host/out.tf`: Fixed empty network handling

## Migration Guide

**For users on v2.17.x or earlier:**
- ✅ Can upgrade directly to this fix

**For users who already upgraded to v2.18.0:**
- ⚠️ Will need to recreate clusters or restore from v2.17.x backup
- The subnet scheme change is not reversible via terraform

## Test Plan

- [ ] Test upgrade from v2.17.x → this PR (should show no resource replacements)
- [ ] Test new deployment with NAT router enabled
- [ ] Test deployment with multiple control plane pools (5+)
- [ ] Test deployment with many agent pools (10+)
- [ ] Test load balancer import scenario from #1852
- [ ] Verify autoscaler nodes work correctly

## Notes

- Subnet 200 chosen for NAT router based on safety analysis (far from both allocation ends)
- Users with extreme cases can override with `nat_router_subnet_index`
- This prioritizes stability over "cleaner" architecture