### PR TITLE
fix: add tolerations to Cilium Operator for cloud provider initialization taint

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -593,6 +593,13 @@ hubble:
 %{endfor~}
 %{endif~}
 
+# Operator tolerations to ensure it can schedule during cluster initialization
+operator:
+  tolerations:
+    - key: node.cloudprovider.kubernetes.io/uninitialized
+      operator: Exists
+      effect: NoSchedule
+
 MTU: 1450
   EOT
 


### PR DESCRIPTION
## Summary
- Adds toleration for `node.cloudprovider.kubernetes.io/uninitialized` taint to Cilium Operator
- Ensures operator can schedule during cluster initialization when nodes are temporarily tainted
- Simple, safe, and backward-compatible fix

## Issue
Fixes #1879

## Problem  
During initial cluster creation, the Cilium Operator pod remains unscheduled due to the `node.cloudprovider.kubernetes.io/uninitialized` taint applied by the cloud controller manager. This taint prevents normal pods from scheduling until cloud provider initialization completes, but the Cilium Operator needs to run during this bootstrap period.

## Solution
Added default tolerations to the Cilium Operator via Helm values in the default `cilium_values` configuration. The toleration uses `operator: Exists` to handle any value the taint might have, ensuring robust scheduling across different environments.

```yaml
operator:
  tolerations:
    - key: node.cloudprovider.kubernetes.io/uninitialized
      operator: Exists
      effect: NoSchedule
```

## Why This Approach
- **Safe default**: Tolerating a taint that may not exist is harmless and only affects scheduling during early bootstrap
- **Backward compatible**: Doesn't change behavior on clusters without this taint; users can still override via custom `cilium_values`
- **Simple**: Uses Cilium Helm chart's existing `operator.tolerations` pattern without introducing special-case logic
- **Minimal**: Avoids adding unnecessary variables or complexity

## Test Plan
- [x] Reviewed code changes
- [x] Ran `terraform fmt` to ensure proper formatting
- [x] Ran `terraform plan` to verify no breaking changes
- [ ] Test deployment on new cluster to verify operator schedules correctly
- [ ] Confirm no impact on existing clusters (toleration is harmless if taint doesn't exist)

## Notes
- This change only affects the default Cilium configuration
- Users with custom `cilium_values` are unaffected unless they adopt this toleration
- The toleration is specific to the cloud provider initialization phase and has no long-term effects

🤖 Generated with [Claude Code](https://claude.ai/code)