### PR TITLE
Add Configurable Replicas and Resources for Cluster Autoscaler

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -30,6 +30,9 @@ locals {
       cloudinit_config                           = local.isUsingLegacyConfig ? base64encode(data.cloudinit_config.autoscaler_legacy_config[0].rendered) : ""
       ca_image                                   = var.cluster_autoscaler_image
       ca_version                                 = var.cluster_autoscaler_version
+      ca_replicas                                = var.cluster_autoscaler_replicas
+      ca_resource_limits                         = var.cluster_autoscaler_resource_limits
+      ca_resources                               = var.cluster_autoscaler_resource_values
       cluster_autoscaler_extra_args              = var.cluster_autoscaler_extra_args
       cluster_autoscaler_log_level               = var.cluster_autoscaler_log_level
       cluster_autoscaler_log_to_stderr           = var.cluster_autoscaler_log_to_stderr

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -455,6 +455,33 @@ module "kube-hetzner" {
   #   "--enforce-node-group-min-size=true",
   # ]
 
+  # Cluster Autoscaler Deployment Configuration
+  #
+  # Configure the number of replicas and resource limits/requests for the cluster autoscaler deployment.
+  #
+  # cluster_autoscaler_replicas: Number of replicas for the cluster autoscaler deployment (default: 1)
+  #   - Setting this to > 1 enables HA for the autoscaler itself (uses leader election)
+  #
+  # cluster_autoscaler_resource_limits: Enable or disable resource limits/requests (default: true)
+  #   - Set to false to remove resource constraints entirely
+  #
+  # cluster_autoscaler_resource_values: Customize CPU and memory resources (defaults: 100m CPU, 300Mi memory for both requests and limits)
+  #
+  # Example:
+  #
+  # cluster_autoscaler_replicas = 2
+  # cluster_autoscaler_resource_limits = true
+  # cluster_autoscaler_resource_values = {
+  #   requests = {
+  #     cpu    = "100m"
+  #     memory = "300Mi"
+  #   }
+  #   limits = {
+  #     cpu    = "200m"
+  #     memory = "500Mi"
+  #   }
+  # }
+
   # Enable delete protection on compatible resources to prevent accidental deletion from the Hetzner Cloud Console.
   # This does not protect deletion from Terraform itself.
   # enable_delete_protection = {

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -125,7 +125,7 @@ metadata:
   labels:
     app: cluster-autoscaler
 spec:
-  replicas: 1
+  replicas: ${ca_replicas}
   selector:
     matchLabels:
       app: cluster-autoscaler
@@ -155,13 +155,15 @@ spec:
       containers:
         - image: ${ca_image}:${ca_version}
           name: cluster-autoscaler
+          %{~ if ca_resource_limits ~}
           resources:
             limits:
-              cpu: 100m
-              memory: 300Mi
+              cpu: ${ca_resources.limits.cpu}
+              memory: ${ca_resources.limits.memory}
             requests:
-              cpu: 100m
-              memory: 300Mi
+              cpu: ${ca_resources.requests.cpu}
+              memory: ${ca_resources.requests.memory}
+          %{~ endif ~}
           ports:
             - containerPort: 8085
           command:

--- a/variables.tf
+++ b/variables.tf
@@ -383,6 +383,47 @@ variable "cluster_autoscaler_server_creation_timeout" {
   description = "Timeout (in minutes) until which a newly created server/node has to become available before giving up and destroying it."
 }
 
+variable "cluster_autoscaler_replicas" {
+  type        = number
+  default     = 1
+  description = "Number of replicas for the cluster autoscaler deployment."
+
+  validation {
+    condition     = var.cluster_autoscaler_replicas >= 1
+    error_message = "Number of cluster autoscaler replicas must be at least 1."
+  }
+}
+
+variable "cluster_autoscaler_resource_limits" {
+  type        = bool
+  default     = true
+  description = "Should cluster autoscaler enable default resource requests and limits. Default values are requests: 100m & 300Mi and limits: 100m & 300Mi."
+}
+
+variable "cluster_autoscaler_resource_values" {
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      cpu    = "100m"
+      memory = "300Mi"
+    }
+    limits = {
+      cpu    = "100m"
+      memory = "300Mi"
+    }
+  }
+  description = "Requests and limits for Cluster Autoscaler."
+}
+
 variable "autoscaler_nodepools" {
   description = "Cluster autoscaler nodepools."
   type = list(object({


### PR DESCRIPTION
## Summary

This PR adds configuration options for the cluster autoscaler deployment, allowing users to:
1. Configure the number of replicas (for HA setup with leader election)
2. Customize CPU and memory resource requests and limits
3. Optionally disable resource limits entirely

## Motivation

Previously, the cluster autoscaler was deployed with hardcoded values:
- `replicas: 1` (no HA option)
- Fixed resources: `100m CPU` and `300Mi memory` for both limits and requests

This made it difficult to:
- Run the autoscaler in HA mode (multiple replicas with leader election)
- Adjust resources for larger clusters with many nodepools
- Optimize resource usage based on actual cluster needs

## Changes Made

### 1. New Variables in `variables.tf`

Added three new variables:

```hcl
variable "cluster_autoscaler_replicas" {
  type        = number
  default     = 1
  description = "Number of replicas for the cluster autoscaler deployment."

  validation {
    condition     = var.cluster_autoscaler_replicas >= 1
    error_message = "Number of cluster autoscaler replicas must be at least 1."
  }
}

variable "cluster_autoscaler_resource_limits" {
  type        = bool
  default     = true
  description = "Should cluster autoscaler enable default resource requests and limits."
}

variable "cluster_autoscaler_resource_values" {
  type = object({
    requests = object({
      cpu    = string
      memory = string
    })
    limits = object({
      cpu    = string
      memory = string
    })
  })
  default = {
    requests = {
      cpu    = "100m"
      memory = "300Mi"
    }
    limits = {
      cpu    = "100m"
      memory = "300Mi"
    }
  }
  description = "Requests and limits for Cluster Autoscaler."
}
```

### 2. Updated Template `templates/autoscaler.yaml.tpl`

Modified the Deployment spec to use the new variables:

```yaml
spec:
  replicas: ${ca_replicas}  # Changed from hardcoded 1
  ...
  containers:
    - image: ${ca_image}:${ca_version}
      name: cluster-autoscaler
      %{~ if ca_resource_limits ~}
      resources:
        limits:
          cpu: ${ca_resources.limits.cpu}
          memory: ${ca_resources.limits.memory}
        requests:
          cpu: ${ca_resources.requests.cpu}
          memory: ${ca_resources.requests.memory}
      %{~ endif ~}
```

### 3. Updated `autoscaler-agents.tf`

Added new variables to the template invocation:

```hcl
autoscaler_yaml = length(var.autoscaler_nodepools) == 0 ? "" : templatefile(
  "${path.module}/templates/autoscaler.yaml.tpl",
  {
    # ... existing variables ...
    ca_replicas                = var.cluster_autoscaler_replicas
    ca_resource_limits         = var.cluster_autoscaler_resource_limits
    ca_resources               = var.cluster_autoscaler_resource_values
    # ... rest of variables ...
  }
)
```

### 4. Updated Documentation `kube.tf.example`

Added comprehensive documentation with examples:

```hcl
# Cluster Autoscaler Deployment Configuration
#
# Configure the number of replicas and resource limits/requests for the cluster autoscaler deployment.
#
# cluster_autoscaler_replicas: Number of replicas for the cluster autoscaler deployment (default: 1)
#   - Setting this to > 1 enables HA for the autoscaler itself (uses leader election)
#
# cluster_autoscaler_resource_limits: Enable or disable resource limits/requests (default: true)
#   - Set to false to remove resource constraints entirely
#
# cluster_autoscaler_resource_values: Customize CPU and memory resources
#
# Example:
#
# cluster_autoscaler_replicas = 2
# cluster_autoscaler_resource_limits = true
# cluster_autoscaler_resource_values = {
#   requests = {
#     cpu    = "100m"
#     memory = "300Mi"
#   }
#   limits = {
#     cpu    = "200m"
#     memory = "500Mi"
#   }
# }
```

## Usage Examples

### Example 1: Enable HA with 2 replicas (default resources)

```hcl
cluster_autoscaler_replicas = 2
```

### Example 2: Increase resources for large clusters

```hcl
cluster_autoscaler_resource_values = {
  requests = {
    cpu    = "200m"
    memory = "500Mi"
  }
  limits = {
    cpu    = "500m"
    memory = "1Gi"
  }
}
```

### Example 3: HA setup with custom resources

```hcl
cluster_autoscaler_replicas = 3

cluster_autoscaler_resource_values = {
  requests = {
    cpu    = "150m"
    memory = "400Mi"
  }
  limits = {
    cpu    = "300m"
    memory = "800Mi"
  }
}
```

### Example 4: Disable resource limits

```hcl
cluster_autoscaler_resource_limits = false
```

## Backward Compatibility

✅ **Fully backward compatible**

All new variables have sensible defaults that maintain the existing behavior:
- `cluster_autoscaler_replicas = 1` (same as before)
- `cluster_autoscaler_resource_limits = true` (resources enabled as before)
- `cluster_autoscaler_resource_values` defaults to `100m CPU` and `300Mi memory` (same as hardcoded values)

Existing deployments will continue to work without any changes to their `kube.tf` files.