### PR TITLE
feat: support TCP/UDP in traefik_additional_ports

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1311,9 +1311,10 @@ Excellent! Let's continue our meticulous dissection.
   * **If `false`:** Traefik pods might run without specific requests/limits, relying on defaults or potentially being less predictable in resource consumption.
 
 ```terraform
-  # If you want to configure additional ports for traefik, enter them here as a list of objects with name, port, and exposedPort properties.
+  # If you want to configure additional ports for traefik, enter them here as a list of objects with
+  # name, port, exposedPort, and optional protocol (TCP or UDP; default TCP).
   # Example:
-  # traefik_additional_ports = [{name = "example", port = 1234, exposedPort = 1234}]
+  # traefik_additional_ports = [{name = "example", port = 1234, exposedPort = 1234, protocol = "TCP"}]
 ```
 
 * **`traefik_additional_ports` (List of Maps, Optional, specific to `ingress_controller = "traefik"`):**
@@ -1322,7 +1323,7 @@ Excellent! Let's continue our meticulous dissection.
     * `name` (String): A unique name for this entrypoint (e.g., "tcp-echo", "metrics").
     * `port` (Number): The port number Traefik will listen on internally for this entrypoint.
     * `exposedPort` (Number): The port number on the Traefik service (and thus on the Hetzner Load Balancer) that will map to the internal `port`. Often these are the same.
-    * You might also need to specify `protocol` (e.g., `TCP`, `UDP`) if not HTTP/S, depending on how the Traefik Helm chart handles this.
+    * `protocol` (String, Optional): `TCP` or `UDP`. Defaults to `TCP`.
   * **Use Case:** Exposing non-HTTP services (e.g., TCP or UDP applications, metrics endpoints on custom ports) through Traefik.
 
 ```terraform

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -661,9 +661,10 @@ module "kube-hetzner" {
   # The default is true.
   # traefik_resource_limits = false
 
-  # If you want to configure additional ports for traefik, enter them here as a list of objects with name, port, and exposedPort properties.
+  # If you want to configure additional ports for traefik, enter them here as a list of objects with
+  # name, port, exposedPort, and optional protocol (TCP or UDP; default TCP).
   # Example:
-  # traefik_additional_ports = [{name = "example", port = 1234, exposedPort = 1234}]
+  # traefik_additional_ports = [{name = "example", port = 1234, exposedPort = 1234, protocol = "TCP"}]
 
   # If you want to configure additional trusted IPs for traefik, enter them here as a list of IPs (strings).
   # Example for Cloudflare:

--- a/locals.tf
+++ b/locals.tf
@@ -1244,7 +1244,7 @@ ports:
     expose:
       default: true
     exposedPort: ${option.exposedPort}
-    protocol: TCP
+    protocol: ${upper(option.protocol)}
     observability:
       metrics: false
       accessLogs: false

--- a/variables.tf
+++ b/variables.tf
@@ -778,9 +778,18 @@ variable "traefik_additional_ports" {
     name        = string
     port        = number
     exposedPort = number
+    protocol    = optional(string, "TCP")
   }))
   default     = []
   description = "Additional ports to pass to Traefik. These are the ones that go into the ports section of the Traefik helm values file."
+
+  validation {
+    condition = alltrue([
+      for option in var.traefik_additional_ports :
+      contains(["TCP", "UDP"], upper(option.protocol))
+    ])
+    error_message = "Each traefik_additional_ports item must set protocol to either TCP or UDP."
+  }
 }
 
 variable "traefik_additional_options" {


### PR DESCRIPTION
## Summary
Implements discussion #1832 by adding explicit protocol support (`TCP`/`UDP`) for `traefik_additional_ports`.

### What changed
- Updated `traefik_additional_ports` schema in `variables.tf`:
  - added optional `protocol` field (default `TCP`),
  - added validation to allow only `TCP` or `UDP`.
- Updated Traefik values rendering in `locals.tf` to use `protocol: ${upper(option.protocol)}`.
- Updated examples/docs:
  - `kube.tf.example`
  - `docs/llms.md`

## Why this matters
- Enables clean definition of non-HTTP Traefik entrypoints that require UDP.
- Removes hardcoded TCP behavior and makes the intent explicit in user configuration.

## Validation
- `terraform fmt variables.tf locals.tf`
- `terraform init -upgrade` in `/Users/karim/Code/kube-test`
- `terraform plan -no-color` in `/Users/karim/Code/kube-test` with placeholder 64-char token
  - Plan builds and then fails on Hetzner API auth (`401`) in this environment.

## Discussion
- Source: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/discussions/1832
