### PR TITLE
fix: increase system-upgrade-controller timeout to 900s

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -461,7 +461,7 @@ resource "null_resource" "kustomization" {
         # Ready, set, go for the kustomization
         "kubectl apply -k /var/post_install",
         "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
-        "kubectl -n system-upgrade wait --for=condition=available --timeout=360s deployment/system-upgrade-controller",
+        "kubectl -n system-upgrade wait --for=condition=available --timeout=900s deployment/system-upgrade-controller",
         "sleep 7", # important as the system upgrade controller CRDs sometimes don't get ready right away, especially with Cilium.
         "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml"
       ],


### PR DESCRIPTION
## Summary
- Increases the system-upgrade-controller deployment timeout from 360s to 900s (15 minutes)
- Fixes deployment failures during initial cluster creation caused by temporary node taints

## Issue
Fixes #1880

## Problem
During initial cluster creation, the system-upgrade-controller was failing to deploy within the hardcoded 360-second timeout. This occurred because nodes have temporary taints that prevent pod scheduling:
- `node.cilium.io/agent-not-ready` - Cilium CNI still initializing  
- `node.cloudprovider.kubernetes.io/uninitialized: true` - Cloud controller manager initializing

These taints typically take 6-7 minutes to clear on fresh clusters, causing Terraform to fail even though the deployment eventually succeeds (~414 seconds in reported cases).

## Solution
Simple and backward-compatible: increase the timeout from 360s to 900s. This provides sufficient buffer for:
- CNI initialization (Cilium)
- Cloud controller manager initialization  
- Slower environments or resource-constrained nodes
- Various cluster configurations

## Test Plan
- [x] Reviewed code changes
- [x] Ran `terraform plan` to verify no breaking changes
- [ ] Test deployment on new cluster with small nodes (reproduces original issue)
- [ ] Verify deployment succeeds within new timeout
- [ ] Confirm no impact on existing clusters

## Notes
- This is a minimal, non-breaking change that maintains simplicity
- Alternative solutions (tolerations, configurable timeout) were considered but deemed unnecessary for this specific issue
- The 900s timeout aligns with other similar timeouts in the module

🤖 Generated with [Claude Code](https://claude.ai/code)