### PR TITLE
fix: align kured_version logic with csi/calico pattern

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
 
   ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version    = length(data.github_release.hetzner_csi) == 0 ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
-  kured_version  = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
+  kured_version  = length(data.github_release.kured) == 0 ? var.kured_version : data.github_release.kured[0].release_tag
   calico_version = length(data.github_release.calico) == 0 ? var.calico_version : data.github_release.calico[0].release_tag
 
   # Determine kured YAML suffix based on version (>= 1.20.0 uses -combined.yaml, < 1.20.0 uses -dockerhub.yaml)


### PR DESCRIPTION
## Summary

- Fixes the `kured_version is null` error when `kured_version` is omitted from kube.tf
- Aligns `kured_version` assignment with the established pattern used by `csi_version` and `calico_version`

## Problem

When `kured_version` was omitted, the semver comparison on line 19 failed:
```
Error: Invalid function argument
  local.kured_version is null
  Invalid value for "version_a" parameter: argument must not be null.
```

## Solution

Changed from:
```terraform
kured_version = var.kured_version != null ? var.kured_version : data.github_release.kured[0].release_tag
```

To:
```terraform
kured_version = length(data.github_release.kured) == 0 ? var.kured_version : data.github_release.kured[0].release_tag
```

This matches the pattern used for `csi_version` and `calico_version`, which checks the data source existence directly via `length()` rather than checking the variable.

## Test plan

- [ ] `terraform fmt` passes
- [ ] `terraform validate` passes
- [ ] `terraform plan` works with `kured_version` omitted (uses GitHub latest)
- [ ] `terraform plan` works with explicit `kured_version = "1.20.0"`

Fixes #2017