### PR TITLE
Fix circular dependency with Hetzner CCM Helm deployment and Cilium CNI

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -593,6 +593,7 @@ hubble:
 %{endfor~}
 %{endif~}
 
+
 MTU: 1450
   EOT
 
@@ -701,6 +702,8 @@ env:
     value: "${!local.using_klipper_lb}"
   HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS:
     value: "true"
+# Use host network to avoid circular dependency with CNI
+hostNetwork: true
   EOT
 
   haproxy_values = var.haproxy_values != "" ? var.haproxy_values : <<EOT


### PR DESCRIPTION
## Summary
- Fixes circular dependency between Hetzner CCM Helm deployment and Cilium CNI
- Adds `hostNetwork: true` to Hetzner CCM Helm values to align with customization method behavior
- Enables CCM to start using host networking before CNI is ready

## Problem Analysis
When using Hetzner CCM via Helm with Cilium CNI, a circular dependency occurred:
1. **CCM pods** (deployed via Helm) required CNI network to start (no `hostNetwork`)
2. **Cilium operator** couldn't schedule due to `node.cloudprovider.kubernetes.io/uninitialized` taint
3. **Nodes remained uninitialized** because CCM couldn't start to remove the taint

## Root Cause
The difference between working customization method and failing Helm method:
- **Customization CCM**: Uses `hostNetwork: true` (works ✅)
- **Helm CCM**: Missing `hostNetwork: true` (fails ❌)

## Solution
Added `hostNetwork: true` to the Hetzner CCM Helm values in `locals.tf`, making Helm deployment behavior identical to customization deployment.

## Test Results
✅ All nodes Ready (control plane + agents)  
✅ Cilium operator: 2/2 Running  
✅ Cilium agents: Running on all nodes  
✅ Hetzner CCM: 1/1 Running with hostNetwork enabled  
✅ No circular dependency - CCM starts before CNI initialization  

## Test plan
- [x] Create test cluster with Cilium CNI and `hetzner_ccm_use_helm = true`
- [x] Verify all nodes reach Ready status
- [x] Confirm Cilium operator pods schedule successfully 
- [x] Confirm Hetzner CCM pod runs with hostNetwork enabled
- [x] Verify no resource recreation on upgrade from current master
- [x] Test with both minimal and complex configurations

Fixes #1879

🤖 Generated with [Claude Code](https://claude.ai/code)