### PR TITLE
Provide bastion host if no nat_router is provided

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -165,6 +165,7 @@ locals {
           local.control_plane_endpoint_host,
           module.control_planes[k].ipv4_address != "" ? module.control_planes[k].ipv4_address : null,
           module.control_planes[k].ipv6_address != "" ? module.control_planes[k].ipv6_address : null,
+          var.kubeconfig_server_address != "" ? var.kubeconfig_server_address : null,
           try(one(module.control_planes[k].network).ip, null)
         ]),
       var.additional_tls_sans)

--- a/locals.tf
+++ b/locals.tf
@@ -359,7 +359,7 @@ locals {
     bastion_port        = var.ssh_port
     bastion_user        = "nat-router"
     bastion_private_key = var.ssh_private_key
-    } : {
+    } : var.default_bastion != null ? var.default_bastion : {
     bastion_host        = null
     bastion_port        = null
     bastion_user        = null

--- a/locals.tf
+++ b/locals.tf
@@ -359,7 +359,7 @@ locals {
     bastion_port        = var.ssh_port
     bastion_user        = "nat-router"
     bastion_private_key = var.ssh_private_key
-    } : var.default_bastion != null ? var.default_bastion : {
+    } : var.optional_bastion_host != null ? var.optional_bastion_host : {
     bastion_host        = null
     bastion_port        = null
     bastion_user        = null

--- a/locals.tf
+++ b/locals.tf
@@ -354,17 +354,21 @@ locals {
 
   use_nat_router = var.nat_router != null
 
-  ssh_bastion = local.use_nat_router ? {
-    bastion_host        = hcloud_server.nat_router[0].ipv4_address
-    bastion_port        = var.ssh_port
-    bastion_user        = "nat-router"
-    bastion_private_key = var.ssh_private_key
-    } : var.optional_bastion_host != null ? var.optional_bastion_host : {
-    bastion_host        = null
-    bastion_port        = null
-    bastion_user        = null
-    bastion_private_key = null
-  }
+  ssh_bastion = coalesce(
+    local.use_nat_router ? {
+      bastion_host        = hcloud_server.nat_router[0].ipv4_address
+      bastion_port        = var.ssh_port
+      bastion_user        = "nat-router"
+      bastion_private_key = var.ssh_private_key
+    } : null,
+    var.optional_bastion_host,
+    {
+      bastion_host        = null
+      bastion_port        = null
+      bastion_user        = null
+      bastion_private_key = null
+    }
+  )
 
   # Create subnets from the base network CIDR.
   # Control planes allocate from the end of the range and agents from the start (0, 1, 2...)

--- a/variables.tf
+++ b/variables.tf
@@ -1535,12 +1535,13 @@ variable "control_plane_endpoint" {
   }
 }
 
-variable "default_bastion" {
+variable "optional_bastion_host" {
   type = object({
     bastion_host        = string
     bastion_port        = number
     bastion_user        = string
     bastion_private_key = string
   })
+  description = "Optional bastion host used to connect to the nodes in the cluster. Can be useful when using a preexisting NAT router."
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1543,5 +1543,6 @@ variable "optional_bastion_host" {
     bastion_private_key = string
   })
   description = "Optional bastion host used to connect to the nodes in the cluster. Can be useful when using a preexisting NAT router."
+  sensitive = true
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1534,3 +1534,13 @@ variable "control_plane_endpoint" {
     error_message = "The control_plane_endpoint must be null or a valid URL (e.g., https://my-api.example.com:6443)."
   }
 }
+
+variable "default_bastion" {
+  type = object({
+    bastion_host        = string
+    bastion_port        = number
+    bastion_user        = string
+    bastion_private_key = string
+  })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1546,15 +1546,3 @@ variable "control_plane_endpoint" {
     error_message = "The control_plane_endpoint must be null or a valid URL (e.g., https://my-api.example.com:6443)."
   }
 }
-
-variable "optional_bastion_host" {
-  type = object({
-    bastion_host        = string
-    bastion_port        = number
-    bastion_user        = string
-    bastion_private_key = string
-  })
-  description = "Optional bastion host used to connect to the nodes in the cluster. Can be useful when using a preexisting NAT router."
-  sensitive   = true
-  default     = null
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1543,6 +1543,6 @@ variable "optional_bastion_host" {
     bastion_private_key = string
   })
   description = "Optional bastion host used to connect to the nodes in the cluster. Can be useful when using a preexisting NAT router."
-  sensitive = true
-  default = null
+  sensitive   = true
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,18 @@ variable "nat_router" {
   })
 }
 
+variable "optional_bastion_host" {
+  description = "Optional bastion host used to connect to cluster nodes. Useful when using a pre-existing NAT router."
+  type = object({
+    bastion_host        = string
+    bastion_port        = number
+    bastion_user        = string
+    bastion_private_key = string
+  })
+  sensitive = true
+  default   = null
+}
+
 variable "nat_router_subnet_index" {
   type        = number
   default     = 200


### PR DESCRIPTION
Provides a default bastion host that can be set. Very useful if you have an existing nat_router and want to use that. If you have an existing nat_router the current code just isn't able to use a bastion host.