### PR TITLE
docs: consistent heredoc syntax and boolean types across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ locals {
 
 cluster_ipv4_cidr = local.cluster_ipv4_cidr
 
-cilium_values = <<EOT
+cilium_values = <<-EOT
 ipam:
   mode: kubernetes
 k8s:

--- a/docs/customize-mount-path-longhorn.md
+++ b/docs/customize-mount-path-longhorn.md
@@ -14,7 +14,7 @@ In order to use NVMe and external disks with Longhorn, you may need to mount an 
 
 2.  Set the Helm values for Longhorn. The `defaultDataPath` is important as this path is automatically created by Longhorn and will be the default storage class pointing to your primary disks (e.g., NVMe).
     ```yaml
-    longhorn_values = <<EOT
+    longhorn_values = <<-EOT
     defaultSettings:
       nodeDrainPolicy: allow-if-replica-is-stopped
       defaultDataPath: /var/longhorn

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1151,10 +1151,10 @@ Excellent! Let's continue our meticulous dissection.
   # Automatically "true" in the case of single node cluster (as it does not make sense to use the Hetzner LB in that situation).
   # It can work with any ingress controller that you choose to deploy.
   # Please note that because the klipperLB points to all nodes, we automatically allow scheduling on the control plane when it is active.
-  # enable_klipper_metal_lb = "true"
+  # enable_klipper_metal_lb = true
 ```
 
-* **`enable_klipper_metal_lb` (Boolean, Optional, or String `"true"`/`"false"`):**
+* **`enable_klipper_metal_lb` (Boolean, Optional):**
   * **Default:** `false` (unless it's a single-node cluster, then it's automatically `true`).
   * **Purpose:** If `true`, deploys [Klipper LoadBalancer](https://github.com/k3s-io/klipper-lb) (which is k3s's embedded service load balancer, similar in concept to MetalLB for bare-metal clusters).
   * **Mechanism:** Klipper LB allows services of type `LoadBalancer` to get an IP address from a pool of the nodes' own IP addresses. For external access, this typically means one of the node's public IPs is used by the Ingress controller's service.
@@ -2324,7 +2324,7 @@ This section introduces the mechanism for providing detailed, custom Helm chart 
   # Please understand that the indentation is very important, inside the EOTs, as those are proper yaml helm values.
   # We advise you to use the default values, and only change them if you know what you are doing!
 
-  # You can inline the values here in heredoc-style (as the examples below with the <<EOT to EOT). Please note that the current indentation inside the EOT is important.
+  # You can inline the values here in heredoc-style (as the examples below with the <<-EOT to EOT). Please note that the indentation inside the EOT is important.
   # Or you can create a thepackage-values.yaml file with the content and use it here with the following syntax:
   # thepackage_values = file("thepackage-values.yaml")
 
@@ -2558,7 +2558,7 @@ controller:
   # Override values given to the HAProxy helm chart.
   # All HAProxy helm values can be found at https://github.com/haproxytech/helm-charts/blob/main/kubernetes-ingress/values.yaml
   # Default values can be found at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/locals.tf
-  /*   haproxy_values = <<EOT
+  /*   haproxy_values = <<-EOT
   EOT */
 ```
 
@@ -2853,37 +2853,37 @@ The following variables allow deep customization of various components through H
 
 ```terraform
   # Custom Cilium values
-  # cilium_values = <<EOT
+  # cilium_values = <<-EOT
   # ipam:
   #   mode: kubernetes
   # EOT
   
   # Custom cert-manager values
-  # cert_manager_values = <<EOT
+  # cert_manager_values = <<-EOT
   # crds:
   #   enabled: true
   # EOT
   
   # Custom Hetzner CCM values
-  # hetzner_ccm_values = <<EOT
+  # hetzner_ccm_values = <<-EOT
   # networking:
   #   enabled: true
   # EOT
   
   # Custom CSI driver SMB values
-  # csi_driver_smb_values = <<EOT
+  # csi_driver_smb_values = <<-EOT
   # controller:
   #   replicas: 2
   # EOT
   
   # Custom Longhorn values
-  # longhorn_values = <<EOT
+  # longhorn_values = <<-EOT
   # defaultSettings:
   #   defaultDataPath: /var/longhorn
   # EOT
   
   # Custom Rancher values
-  # rancher_values = <<EOT
+  # rancher_values = <<-EOT
   # hostname: rancher.example.com
   # replicas: 3
   # EOT
@@ -2904,13 +2904,13 @@ Each of these `*_values` variables:
   # haproxy_version = "1.41.0"
   
   # Custom Traefik values
-  # traefik_values = <<EOT
+  # traefik_values = <<-EOT
   # deployment:
   #   replicas: 3
   # EOT
   
   # Custom Nginx values
-  # nginx_values = <<EOT
+  # nginx_values = <<-EOT
   # controller:
   #   replicaCount: 3
   # EOT
@@ -2919,7 +2919,7 @@ Each of these `*_values` variables:
   # haproxy_additional_proxy_protocol_ips = ["10.0.0.0/8", "172.16.0.0/12"]
   # haproxy_requests_cpu = "250m"
   # haproxy_requests_memory = "256Mi"
-  # haproxy_values = <<EOT
+  # haproxy_values = <<-EOT
   # controller:
   #   replicaCount: 3
   # EOT

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -284,7 +284,7 @@
 | <a name="input_traefik_values"></a> [traefik\_values](#input\_traefik\_values) | Additional helm values file to pass to Traefik as 'valuesContent' at the HelmChart. | `string` | `""` | no |
 | <a name="input_traefik_version"></a> [traefik\_version](#input\_traefik\_version) | Version of Traefik helm chart. See https://github.com/traefik/traefik-helm-chart/releases for the available versions. | `string` | `""` | no |
 | <a name="input_use_cluster_name_in_node_name"></a> [use\_cluster\_name\_in\_node\_name](#input\_use\_cluster\_name\_in\_node\_name) | Whether to use the cluster name in the node name. | `bool` | `true` | no |
-| <a name="input_use_control_plane_lb"></a> [use\_control\_plane\_lb](#input\_use\_control\_plane\_lb) | When this is enabled, rather than the first node, all external traffic will be routed via a control-plane loadbalancer, allowing for high availability. | `bool` | `false` | no |
+| <a name="input_use_control_plane_lb"></a> [use\_control\_plane\_lb](#input\_use\_control\_plane\_lb) | Creates a dedicated load balancer for the Kubernetes API (port 6443). When enabled, kubectl and other API clients connect through this LB instead of directly to the first control plane node. Recommended for production clusters with multiple control plane nodes for high availability. Note: This is separate from the ingress load balancer for HTTP/HTTPS traffic. | `bool` | `false` | no |
 
 ### Outputs
 


### PR DESCRIPTION
Follow-up to v2.18.6 doc fixes - consistent heredoc syntax and boolean types