### PR TITLE
[Bug]: Hardcoded gateway 10.0.0.1 breaks custom network_ipv4_cidr (e.g. 10.1.0.0/16)

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -39,6 +39,8 @@ module "agents" {
 
   automatically_upgrade_os = var.automatically_upgrade_os
 
+  network_gw_ipv4 = local.network_gw_ipv4
+
   depends_on = [
     hcloud_network_subnet.agent,
     hcloud_placement_group.agent,

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -129,6 +129,7 @@ data "cloudinit_config" "autoscaler_config" {
         cloudinit_write_files_common = local.cloudinit_write_files_common
         cloudinit_runcmd_common      = local.cloudinit_runcmd_common,
         private_network_only         = var.autoscaler_disable_ipv4 && var.autoscaler_disable_ipv6,
+        network_gw_ipv4              = local.network_gw_ipv4
       }
     )
   }
@@ -168,6 +169,7 @@ data "cloudinit_config" "autoscaler_legacy_config" {
         cloudinit_write_files_common = local.cloudinit_write_files_common
         cloudinit_runcmd_common      = local.cloudinit_runcmd_common,
         private_network_only         = var.autoscaler_disable_ipv4 && var.autoscaler_disable_ipv6,
+        network_gw_ipv4              = local.network_gw_ipv4,
       }
     )
   }

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -42,6 +42,8 @@ module "control_planes" {
 
   automatically_upgrade_os = var.automatically_upgrade_os
 
+  network_gw_ipv4 = local.network_gw_ipv4
+
   depends_on = [
     hcloud_network_subnet.control_plane,
     hcloud_placement_group.control_plane,

--- a/locals.tf
+++ b/locals.tf
@@ -103,7 +103,7 @@ locals {
         "if ip link show eth1 &>/dev/null; then",
         "  # Add default route via private network with high metric",
         "  # Metric 20101 matches current DHCP-provided route for compatibility",
-        "  ip route add default via 10.0.0.1 dev eth1 metric 20101 2>/dev/null",
+        "  ip route add default via ${local.network_gw_ipv4} dev eth1 metric 20101 2>/dev/null",
         "  ",
         "  # Configure NetworkManager to ignore DHCP default route on private interface",
         "  if systemctl is-active --quiet NetworkManager; then",
@@ -307,6 +307,8 @@ locals {
 
   # By convention the DNS service (usually core-dns) is assigned the 10th IP address in the service CIDR block
   cluster_dns_ipv4 = var.cluster_dns_ipv4 != null ? var.cluster_dns_ipv4 : cidrhost(var.service_ipv4_cidr, 10)
+
+  network_gw_ipv4 = cidrhost(var.network_ipv4_cidr, 1)
 
   # if we are in a single cluster config, we use the default klipper lb instead of Hetzner LB
   control_plane_count    = sum([for v in var.control_plane_nodepools : v.count])

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -188,6 +188,7 @@ data "cloudinit_config" "config" {
         cloudinit_runcmd_common      = var.cloudinit_runcmd_common
         swap_size                    = var.swap_size
         private_network_only         = (var.disable_ipv4 && var.disable_ipv6)
+        network_gw_ipv4              = var.network_gw_ipv4
       }
     )
   }

--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -35,7 +35,7 @@ ${cloudinit_runcmd_common}
 # Configure default routes based on public ip availability
 %{if private_network_only~}
 # Private-only setup: eth0 is the private interface
-- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0', metric, '100']
+- [ip, route, add, default, via, '${network_gw_ipv4}', dev, 'eth0', metric, '100']
 %{else~}
 # Standard setup: eth0 is public, configure both IPv4 and IPv6
 - [ip, route, add, default, via, '172.31.1.1', dev, 'eth0', metric, '100']

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -172,3 +172,8 @@ variable "ssh_bastion" {
     bastion_private_key = string
   })
 }
+
+variable "network_gw_ipv4" {
+  type    = string
+  default = "Default IPv4 gateway address for the node's primary network interface"
+}

--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -45,7 +45,7 @@ ${cloudinit_runcmd_common}
 # Configure default routes based on public ip availability
 %{if private_network_only~}
 # Private-only setup: eth0 is the private interface
-- [ip, route, add, default, via, '10.0.0.1', dev, 'eth0', metric, '100']
+- [ip, route, add, default, via, '${network_gw_ipv4}', dev, 'eth0', metric, '100']
 %{else~}
 # Standard setup: eth0 is public, configure both IPv4 and IPv6
 - [ip, route, add, default, via, '172.31.1.1', dev, 'eth0', metric, '100']


### PR DESCRIPTION
## Description  

### Problem  
When using a `network_ipv4_cidr` different from `10.0.0.0/8` (e.g. `10.1.0.0/16`), cluster nodes lose egress.  
In the cloud-init/script a hardcoded default route is added:  

```bash
ip route add default via 10.0.0.1 dev eth1 metric 20101 2>/dev/null
```  

In Hetzner Cloud, the correct gateway for each `/16` subnet is always the **first IP address** of that subnet (`10.X.0.1`).  
For `10.1.0.0/16` this should be `10.1.0.1`. With the hardcoded `10.0.0.1`, the next hop does not exist → `Network unreachable`.  

---

### Steps to Reproduce  
1. Set `network_ipv4_cidr = "10.1.0.0/16"`.  
2. Deploy the cluster.  
3. Check routing and connectivity:  
   ```bash
   ip route
   tracepath 8.8.8.8
   dig @8.8.8.8 google.com
   ```  
4. The default route points to `10.0.0.1` and traffic cannot leave the cluster.  

---

### Expected Behavior  
Default route should point to the **first address of the actual subnet** derived from `network_ipv4_cidr` or nodepool subnet (`cidrhost(<cidr>, 1)`).  

---

### Actual Behavior  
Default route is always set to `10.0.0.1`, which only works for `10.0.0.0/16`.  
