### PR TITLE
fix: detect public network interface dynamically for ARM servers

### DIFF
--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -63,8 +63,14 @@ ${cloudinit_runcmd_common}
     awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}'
   }
   PUB_IF=$(ip -4 route get 172.31.1.1 2>/dev/null | route_dev)
+  # Verify we didn't accidentally pick the private interface (can happen if network_ipv4_cidr overlaps 172.31.0.0/16)
+  PRIV_IF=$(ip -4 route get '${network_gw_ipv4}' 2>/dev/null | route_dev)
+  if [ -n "$PRIV_IF" ] && [ "$PUB_IF" = "$PRIV_IF" ]; then
+    echo "WARN: detected interface $PUB_IF matches private interface, clearing to trigger fallback" >&2
+    PUB_IF=""
+  fi
   if [ -z "$PUB_IF" ]; then
-    # Fallback to eth0 if detection fails
+    echo "WARN: could not detect public interface, falling back to eth0" >&2
     PUB_IF="eth0"
   fi
   ip route replace default via 172.31.1.1 dev "$PUB_IF" metric 100


### PR DESCRIPTION
## Summary

ARM servers (cax*) use `enp7s0` interface naming instead of `eth0`. The cloudinit templates now detect the public interface dynamically instead of hardcoding `eth0`.

## Changes

The cloudinit templates for both regular nodes and autoscaler nodes now use dynamic interface detection:

```bash
PUB_IF=$(ip -4 route get 172.31.1.1 2>/dev/null | route_dev)
if [ -z "$PUB_IF" ]; then
  PUB_IF="eth0"  # fallback
fi
```

This uses the same approach already in place for private-only networks.

## Test plan

- [ ] Test ARM server (cax*) provisioning
- [ ] Test x86 server provisioning (regression)
- [ ] Run `terraform validate`

Fixes #1949