### PR TITLE
Added cert_manager_version var in kube.tf.example

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1013,6 +1013,9 @@ encryption:
 MTU: 1450
   EOT */
 
+  # If you want to use a specific cert-manager helm chart version, set it below; otherwise, leave them as-is for the latest versions.
+  # cert_manager_version = ""
+
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
   # For cert-manager versions < v1.15.0, you need to set installCRDs: true instead of crds.enabled and crds.keep.


### PR DESCRIPTION
First off, many thanks for this amazing project, it's truly a great tool that caters to the vast majority of people that use / migrate to Hetzner imo.

I added the cert_manager_version since it was missing from the example but I am thinking we should also probably provide a warning that pinning is a good idea since cert-manager introduces breaking changes across their versions. It just happened to me these last few days.

If this is enough though we can just leave it as is.