### PR TITLE
add control_plane_endpoint variable for external load balancer

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -51,7 +51,7 @@ locals {
   k3s-agent-config = { for k, v in local.agent_nodes : k => merge(
     {
       node-name = module.agents[k].name
-      server    = "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443"
+      server    = coalesce(var.control_plane_endpoint, "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443")
       token     = local.k3s_token
       # Kubelet arg precedence (last wins): local.kubelet_arg > v.kubelet_args > k3s_global_kubelet_args > k3s_agent_kubelet_args
       kubelet-arg = concat(

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -544,6 +544,9 @@ module "kube-hetzner" {
   # Please note that because the klipperLB points to all nodes, we automatically allow scheduling on the control plane when it is active.
   # enable_klipper_metal_lb = "true"
 
+  # When using an external load balancer, you can specify a stable control plane endpoint URL.
+  # control_plane_endpoint="https://my-external-lb:6443"
+
   # If you want to configure additional arguments for traefik, enter them here as a list and in the form of traefik CLI arguments; see https://doc.traefik.io/traefik/reference/static-configuration/cli/
   # They are the options that go into the additionalArguments section of the Traefik helm values file.
   # We already add "providers.kubernetesingress.ingressendpoint.publishedservice" by default so that Traefik works automatically with services such as External-DNS and ArgoCD.

--- a/variables.tf
+++ b/variables.tf
@@ -1239,3 +1239,14 @@ variable "hetzner_ccm_values" {
   default     = ""
   description = "Additional helm values file to pass to Hetzner Controller Manager as 'valuesContent' at the HelmChart."
 }
+
+variable "control_plane_endpoint" {
+  type        = string
+  description = "Optional external control plane endpoint URL (e.g. https://myapi.domain.com:6443). Used as the k3s 'server' value for agents and secondary control planes."
+  default     = null
+  validation {
+    condition = can(regex("^https?://(?:[a-zA-Z0-9.-]+|(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|\\[[0-9a-fA-F:]+\\])(?::[0-9]{1,5})?(?:/.*)?$", var.control_plane_endpoint)) || var.control_plane_endpoint == null
+
+    error_message = "The control_plane_endpoint must be null or a valid URL (e.g., https://my-api.example.com:6443)."
+  }
+}


### PR DESCRIPTION


Hello,
Thanks for this amazing project!

In some setups, especially when using an external load balancer (e.g. HAProxy), agents and secondary control planes could connect to the cluster through a stable endpoint instead of directly using one of the control plane nodes.

When using the option enable_klipper_metal_lb = true it is sometimes useful to force setting an URL for the external load balancer.
This PR adds this option thanks to the new variable `control_plane_endpoint`.

Example:
`control_plane_endpoint = "https://haproxy.mydomain.com:6443"`

Note: I open this PR again to get a clean discussion history.

Thanks!
