### PR TITLE
feat(v3): add RKE2 upgrade window support (#1591)

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -732,7 +732,8 @@ resource "null_resource" "rke2_kustomization" {
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"
     ])
-    ccm_use_helm = var.hetzner_ccm_use_helm
+    ccm_use_helm                   = var.hetzner_ccm_use_helm
+    system_upgrade_schedule_window = jsonencode(var.system_upgrade_schedule_window)
   }
 
   connection {
@@ -837,6 +838,7 @@ resource "null_resource" "rke2_kustomization" {
         version          = var.install_rke2_version
         disable_eviction = !var.system_upgrade_enable_eviction
         drain            = var.system_upgrade_use_drain
+        upgrade_window   = var.system_upgrade_schedule_window
     })
     destination = "/var/post_install/plans.yaml"
   }

--- a/templates/plans_rke2.yaml.tpl
+++ b/templates/plans_rke2.yaml.tpl
@@ -24,6 +24,24 @@ spec:
     - {key: CriticalAddonsOnly, effect: NoExecute, operator: Exists}
   serviceAccountName: system-upgrade
   cordon: true
+  %{~ if upgrade_window != null ~}
+  window:
+    %{~ if length(try(upgrade_window.days, [])) > 0 ~}
+    days:
+      %{~ for day in try(upgrade_window.days, []) ~}
+      - ${jsonencode(day)}
+      %{~ endfor ~}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.startTime, ""), "") != "" ~}
+    startTime: ${jsonencode(coalesce(try(upgrade_window.startTime, ""), ""))}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.endTime, ""), "") != "" ~}
+    endTime: ${jsonencode(coalesce(try(upgrade_window.endTime, ""), ""))}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.timeZone, ""), "") != "" ~}
+    timeZone: ${jsonencode(coalesce(try(upgrade_window.timeZone, ""), ""))}
+    %{~ endif ~}
+  %{~ endif ~}
   upgrade:
     image: rancher/rke2-upgrade
 ---
@@ -64,5 +82,23 @@ spec:
    disableEviction: ${disable_eviction}
    skipWaitForDeleteTimeout: 60%{ endif }
   %{ if !drain }cordon: true%{ endif }
+  %{~ if upgrade_window != null ~}
+  window:
+    %{~ if length(try(upgrade_window.days, [])) > 0 ~}
+    days:
+      %{~ for day in try(upgrade_window.days, []) ~}
+      - ${jsonencode(day)}
+      %{~ endfor ~}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.startTime, ""), "") != "" ~}
+    startTime: ${jsonencode(coalesce(try(upgrade_window.startTime, ""), ""))}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.endTime, ""), "") != "" ~}
+    endTime: ${jsonencode(coalesce(try(upgrade_window.endTime, ""), ""))}
+    %{~ endif ~}
+    %{~ if coalesce(try(upgrade_window.timeZone, ""), "") != "" ~}
+    timeZone: ${jsonencode(coalesce(try(upgrade_window.timeZone, ""), ""))}
+    %{~ endif ~}
+  %{~ endif ~}
   upgrade:
     image: rancher/rke2-upgrade


### PR DESCRIPTION
## Summary
- pass `var.system_upgrade_schedule_window` to the RKE2 plans template in `init.tf`
- add `window` rendering logic to both server and agent plans in `templates/plans_rke2.yaml.tpl`
- include `system_upgrade_schedule_window` in RKE2 null-resource triggers so schedule changes re-render plans

## Why
K3s already supports schedule windows. This brings RKE2 to parity so upgrade windows are applied consistently across distributions.

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without a valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches full graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/1591
