### PR TITLE
ci: add guarded Hetzner integration test workflow

### DIFF
--- a/.github/workflows/hetzner-test.yaml
+++ b/.github/workflows/hetzner-test.yaml
@@ -1,0 +1,71 @@
+name: Test in Hetzner
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hetzner-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+  TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+  HCLOUD_CONTEXT: ${{ secrets.HCLOUD_CONTEXT }}
+  SNAPSHOT_ID_ARM: ${{ secrets.SNAPSHOT_ID_ARM }}
+  SNAPSHOT_ID_X86: ${{ secrets.SNAPSHOT_ID_X86 }}
+
+jobs:
+  tests:
+    name: Run Hetzner Tests
+    runs-on: ubuntu-latest
+    environment: hetzner-test
+    if: ${{ vars.TEST_IN_HETZNER == '1' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
+    steps:
+      - name: Add env mask
+        run: |
+          echo "::add-mask::${{ secrets.HCLOUD_TOKEN }}"
+          echo "::add-mask::${{ secrets.HCLOUD_CONTEXT }}"
+          echo "::add-mask::${{ secrets.SNAPSHOT_ID_ARM }}"
+          echo "::add-mask::${{ secrets.SNAPSHOT_ID_X86 }}"
+
+      - name: Check prerequisites
+        id: prerequisites
+        run: |
+          if [ -z "$SNAPSHOT_ID_ARM" ] || [ -z "$SNAPSHOT_ID_X86" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Snapshots are not configured, skipping workflow."
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.prerequisites.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+
+      - name: Install Terraform
+        if: steps.prerequisites.outputs.enabled == 'true'
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Create SSH keys
+        if: steps.prerequisites.outputs.enabled == 'true'
+        run: ssh-keygen -f ~/.ssh/id_ed25519 -N ""
+
+      - name: Apply base example
+        if: steps.prerequisites.outputs.enabled == 'true'
+        timeout-minutes: 20
+        run: |
+          cp kube.tf.example kube.tf
+          terraform init
+          terraform validate
+          terraform apply -auto-approve
+
+      - name: Destroy cluster
+        if: steps.prerequisites.outputs.enabled == 'true' && always()
+        run: terraform destroy -auto-approve


### PR DESCRIPTION
### Motivation
- Add a repeatable GitHub Actions workflow to run real Hetzner cloud integration tests against the repository to catch infra regressions earlier. 
- The original idea in the referenced PR is valuable but required hardening to avoid running expensive/insecure tests on forks or without required secrets. 
- Skills used: none (no `SKILL.md` workflow was required for this change).

### Description
- Add a new workflow file at `.github/workflows/hetzner-test.yaml` that provides `pull_request` triggers plus `workflow_dispatch` for manual runs. 
- Guard the job so it only runs when `vars.TEST_IN_HETZNER == '1'` and prevents running on forked PRs by checking `github.event.pull_request.head.repo.full_name == github.repository`. 
- Improve safety and maintainability by adding concurrency, minimal permissions, explicit prerequisite gating for `SNAPSHOT_ID_ARM`/`SNAPSHOT_ID_X86`, masking secrets, using `hashicorp/setup-terraform@v3`, and ensuring `terraform destroy` runs for cleanup. 
- Remove the original apt-based install and self-cancel behavior from the earlier draft and keep the workflow lean and explicit about prerequisites.

### Testing
- Parsed and validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/hetzner-test.yaml')"`, which completed successfully. 
- Fetched the pull request ref and inspected diffs using `git fetch` and `git diff --stat origin/master...pr-1931`, confirming the workflow is the only new file added. 
- Verified the workflow contains the expected guards and `hashicorp/setup-terraform@v3` usage by reading `.github/workflows/hetzner-test.yaml` and checking lines for the prerequisite and conditional logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b67eba148331857d6dce28aca791)