### PR TITLE
Revert "fix: add tolerations to Cilium Operator for cloud provider initialization taint"

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -593,13 +593,6 @@ hubble:
 %{endfor~}
 %{endif~}
 
-# Operator tolerations to ensure it can schedule during cluster initialization
-operator:
-  tolerations:
-    - key: node.cloudprovider.kubernetes.io/uninitialized
-      operator: Exists
-      effect: NoSchedule
-
 MTU: 1450
   EOT
 


### PR DESCRIPTION
Reverts kube-hetzner/terraform-hcloud-kube-hetzner#1882