### PR TITLE
feat(v3): configurable cluster autoscaler tolerations (#1727)

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -49,6 +49,7 @@ locals {
       ca_resource_limits                         = var.cluster_autoscaler_resource_limits
       ca_resources                               = var.cluster_autoscaler_resource_values
       cluster_autoscaler_extra_args              = var.cluster_autoscaler_extra_args
+      cluster_autoscaler_tolerations             = var.cluster_autoscaler_tolerations
       cluster_autoscaler_log_level               = var.cluster_autoscaler_log_level
       cluster_autoscaler_log_to_stderr           = var.cluster_autoscaler_log_to_stderr
       cluster_autoscaler_stderr_threshold        = var.cluster_autoscaler_stderr_threshold

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -141,6 +141,9 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+        %{~ if length(cluster_autoscaler_tolerations) > 0 ~}
+${indent(8, yamlencode(cluster_autoscaler_tolerations))}
+        %{~ endif ~}
 
       # Node affinity is used to force cluster-autoscaler to stick
       # to the control-plane node. This allows the cluster to reliably downscale

--- a/variables.tf
+++ b/variables.tf
@@ -540,6 +540,18 @@ variable "cluster_autoscaler_extra_args" {
   description = "Extra arguments for the Cluster Autoscaler deployment."
 }
 
+variable "cluster_autoscaler_tolerations" {
+  description = "Additional tolerations to append to the cluster-autoscaler deployment."
+  type = list(object({
+    key               = optional(string)
+    operator          = optional(string)
+    value             = optional(string)
+    effect            = optional(string)
+    tolerationSeconds = optional(number)
+  }))
+  default = []
+}
+
 variable "cluster_autoscaler_server_creation_timeout" {
   type        = number
   default     = 15


### PR DESCRIPTION
## Summary
- add `cluster_autoscaler_tolerations` to `variables.tf`
- pass `cluster_autoscaler_tolerations` into `templates/autoscaler.yaml.tpl` via `autoscaler-agents.tf`
- append provided tolerations to the deployment `spec.template.spec.tolerations` list

## Implementation details
- variable type: `list(object({ key, operator, value, effect, tolerationSeconds }))` with optional fields and default `[]`
- template keeps the existing control-plane toleration and appends user-supplied tolerations via `yamlencode`

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches full graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/1727
