### PR TITLE
feat(v3): support per-node cloud-init extra write_files and runcmd (#1039)

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -32,6 +32,8 @@ module "agents" {
   k3s_audit_policy_config          = ""
   k3s_audit_policy_update_script   = ""
   cloudinit_runcmd_common          = local.cloudinit_runcmd_common
+  cloudinit_write_files_extra      = each.value.extra_write_files
+  cloudinit_runcmd_extra           = each.value.extra_runcmd
   swap_size                        = each.value.swap_size
   zram_size                        = each.value.zram_size
   keep_disk_size                   = var.keep_disk_agents

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -32,6 +32,8 @@ module "control_planes" {
   k3s_audit_policy_update_script   = local.k3s_audit_policy_update_script
   cloudinit_write_files_common     = local.cloudinit_write_files_common
   cloudinit_runcmd_common          = local.cloudinit_runcmd_common
+  cloudinit_write_files_extra      = each.value.extra_write_files
+  cloudinit_runcmd_extra           = each.value.extra_runcmd
   swap_size                        = each.value.swap_size
   zram_size                        = each.value.zram_size
   keep_disk_size                   = var.keep_disk_cp

--- a/locals.tf
+++ b/locals.tf
@@ -490,6 +490,8 @@ EOT
         disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
         disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
         network_id : nodepool_obj.network_id,
+        extra_write_files : nodepool_obj.extra_write_files,
+        extra_runcmd : nodepool_obj.extra_runcmd,
       }
     }
   ]...)
@@ -520,6 +522,8 @@ EOT
         disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
         disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
         network_id : nodepool_obj.network_id,
+        extra_write_files : nodepool_obj.extra_write_files,
+        extra_runcmd : nodepool_obj.extra_runcmd,
       }
     }
   ]...)
@@ -551,11 +555,15 @@ EOT
           disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
           disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
           network_id : nodepool_obj.network_id,
+          extra_write_files : nodepool_obj.extra_write_files,
+          extra_runcmd : nodepool_obj.extra_runcmd,
         },
         { for key, value in node_obj : key => value if value != null },
         {
           labels : concat(local.default_agent_labels, nodepool_obj.swap_size != "" || nodepool_obj.zram_size != "" ? local.swap_node_label : [], nodepool_obj.labels, coalesce(node_obj.labels, [])),
           taints : compact(concat(local.default_agent_taints, nodepool_obj.taints, coalesce(node_obj.taints, []))),
+          extra_write_files : concat(nodepool_obj.extra_write_files, coalesce(node_obj.extra_write_files, [])),
+          extra_runcmd : concat(nodepool_obj.extra_runcmd, coalesce(node_obj.extra_runcmd, [])),
         },
         (
           node_obj.append_index_to_node_name ? { node_name_suffix : "-${floor(tonumber(node_key))}" } : {}

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -237,6 +237,8 @@ data "cloudinit_config" "config" {
         sshAuthorizedKeys            = concat([var.ssh_public_key], var.ssh_additional_public_keys)
         cloudinit_write_files_common = var.cloudinit_write_files_common
         cloudinit_runcmd_common      = var.cloudinit_runcmd_common
+        cloudinit_write_files_extra  = var.cloudinit_write_files_extra
+        cloudinit_runcmd_extra       = var.cloudinit_runcmd_extra
         swap_size                    = var.swap_size
         os                           = var.os
         private_network_only         = (var.disable_ipv4 && var.disable_ipv6)

--- a/modules/host/templates/cloudinit.yaml.tpl
+++ b/modules/host/templates/cloudinit.yaml.tpl
@@ -3,6 +3,9 @@
 write_files:
 
 ${cloudinit_write_files_common}
+%{~ if length(cloudinit_write_files_extra) > 0 ~}
+${yamlencode(cloudinit_write_files_extra)}
+%{~ endif ~}
 
 %{ if os == "leapmicro" ~}
 - path: /usr/local/bin/apply-k8s-selinux-policy.sh
@@ -238,3 +241,6 @@ ${cloudinit_runcmd_common}
   systemctl daemon-reload
   systemctl enable swapon-late.service
 %{endif~}
+%{~ if length(cloudinit_runcmd_extra) > 0 ~}
+${yamlencode(cloudinit_runcmd_extra)}
+%{~ endif ~}

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -150,6 +150,18 @@ variable "cloudinit_runcmd_common" {
   type    = string
 }
 
+variable "cloudinit_write_files_extra" {
+  type        = list(any)
+  default     = []
+  description = "Additional cloud-init write_files entries appended after module defaults."
+}
+
+variable "cloudinit_runcmd_extra" {
+  type        = list(any)
+  default     = []
+  description = "Additional cloud-init runcmd entries appended after module defaults."
+}
+
 variable "swap_size" {
   default = ""
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -328,6 +328,8 @@ variable "control_plane_nodepools" {
     disable_ipv4               = optional(bool, false)
     disable_ipv6               = optional(bool, false)
     network_id                 = optional(number, 0)
+    extra_write_files          = optional(list(any), [])
+    extra_runcmd               = optional(list(any), [])
   }))
   default = []
   validation {
@@ -384,6 +386,8 @@ variable "agent_nodepools" {
     disable_ipv4               = optional(bool, false)
     disable_ipv6               = optional(bool, false)
     network_id                 = optional(number, 0)
+    extra_write_files          = optional(list(any), [])
+    extra_runcmd               = optional(list(any), [])
     nodes = optional(map(object({
       server_type                = optional(string)
       location                   = optional(string)
@@ -402,6 +406,8 @@ variable "agent_nodepools" {
       placement_group            = optional(string, null)
       append_index_to_node_name  = optional(bool, true)
       os                         = optional(string)
+      extra_write_files          = optional(list(any), [])
+      extra_runcmd               = optional(list(any), [])
     })))
   }))
   default = []


### PR DESCRIPTION
## Summary
- add `extra_write_files` and `extra_runcmd` to `control_plane_nodepools` and `agent_nodepools`
- add `extra_write_files` and `extra_runcmd` to `agent_nodepools.nodes` so per-node overrides are possible
- thread the new fields through `locals.tf` into the host module and append them in `modules/host/templates/cloudinit.yaml.tpl`

## Implementation details
- `extra_write_files` and `extra_runcmd` are typed as `list(any)` and default to `[]`
- for map-based agent nodes, node-level values are appended after nodepool-level values
- host module appends extras with `yamlencode(...)` to preserve valid cloud-init YAML for objects/strings

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test):
  - fails with invalid/absent Hetzner token in environment
  - with a 64-char placeholder token, plan reaches graphing and then fails with Hetzner API `401` on data sources (expected in this environment)

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/1039
