### PR TITLE
Feature: Adds CredentialProviderConfig to the Kubelet and the AWS ECR credential provider to the OpenSuSE base image

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -41,6 +41,9 @@ module "agents" {
 
   network_gw_ipv4 = local.network_gw_ipv4
 
+  credential_provider_config_content = var.credential_provider_config_content
+  credential_provider_config_path    = var.credential_provider_config_path
+
   depends_on = [
     hcloud_network_subnet.agent,
     hcloud_placement_group.agent,
@@ -60,7 +63,8 @@ locals {
         local.kubelet_arg,
         v.kubelet_args,
         var.k3s_global_kubelet_args,
-        var.k3s_agent_kubelet_args
+        var.k3s_agent_kubelet_args,
+        local.credential_provider_kubelet_arg
       )
       flannel-iface = local.flannel_iface
       node-ip       = module.agents[k].private_ipv4_address

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -44,6 +44,9 @@ module "control_planes" {
 
   network_gw_ipv4 = local.network_gw_ipv4
 
+  credential_provider_config_content = var.credential_provider_config_content
+  credential_provider_config_path    = var.credential_provider_config_path
+
   depends_on = [
     hcloud_network_subnet.control_plane,
     hcloud_placement_group.control_plane,
@@ -118,7 +121,7 @@ locals {
       disable-kube-proxy       = var.disable_kube_proxy
       disable                  = local.disable_extras
       # Kubelet arg precedence (last wins): local.kubelet_arg > v.kubelet_args > k3s_global_kubelet_args > k3s_control_plane_kubelet_args
-      kubelet-arg                 = concat(local.kubelet_arg, v.kubelet_args, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args)
+      kubelet-arg                 = concat(local.kubelet_arg, v.kubelet_args, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args, local.credential_provider_kubelet_arg)
       kube-apiserver-arg          = local.kube_apiserver_arg
       kube-controller-manager-arg = local.kube_controller_manager_arg
       flannel-iface               = local.flannel_iface

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1226,6 +1226,30 @@ replicas: 1
 bootstrapPassword: "supermario"
   EOT */
 
+  # Uncomment if you want to deploy a credential provider configuration.
+  # If this is for an ECR ensure the base image contains the necessary files (variable 'include_aws_ecr_credential_provider')
+  /*
+  credential_provider_bin_path="/opt/kubernetes-credential-provider/bin"
+  credential_provider_config_path="/opt/kubernetes-credential-provider/credential-provider-config.yaml"
+  credential_provider_config_content = <<EOT
+  apiVersion: kubelet.config.k8s.io/v1
+  kind: CredentialProviderConfig
+  providers:
+    - name: ecr-credential-provider
+      matchImages:
+        - "*.dkr.ecr.*.amazonaws.com"
+      defaultCacheDuration: "12h"
+      apiVersion: credentialprovider.kubelet.k8s.io/v1
+      env:
+        # Option 1: Provide credentials directly
+        - name: AWS_ACCESS_KEY_ID
+          value: ""
+        - name: AWS_SECRET_ACCESS_KEY
+          value: ""
+        # Option 2: Provide the AWS profile to use (in /root/.aws/config). Ensure that the config is added in the base image.
+        - name: AWS_PROFILE
+          value: ""
+EOT*/
 }
 
 provider "hcloud" {

--- a/locals.tf
+++ b/locals.tf
@@ -1274,4 +1274,9 @@ cloudinit_runcmd_common = <<EOT
 
 EOT
 
+credential_provider_kubelet_arg = var.credential_provider_config_path != null && var.credential_provider_bin_path != null ? [
+  "image-credential-provider-config=${var.credential_provider_config_path}",
+  "image-credential-provider-bin-dir=${var.credential_provider_bin_path}"
+] : []
+
 }

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -121,6 +121,29 @@ resource "hcloud_server" "server" {
 
 }
 
+resource "null_resource" "credential_provider_config" {
+  count = (var.credential_provider_config_content != null && var.credential_provider_config_path != null) ? 1 : 0
+
+  connection {
+    user           = "root"
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
+    host           = coalesce(hcloud_server.server.ipv4_address, hcloud_server.server.ipv6_address, try(one(hcloud_server.server.network).ip, null))
+    port           = var.ssh_port
+
+    bastion_host        = var.ssh_bastion.bastion_host
+    bastion_port        = var.ssh_bastion.bastion_port
+    bastion_user        = var.ssh_bastion.bastion_user
+    bastion_private_key = var.ssh_bastion.bastion_private_key
+
+  }
+
+  provisioner "file" {
+    content     = var.credential_provider_config_content
+    destination = var.credential_provider_config_path
+  }
+}
+
 resource "null_resource" "registries" {
   triggers = {
     registries = var.k3s_registries

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -177,3 +177,15 @@ variable "network_gw_ipv4" {
   type    = string
   default = "Default IPv4 gateway address for the node's primary network interface"
 }
+
+variable "credential_provider_config_content" {
+  description = "Content of the credential provider configuration file"
+  type        = string
+  default     = null
+}
+
+variable "credential_provider_config_path" {
+  description = "Path to the credential provider configuration file"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1245,3 +1245,21 @@ variable "hetzner_ccm_values" {
   default     = ""
   description = "Additional helm values file to pass to Hetzner Controller Manager as 'valuesContent' at the HelmChart."
 }
+
+variable "credential_provider_config_content" {
+  description = "Content of the credential provider config YAML file."
+  type        = string
+  default     = null
+}
+
+variable "credential_provider_config_path" {
+  description = "Path where the credential provider config YAML file will be created. This path will be added to the kubelet argument \"image-credential-provider-config\""
+  type        = string
+  default     = null
+}
+
+variable "credential_provider_bin_path" {
+  description = "Path where the credential provider will be searched. This path will be added to the kubelet argument \"image-credential-provider-bin-dir\""
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Summary

Adds ability to provide the CredentialProviderConfig to the Kubelet and adds the AWS ECR credential provider to the OpenSuSE base image (optional)

### Details

Credential Provider Configuration
- Extends host module to (optionally) take the path and the contents of the CredentialProviderConfig and place the file on every node.
- Extends Kubelet arguments of agent and control-plane nodes to add the credential provider config
- Allow setting the path of the configuration and bin-directory via variables, providing a default matching the base image

AWS ECR Credential Provider extension in the base image
- Adds variable to enable the integration of the related files into the base image (defaults to false)
- Builds `ecr-credential-provider` binary using sources provided by the Kubernetes GitHub repository