### PR TITLE
feat(v3): per-nodepool keep_disk overrides (#1344)

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -36,7 +36,7 @@ module "agents" {
   cloudinit_runcmd_extra           = each.value.extra_runcmd
   swap_size                        = each.value.swap_size
   zram_size                        = each.value.zram_size
-  keep_disk_size                   = var.keep_disk_agents
+  keep_disk_size                   = coalesce(each.value.keep_disk, var.keep_disk_agents)
   disable_ipv4                     = each.value.disable_ipv4
   disable_ipv6                     = each.value.disable_ipv6
   ssh_bastion                      = local.ssh_bastion

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -36,7 +36,7 @@ module "control_planes" {
   cloudinit_runcmd_extra           = each.value.extra_runcmd
   swap_size                        = each.value.swap_size
   zram_size                        = each.value.zram_size
-  keep_disk_size                   = var.keep_disk_cp
+  keep_disk_size                   = coalesce(each.value.keep_disk, var.keep_disk_cp)
   disable_ipv4                     = each.value.disable_ipv4
   disable_ipv6                     = each.value.disable_ipv6
   ssh_bastion                      = local.ssh_bastion

--- a/locals.tf
+++ b/locals.tf
@@ -490,6 +490,7 @@ EOT
         disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
         disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
         network_id : nodepool_obj.network_id,
+        keep_disk : nodepool_obj.keep_disk,
         extra_write_files : nodepool_obj.extra_write_files,
         extra_runcmd : nodepool_obj.extra_runcmd,
       }
@@ -522,6 +523,7 @@ EOT
         disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
         disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
         network_id : nodepool_obj.network_id,
+        keep_disk : nodepool_obj.keep_disk,
         extra_write_files : nodepool_obj.extra_write_files,
         extra_runcmd : nodepool_obj.extra_runcmd,
       }
@@ -555,6 +557,7 @@ EOT
           disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
           disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
           network_id : nodepool_obj.network_id,
+          keep_disk : nodepool_obj.keep_disk,
           extra_write_files : nodepool_obj.extra_write_files,
           extra_runcmd : nodepool_obj.extra_runcmd,
         },

--- a/variables.tf
+++ b/variables.tf
@@ -336,6 +336,7 @@ variable "control_plane_nodepools" {
     disable_ipv4               = optional(bool, false)
     disable_ipv6               = optional(bool, false)
     network_id                 = optional(number, 0)
+    keep_disk                  = optional(bool)
     extra_write_files          = optional(list(any), [])
     extra_runcmd               = optional(list(any), [])
   }))
@@ -394,6 +395,7 @@ variable "agent_nodepools" {
     disable_ipv4               = optional(bool, false)
     disable_ipv6               = optional(bool, false)
     network_id                 = optional(number, 0)
+    keep_disk                  = optional(bool)
     extra_write_files          = optional(list(any), [])
     extra_runcmd               = optional(list(any), [])
     nodes = optional(map(object({


### PR DESCRIPTION
## Summary
- add optional `keep_disk` to `control_plane_nodepools` and `agent_nodepools`
- propagate nodepool `keep_disk` through `locals.tf`
- update host module calls to use:
  - `coalesce(each.value.keep_disk, var.keep_disk_cp)` for control planes
  - `coalesce(each.value.keep_disk, var.keep_disk_agents)` for agents

## Why
This enables disk-retention behavior to be set per nodepool instead of globally, while preserving existing behavior when no nodepool override is provided.

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/1344
