### PR TITLE
Wait for system deployments and jobs on init

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -485,7 +485,11 @@ resource "null_resource" "kustomization" {
         "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
         "kubectl -n system-upgrade wait --for=condition=available --timeout=900s deployment/system-upgrade-controller",
         "sleep 7", # important as the system upgrade controller CRDs sometimes don't get ready right away, especially with Cilium.
-        "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml"
+        "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml",
+        # Wait for all system deployments, daemonsets and jobs to become available or complete
+        "kubectl wait --all-namespaces deployment --all --for=condition=Available --timeout=600s",
+        "kubectl wait --all-namespaces job --all --for=condition=Complete --timeout=600s",
+        "kubectl wait --all-namespaces pod --for=condition=Ready --field-selector=status.phase!=Succeeded,status.phase!=Failed --timeout=600s"
       ],
       local.has_external_load_balancer ? [] : [
         <<-EOT


### PR DESCRIPTION
### Description

Adds wait-steps to wait for system deployments and jobs on init. Some of the system-Helms, for example cert-manager and longhorn are a bit slow to start completely and subsequent manifest installations may fail if these expected system helms are not yet fully installed.

To inspect I ran a `kubectl get pods,deployments,jobs -A` command right after this line:
https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/ee1b6badba4223ff6dc7f619e52aee7f822db48c/init.tf#L488

**Before waits**
Looking at the output below, certain deployments and jobs were still in different states of initialization. (List of Pods is just for reference here and other types were excluded from this extract)

``` 
 NAMESPACE         NAME                                                     READY   STATUS              RESTARTS   AGE
 kube-system       pod/cilium-9lfk6                                         1/1     Running             0          39s
 kube-system       pod/cilium-c7n4s                                         1/1     Running             0          39s
 kube-system       pod/cilium-envoy-5f59d                                   1/1     Running             0          39s
 kube-system       pod/cilium-envoy-cxm94                                   1/1     Running             0          39s
 kube-system       pod/cilium-envoy-fbd8z                                   1/1     Running             0          39s
 kube-system       pod/cilium-envoy-jgzfv                                   1/1     Running             0          39s
 kube-system       pod/cilium-envoy-vsxzx                                   1/1     Running             0          39s
 kube-system       pod/cilium-envoy-x4wmd                                   1/1     Running             0          39s
 kube-system       pod/cilium-ffjlf                                         1/1     Running             0          39s
 kube-system       pod/cilium-ldz5p                                         1/1     Running             0          39s
 kube-system       pod/cilium-operator-657f46f59c-ccfc6                     1/1     Running             0          39s
 kube-system       pod/cilium-operator-657f46f59c-kfmqz                     1/1     Running             0          39s
 kube-system       pod/cilium-qlvq5                                         1/1     Running             0          39s
 kube-system       pod/cilium-vj4vx                                         1/1     Running             0          39s
 kube-system       pod/coredns-64fd4b4794-mgpwv                             1/1     Running             0          2m48s
 kube-system       pod/hcloud-cloud-controller-manager-fc85ff7c7-z24sh      1/1     Running             0          42s
 kube-system       pod/hcloud-csi-controller-767b5cf9cd-b2qn8               5/5     Running             0          42s
 kube-system       pod/hcloud-csi-node-7twfd                                3/3     Running             0          42s
 kube-system       pod/hcloud-csi-node-95ms6                                3/3     Running             0          42s
 kube-system       pod/hcloud-csi-node-p92ft                                3/3     Running             0          42s
 kube-system       pod/helm-install-cert-manager-69vmt                      1/1     Running             0          50s
 kube-system       pod/helm-install-cilium-9vfzc                            0/1     Completed           0          50s
 kube-system       pod/helm-install-hcloud-cloud-controller-manager-bpzmt   0/1     Completed           0          50s
 kube-system       pod/helm-install-hcloud-csi-4rp48                        0/1     Completed           0          49s
 kube-system       pod/helm-install-longhorn-xzjvp                          0/1     Completed           0          49s
 kube-system       pod/helm-install-traefik-2zpm2                           0/1     Completed           0          49s
 kube-system       pod/kured-272nr                                          1/1     Running             0          13s
 kube-system       pod/kured-2m8gz                                          1/1     Running             0          13s
 kube-system       pod/kured-8l8fp                                          1/1     Running             0          13s
 kube-system       pod/kured-bvwgs                                          0/1     ContainerCreating   0          10s
 kube-system       pod/kured-knhgh                                          1/1     Running             0          13s
 kube-system       pod/kured-r6gbn                                          1/1     Running             0          13s
 kube-system       pod/metrics-server-7bfffcd44-nbdvg                       1/1     Running             0          2m48s
 longhorn-system   pod/longhorn-driver-deployer-74f45ccf86-brfjp            0/1     Init:0/1            0          1s
 longhorn-system   pod/longhorn-manager-2mkkz                               0/2     ContainerCreating   0          1s
 longhorn-system   pod/longhorn-manager-2n656                               0/2     ContainerCreating   0          1s
 longhorn-system   pod/longhorn-manager-qld5m                               0/2     ContainerCreating   0          1s
 longhorn-system   pod/longhorn-ui-7b8657c6cd-cbdtx                         0/1     ContainerCreating   0          1s
 longhorn-system   pod/longhorn-ui-7b8657c6cd-jq66n                         0/1     ContainerCreating   0          1s
 system-upgrade    pod/system-upgrade-controller-6df5bf54f6-zsrdv           1/1     Running             0          50s
 traefik           pod/traefik-79c7f596d9-k2p2q                             1/1     Running             0          25s
 traefik           pod/traefik-79c7f596d9-tvr9g                             1/1     Running             0          25s
 traefik           pod/traefik-79c7f596d9-zzspd                             1/1     Running             0          40s
 
 NAMESPACE         NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
 cert-manager      deployment.apps/cert-manager                      0/1     0            0           0s
 cert-manager      deployment.apps/cert-manager-cainjector           0/1     0            0           0s
 cert-manager      deployment.apps/cert-manager-webhook              0/1     0            0           0s
 kube-system       deployment.apps/cilium-operator                   2/2     2            2           39s
 kube-system       deployment.apps/coredns                           1/1     1            1           2m51s
 kube-system       deployment.apps/hcloud-cloud-controller-manager   1/1     1            1           42s
 kube-system       deployment.apps/hcloud-csi-controller             1/1     1            1           42s
 kube-system       deployment.apps/metrics-server                    1/1     1            1           2m50s
 longhorn-system   deployment.apps/longhorn-driver-deployer          0/1     1            0           1s
 longhorn-system   deployment.apps/longhorn-ui                       0/2     2            0           1s
 system-upgrade    deployment.apps/system-upgrade-controller         1/1     1            1           50s
 traefik           deployment.apps/traefik                           3/3     3            3           40s
 
 NAMESPACE     NAME                                                     STATUS     COMPLETIONS   DURATION   AGE
 kube-system   job.batch/helm-install-cert-manager                      Running    0/1           50s        50s
 kube-system   job.batch/helm-install-cilium                            Complete   1/1           14s        50s
 kube-system   job.batch/helm-install-hcloud-cloud-controller-manager   Complete   1/1           10s        50s
 kube-system   job.batch/helm-install-hcloud-csi                        Complete   1/1           10s        49s
 kube-system   job.batch/helm-install-longhorn                          Running    0/1           49s        49s
 kube-system   job.batch/helm-install-traefik                           Complete   1/1           12s        49s

```
**After wait**
Then waiting for the deployments and jobs as described in this PR and running the same `kubectl get all -A` right after those waits yields:

```
 NAMESPACE         NAME                                                     READY   STATUS      RESTARTS   AGE
 cert-manager      pod/cert-manager-77b74755d9-ffdhb                        1/1     Running     0          23s
 cert-manager      pod/cert-manager-cainjector-65fcfd6ccf-sf7mm             1/1     Running     0          23s
 cert-manager      pod/cert-manager-webhook-9b4dd78-957r9                   1/1     Running     0          23s
 kube-system       pod/cilium-9lfk6                                         1/1     Running     0          62s
 kube-system       pod/cilium-c7n4s                                         1/1     Running     0          62s
 kube-system       pod/cilium-envoy-5f59d                                   1/1     Running     0          62s
 kube-system       pod/cilium-envoy-cxm94                                   1/1     Running     0          62s
 kube-system       pod/cilium-envoy-fbd8z                                   1/1     Running     0          62s
 kube-system       pod/cilium-envoy-jgzfv                                   1/1     Running     0          62s
 kube-system       pod/cilium-envoy-vsxzx                                   1/1     Running     0          62s
 kube-system       pod/cilium-envoy-x4wmd                                   1/1     Running     0          62s
 kube-system       pod/cilium-ffjlf                                         1/1     Running     0          62s
 kube-system       pod/cilium-ldz5p                                         1/1     Running     0          62s
 kube-system       pod/cilium-operator-657f46f59c-ccfc6                     1/1     Running     0          62s
 kube-system       pod/cilium-operator-657f46f59c-kfmqz                     1/1     Running     0          62s
 kube-system       pod/cilium-qlvq5                                         1/1     Running     0          62s
 kube-system       pod/cilium-vj4vx                                         1/1     Running     0          62s
 kube-system       pod/coredns-64fd4b4794-mgpwv                             1/1     Running     0          3m11s
 kube-system       pod/hcloud-cloud-controller-manager-fc85ff7c7-z24sh      1/1     Running     0          65s
 kube-system       pod/hcloud-csi-controller-767b5cf9cd-b2qn8               5/5     Running     0          65s
 kube-system       pod/hcloud-csi-node-7twfd                                3/3     Running     0          65s
 kube-system       pod/hcloud-csi-node-95ms6                                3/3     Running     0          65s
 kube-system       pod/hcloud-csi-node-p92ft                                3/3     Running     0          65s
 kube-system       pod/helm-install-cert-manager-69vmt                      0/1     Completed   0          73s
 kube-system       pod/helm-install-cilium-9vfzc                            0/1     Completed   0          73s
 kube-system       pod/helm-install-hcloud-cloud-controller-manager-bpzmt   0/1     Completed   0          73s
 kube-system       pod/helm-install-hcloud-csi-4rp48                        0/1     Completed   0          72s
 kube-system       pod/helm-install-longhorn-xzjvp                          0/1     Completed   0          72s
 kube-system       pod/helm-install-traefik-2zpm2                           0/1     Completed   0          72s
 kube-system       pod/kured-272nr                                          1/1     Running     0          36s
 kube-system       pod/kured-2m8gz                                          1/1     Running     0          36s
 kube-system       pod/kured-8l8fp                                          1/1     Running     0          36s
 kube-system       pod/kured-bvwgs                                          1/1     Running     0          33s
 kube-system       pod/kured-knhgh                                          1/1     Running     0          36s
 kube-system       pod/kured-r6gbn                                          1/1     Running     0          36s
 kube-system       pod/metrics-server-7bfffcd44-nbdvg                       1/1     Running     0          3m11s
 longhorn-system   pod/engine-image-ei-26bab25d-87sdv                       0/1     Running     0          8s
 longhorn-system   pod/engine-image-ei-26bab25d-pkv5d                       0/1     Running     0          8s
 longhorn-system   pod/engine-image-ei-26bab25d-wttkg                       0/1     Running     0          8s
 longhorn-system   pod/longhorn-driver-deployer-74f45ccf86-brfjp            1/1     Running     0          24s
 longhorn-system   pod/longhorn-manager-2mkkz                               2/2     Running     0          24s
 longhorn-system   pod/longhorn-manager-2n656                               2/2     Running     0          24s
 longhorn-system   pod/longhorn-manager-qld5m                               2/2     Running     0          24s
 longhorn-system   pod/longhorn-ui-7b8657c6cd-cbdtx                         1/1     Running     0          24s
 longhorn-system   pod/longhorn-ui-7b8657c6cd-jq66n                         1/1     Running     0          24s
 system-upgrade    pod/system-upgrade-controller-6df5bf54f6-zsrdv           1/1     Running     0          73s
 traefik           pod/traefik-79c7f596d9-k2p2q                             1/1     Running     0          48s
 traefik           pod/traefik-79c7f596d9-tvr9g                             1/1     Running     0          48s
 traefik           pod/traefik-79c7f596d9-zzspd                             1/1     Running     0          63s

 NAMESPACE         NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
 cert-manager      deployment.apps/cert-manager                      1/1     1            1           23s
 cert-manager      deployment.apps/cert-manager-cainjector           1/1     1            1           23s
 cert-manager      deployment.apps/cert-manager-webhook              1/1     1            1           23s
 kube-system       deployment.apps/cilium-operator                   2/2     2            2           62s
 kube-system       deployment.apps/coredns                           1/1     1            1           3m14s
 kube-system       deployment.apps/hcloud-cloud-controller-manager   1/1     1            1           65s
 kube-system       deployment.apps/hcloud-csi-controller             1/1     1            1           65s
 kube-system       deployment.apps/metrics-server                    1/1     1            1           3m13s
 longhorn-system   deployment.apps/longhorn-driver-deployer          1/1     1            1           24s
 longhorn-system   deployment.apps/longhorn-ui                       2/2     2            2           24s
 system-upgrade    deployment.apps/system-upgrade-controller         1/1     1            1           73s
 traefik           deployment.apps/traefik                           3/3     3            3           63s

 NAMESPACE     NAME                                                     STATUS     COMPLETIONS   DURATION   AGE
 kube-system   job.batch/helm-install-cert-manager                      Complete   1/1           72s        73s
 kube-system   job.batch/helm-install-cilium                            Complete   1/1           14s        73s
 kube-system   job.batch/helm-install-hcloud-cloud-controller-manager   Complete   1/1           10s        73s
 kube-system   job.batch/helm-install-hcloud-csi                        Complete   1/1           10s        72s
 kube-system   job.batch/helm-install-longhorn                          Complete   1/1           51s        72s
 kube-system   job.batch/helm-install-traefik                           Complete   1/1           12s        72s
```