### PR TITLE
fix(lb): exclude cp nodes from ingress lb if no scheduling on cp

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -78,15 +78,6 @@ locals {
     module.control_planes[keys(module.control_planes)[0]].ipv6_address,
     module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
   )
-
-  # Exclude control plane nodes from receiving LB traffic
-  # if scheduling is not allowed or it's not a single node cluster (see locals.tf)
-
-  lb_target_groups = (
-    local.allow_loadbalancer_target_on_control_plane ?
-    [local.labels_control_plane_node, local.labels_agent_node] :
-    [local.labels_agent_node]
-  )
 }
 
 resource "null_resource" "first_control_plane" {

--- a/locals.tf
+++ b/locals.tf
@@ -392,6 +392,14 @@ locals {
   # Determine if loadbalancer target should be allowed on control plane nodes, which will be always true for single node clusters or if scheduling is allowed on control plane nodes
   allow_loadbalancer_target_on_control_plane = local.is_single_node_cluster ? true : var.allow_scheduling_on_control_plane
 
+  # Add control plane nodes to LB targets (label selector) only if allow_loadbalancer_target_on_control_plane is true
+
+  lb_target_groups = (
+    local.allow_loadbalancer_target_on_control_plane ?
+    [local.labels_control_plane_node, local.labels_agent_node] :
+    [local.labels_agent_node]
+  )
+
   # Default k3s node labels
   default_agent_labels = concat(
     var.exclude_agents_from_external_load_balancers ? ["node.kubernetes.io/exclude-from-external-load-balancers=true"] : [],


### PR DESCRIPTION
## Problem
Currently, the module targets **all** nodes (Control Plane + Agents) for the main Load Balancer, even when scheduling on control plane nodes is **not allowed**.
The code correctly excludes control plane nodes from CCM-managed LoadBalancer, by adding `node.kubernetes.io/exclude-from-external-load-balancers=true` to `default_control_plane_labels` but the targets are still present in labels, because the labels are added unconditionally, even when there is no scheduling on cp nodes.

This results in:
1. Inefficient routing (Ingress traffic making extra hops through CP nodes via kube-proxy).
2. Wasted Load Balancer target slots (Hetzner limits).

## Solution
I have updated `init.tf` to conditionally exclude Control Plane nodes from the main Load Balancer targets logic.

I have used the existing `local.allow_loadbalancer_target_on_control_plane` variable, already used to exclude control plane nodes from CCM-managed LoadBalancer services in the same case.

The logic now also excludes CP nodes from LB targets **if** `allow_loadbalancer_target_on_control_plane` is `false`.