### PR TITLE
Document kube.tf autoscaler min_nodes option

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -368,6 +368,7 @@ module "kube-hetzner" {
   #    name        = "autoscaled-small"
   #    server_type = "cx32"
   #    location    = "fsn1"
+  #    # Add the arg --enforce-node-group-min-size=true in the cluster_autoscaler_extra_args option below if you want min_nodes to be effective
   #    min_nodes   = 0
   #    max_nodes   = 5
   #    labels      = {


### PR DESCRIPTION
Spent a bunch of minutes figuring out why the autoscaler didn't have the default minimum amount of nodes provided, I think adding this simple line comment can save some minutes to a bunch of people