### PR TITLE
fix: update kured deployment to use combined.yaml manifest

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -136,7 +136,7 @@ locals {
     kind       = "Kustomization"
     resources = concat(
       [
-        "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-dockerhub.yaml",
+        "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-combined.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
       ],


### PR DESCRIPTION
## Summary
- Switch kured deployment from `dockerhub.yaml` to `combined.yaml` manifest
- This change uses the more comprehensive combined manifest that includes all necessary resources

## Problem
The current kured deployment uses the `dockerhub.yaml` manifest which may be deprecated or missing certain components compared to the `combined.yaml` version.

## Solution
Update the kured resource URL in `locals.tf` to use the `combined.yaml` manifest instead of `dockerhub.yaml`.

## Test plan
- [x] Run `terraform plan` on existing deployment to ensure no resource recreation
- [x] Verify kured deployment works correctly with the new manifest
- [x] Test upgrade path from existing deployments

## Backward Compatibility
✅ This change is backward compatible - it only updates the manifest URL and should not cause any resource recreation.