### PR TITLE
fixes autoscaler resource permissions

### DIFF
--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -52,7 +52,12 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers"]
+    resources: 
+      - "storageclasses"
+      - "csinodes"
+      - "csistoragecapacities"
+      - "csidrivers"
+      - "volumeattachments"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -40,7 +40,6 @@ rules:
       - "replicationcontrollers"
       - "persistentvolumeclaims"
       - "persistentvolumes"
-      - "volumeattachments"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["extensions"]
     resources: ["replicasets", "daemonsets"]

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -51,12 +51,7 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: 
-      - "storageclasses"
-      - "csinodes"
-      - "csistoragecapacities"
-      - "csidrivers"
-      - "volumeattachments"
+    resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers", "volumeattachments"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]


### PR DESCRIPTION
Moved volumeattachments resource to storage.k8s.io api group according to https://github.com/kubernetes/autoscaler/pull/7904