### PR TITLE
Update hcloud plugin source in Packer template

### DIFF
--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -5,7 +5,7 @@ packer {
   required_plugins {
     hcloud = {
       version = ">= 1.0.5"
-      source  = "github.com/hashicorp/hcloud"
+      source  = "github.com/hetznercloud/hcloud"
     }
   }
 }


### PR DESCRIPTION
This pull request makes a small but important update to the Packer plugin configuration. The source for the `hcloud` plugin is corrected from `github.com/hashicorp/hcloud` to the official `github.com/hetznercloud/hcloud`.

https://github.com/hetznercloud/packer-plugin-hcloud/blob/f9d9fd89ac353432997556034064cbc82f44f2a2/docs/README.md?plain=1#L25-L39

Fixes #1890