### PR TITLE
feat(v3): add RDNS for NAT router and control-plane LB (#223)

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -108,6 +108,14 @@ resource "hcloud_load_balancer_service" "control_plane" {
   listen_port      = "6443"
 }
 
+resource "hcloud_rdns" "control_plane_lb_ipv4" {
+  count = (var.use_control_plane_lb && var.control_plane_lb_enable_public_interface && var.base_domain != "") ? 1 : 0
+
+  load_balancer_id = hcloud_load_balancer.control_plane[0].id
+  ip_address       = hcloud_load_balancer.control_plane[0].ipv4
+  dns_ptr          = "${var.cluster_name}-control-plane.${var.base_domain}"
+}
+
 locals {
   control_plane_endpoint_host = var.control_plane_endpoint != null ? one(compact(regexall("^(?:https?://)?(?:.*@)?(?:\\[([a-fA-F0-9:]+)\\]|([^:/?#]+))", var.control_plane_endpoint)[0])) : null
 

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -149,6 +149,22 @@ resource "hcloud_server" "nat_router" {
 
 }
 
+resource "hcloud_rdns" "nat_router_primary_ipv4" {
+  count = (var.nat_router != null && var.base_domain != "") ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+
+  primary_ip_id = hcloud_primary_ip.nat_router_primary_ipv4[count.index].id
+  ip_address    = hcloud_primary_ip.nat_router_primary_ipv4[count.index].ip_address
+  dns_ptr       = "${hcloud_server.nat_router[count.index].name}.${var.base_domain}"
+}
+
+resource "hcloud_rdns" "nat_router_primary_ipv6" {
+  count = (var.nat_router != null && var.base_domain != "") ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+
+  primary_ip_id = hcloud_primary_ip.nat_router_primary_ipv6[count.index].id
+  ip_address    = hcloud_primary_ip.nat_router_primary_ipv6[count.index].ip_address
+  dns_ptr       = "${hcloud_server.nat_router[count.index].name}.${var.base_domain}"
+}
+
 resource "terraform_data" "nat_router_await_cloud_init" {
   count = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
 

--- a/output.tf
+++ b/output.tf
@@ -94,6 +94,20 @@ output "domain_assignments" {
     [for rdns in hcloud_rdns.agents : {
       domain = rdns.dns_ptr
       ips    = [rdns.ip_address]
+    }],
+    # NAT router primary IP PTR assignments.
+    [for rdns in hcloud_rdns.nat_router_primary_ipv4 : {
+      domain = rdns.dns_ptr
+      ips    = [rdns.ip_address]
+    }],
+    [for rdns in hcloud_rdns.nat_router_primary_ipv6 : {
+      domain = rdns.dns_ptr
+      ips    = [rdns.ip_address]
+    }],
+    # Control plane load balancer PTR assignment.
+    [for rdns in hcloud_rdns.control_plane_lb_ipv4 : {
+      domain = rdns.dns_ptr
+      ips    = [rdns.ip_address]
     }]
   )
 }


### PR DESCRIPTION
## Summary
- add `hcloud_rdns` resources for NAT router primary IPv4 and IPv6 addresses when `base_domain` is set
- add `hcloud_rdns` for control-plane load balancer public IPv4 when `use_control_plane_lb=true`, public interface is enabled, and `base_domain` is set
- include these new PTR assignments in `output.domain_assignments`

## Details
- NAT router PTR records are attached to `hcloud_primary_ip` resources and use the NAT router server name under `base_domain`
- control-plane LB PTR uses `${cluster_name}-control-plane.${base_domain}`

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/223
