### PR TITLE
Add ability to run local commands before Kustomization

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -2829,6 +2829,25 @@ The following variables have been added to the `kube-hetzner` module since the i
   * **Purpose:** Variables passed to `extra-manifests/kustomization.yaml.tpl`
   * **Use Case:** Template variables for custom kustomization overlays
 
+```terraform
+  # Extra commands to be executed locally before the `kubectl apply -k` (useful for pre-install actions, e.g. install repos and CRDs). Default is "".
+  # Note: The commands are run locally and they are run only when the list of commands has changed. Therefore Terraform does not enforce or check that the resources exist later on.
+  # The option requires setting `create_kubeconfig = true`.
+  # Example: 
+  # extra_kustomize_pre_deployment_local_exec = <<-EOT
+  #   helm repo add external-secrets https://charts.external-secrets.io
+  #   helm install --wait --wait-for-jobs --timeout 1m0s external-secrets external-secrets/external-secrets -n external-secrets --create-namespace 
+  # EOT
+  # extra_kustomize_pre_deployment_local_exec = ""
+```
+
+* **`extra_kustomize_pre_deployment_local_exec` (String, Optional):**
+  * **Default:** Empty string ""
+  * **Purpose:** Commands to be executed locally before the kustomization `kubectl apply -k` and `extra_kustomize_deployment_commands`. 
+  * **Use Cases:** 
+    * Add repos
+    * Install CRDs
+
 **MicroOS Snapshot Control**
 
 ```terraform

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -952,6 +952,16 @@ module "kube-hetzner" {
   # More information about the registration can be found here https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/
   # rancher_registration_manifest_url = "https://rancher.xyz.dev/v3/import/xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz.yaml"
 
+  # Extra commands to be executed locally before the `kubectl apply -k` (useful for pre-install actions, e.g. install repos and CRDs). Default is "".
+  # The option requires setting `create_kubeconfig = true`.
+  # Note: The commands are run locally and they are run only when the list of commands has changed. Therefore Terraform does not enforce or check that the resources exist later on.
+  # Example: 
+  # extra_kustomize_pre_deployment_local_exec = <<-EOT
+  #   helm repo add external-secrets https://charts.external-secrets.io
+  #   helm install --wait --wait-for-jobs --timeout 1m0s external-secrets external-secrets/external-secrets -n external-secrets --create-namespace 
+  # EOT
+  # extra_kustomize_pre_deployment_local_exec = ""
+
   # Extra commands to be executed after the `kubectl apply -k` (useful for post-install actions, e.g. wait for CRD, apply additional manifests, etc.).
   # extra_kustomize_deployment_commands=""
 

--- a/variables.tf
+++ b/variables.tf
@@ -1068,6 +1068,11 @@ variable "postinstall_exec" {
   description = "Additional to execute after the install calls, for example restoring a backup."
 }
 
+variable "extra_kustomize_pre_deployment_local_exec" {
+  type        = string
+  default     = ""
+  description = "A series of commands to be executed locally before the user kustomizations are applied. Useful for pre-install actions like adding Helm repositories or installing CRDs before the main kustomization manifests are deployed."
+}
 
 variable "extra_kustomize_deployment_commands" {
   type        = string


### PR DESCRIPTION
### Summary
Add variable `extra_kustomize_pre_deployment_local_exec` for running commands before the Kustomization.
Purpose of the variable is to be able add repos and CRDs before the Kustomization and Kustomization-post commands.

### Test plan
- [ ] Test without the setting, validate that nothing changes.
- [ ] Add repo and helm CRDs via the  `extra_kustomize_pre_deployment_local_exec`. Validate that they were added succesfully.

### Gemini

> This pull request enhances the deployment workflow by introducing a new `extra_kustomize_pre_deployment_local_exec` variable. This variable allows users to define and execute arbitrary local commands prior to the main Kustomization application step. This is particularly useful for managing dependencies such as Helm chart repositories or Custom Resource Definitions (CRDs) that must be present before other Kubernetes resources can be deployed, thereby improving the robustness and flexibility of complex application deployments.
> 
> ### Highlights
> * **New Pre-Deployment Hook**: Introduced `extra_kustomize_pre_deployment_local_exec` to run local commands before the main Kustomization application step.
> * **CRD and Repo Management**: This new variable enables the pre-installation of Helm repositories and Custom Resource Definitions (CRDs), which is crucial for applications that require these resources to be present before their deployment.
> * **Local Execution & Idempotency**: The commands specified are executed locally and are only re-run if the content of the `extra_kustomize_pre_deployment_local_exec` variable changes, ensuring controlled and predictable execution.
> 