### PR TITLE
feat: add ssh public key format validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,14 @@ variable "ssh_port" {
 variable "ssh_public_key" {
   description = "SSH public Key."
   type        = string
+
+  validation {
+    condition = can(regex(
+      "^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|sk-ssh-ed25519@openssh.com|sk-ecdsa-sha2-nistp256@openssh.com)\\s+",
+      trimspace(var.ssh_public_key)
+    ))
+    error_message = "ssh_public_key must be a valid OpenSSH public key starting with a supported key type (for example: ssh-ed25519, ssh-rsa, or ecdsa-sha2-nistp256)."
+  }
 }
 
 variable "ssh_private_key" {


### PR DESCRIPTION
## Summary
Implements discussion #2000 by validating `ssh_public_key` input format early in Terraform validation.

### What changed
- Added a validation block to `variable "ssh_public_key"` in `variables.tf`.
- Validation accepts standard OpenSSH public key prefixes:
  - `ssh-rsa`
  - `ssh-ed25519`
  - `ecdsa-sha2-nistp{256,384,521}`
  - `sk-ssh-ed25519@openssh.com`
  - `sk-ecdsa-sha2-nistp256@openssh.com`

## Why this matters
- Fails fast on malformed key input with a clear error message.
- Prevents delayed provisioning failures caused by invalid SSH key values.

## Validation
- `terraform fmt variables.tf`
- `terraform init -upgrade` in `/Users/karim/Code/kube-test`
- `terraform plan -no-color` in `/Users/karim/Code/kube-test` with placeholder 64-char token
  - Plan reaches graph construction and then fails on Hetzner API auth (`401`) in this environment.

## Discussion
- Source: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/2000
