### PR TITLE
Disable root access to the nat-router when enable_sudo = true

### DIFF
--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -23,7 +23,9 @@ write_files:
       AllowTcpForwarding yes
       AllowAgentForwarding yes
       AuthorizedKeysFile .ssh/authorized_keys
-      # PermitRootLogin no
+%{ if enable_sudo ~}
+      PermitRootLogin no
+%{ endif ~}
     path: /etc/ssh/sshd_config.d/kube-hetzner.conf
   - path: /etc/fail2ban/jail.d/sshd.local
     content: |


### PR DESCRIPTION
Implementing what the comment in kube.tf.example already said, disabling root login when enable_sudo = true on the NAT router