### PR TITLE
fix: ensure backward compatibility for v2.19.0 release

### DIFF
--- a/nat-router.tf
+++ b/nat-router.tf
@@ -49,6 +49,11 @@ resource "hcloud_primary_ip" "nat_router_primary_ipv4" {
   location      = var.nat_router.location
   auto_delete   = false
   assignee_type = "server"
+
+  # Prevent recreation when upgrading from datacenter to location attribute
+  lifecycle {
+    ignore_changes = [datacenter, location]
+  }
 }
 
 resource "hcloud_primary_ip" "nat_router_primary_ipv6" {
@@ -60,6 +65,11 @@ resource "hcloud_primary_ip" "nat_router_primary_ipv6" {
   location      = var.nat_router.location
   auto_delete   = false
   assignee_type = "server"
+
+  # Prevent recreation when upgrading from datacenter to location attribute
+  lifecycle {
+    ignore_changes = [datacenter, location]
+  }
 }
 resource "hcloud_server" "nat_router" {
   count        = var.nat_router != null ? 1 : 0


### PR DESCRIPTION
## Summary

This PR ensures smooth upgrades from v2.18.5 to v2.19.0 by addressing two backward compatibility concerns identified during AI-assisted code review (Gemini + Codex CLI).

## Changes

### 1. NAT Router Primary IP Protection
- Added `lifecycle { ignore_changes = [datacenter, location] }` to both `hcloud_primary_ip.nat_router_primary_ipv4` and `hcloud_primary_ip.nat_router_primary_ipv6`
- **Why**: The datacenter→location migration (PR #2021) was a necessary bug fix for infinite replacement cycles, but changing the attribute could cause one-time IP recreation for existing NAT router users
- **Result**: Existing clusters keep their IPs; new clusters use the correct `location` attribute

### 2. Audit Policy Script Fix
- Modified `k3s_audit_policy_update_script` to NOT remove existing audit policies when `k3s_audit_policy_config` is empty
- **Why**: Previously, upgrading would delete any manually-configured audit policies on control planes
- **Result**: Existing audit configurations are preserved; Terraform only manages policies when explicitly configured

## Review Notes

### Regarding IP Offset Formula (Issue 1 from Codex review)
After thorough analysis, the IP offset formula change is **NOT breaking**:
- For `/16` or larger networks: offset stays `101` (unchanged behavior)  
- For smaller networks (`/17` and below): the old fixed `101` offset would have **exceeded subnet bounds** and failed at the Hetzner API level

The new dynamic formula enables smaller networks to work, but since those couldn't have worked before, no existing deployments are affected.

## Test Plan
- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [ ] Test upgrade from v2.18.5 deployment (manual verification recommended)

## Backward Compatibility
✅ All existing v2.18.5 deployments should upgrade cleanly without resource recreation.