### PR TITLE
feat(v3): add custom ingress mode and LB IPv4 output (#284)

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -674,7 +674,7 @@ resource "terraform_data" "kustomization" {
         # Wait for helm install jobs to complete (only in namespaces that have jobs)
         "for ns in kube-system ${var.enable_longhorn ? var.longhorn_namespace : ""}; do [ -n \"$ns\" ] && kubectl get ns $ns &>/dev/null && kubectl -n $ns get job -o name 2>/dev/null | grep -q . && kubectl -n $ns wait job --all --for=condition=Complete --timeout=300s || true; done"
       ],
-      local.has_external_load_balancer ? [] : [
+      (local.has_external_load_balancer || !local.is_managed_ingress_controller) ? [] : [
         <<-EOT
       timeout 360 bash <<EOF
       until [ -n "\$(kubectl get -n ${local.ingress_controller_namespace} service/${lookup(local.ingress_controller_service_names, var.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].${var.lb_hostname != "" ? "hostname" : "ip"}}' 2> /dev/null)" ]; do
@@ -968,7 +968,7 @@ resource "null_resource" "rke2_kustomization" {
         "sleep 7", # important as the system upgrade controller CRDs sometimes don't get ready right away, especially with Cilium.
         "${local.kubectl_cli} -n system-upgrade apply -f /var/post_install/plans.yaml"
       ],
-      local.has_external_load_balancer ? [] : [
+      (local.has_external_load_balancer || !local.is_managed_ingress_controller) ? [] : [
         <<-EOT
       timeout 360 bash <<EOF
       until [ -n "\$(${local.kubectl_cli} get -n ${local.ingress_controller_namespace} service/${lookup(local.ingress_controller_service_names, var.ingress_controller)} --output=jsonpath='{.status.loadBalancer.ingress[0].${var.lb_hostname != "" ? "hostname" : "ip"}}' 2> /dev/null)" ]; do

--- a/locals.tf
+++ b/locals.tf
@@ -663,6 +663,12 @@ EOT
 
   has_external_load_balancer = local.using_klipper_lb || var.ingress_controller == "none"
   load_balancer_name         = "${var.cluster_name}-${var.ingress_controller}"
+  managed_ingress_controllers = [
+    "traefik",
+    "nginx",
+    "haproxy"
+  ]
+  is_managed_ingress_controller = contains(local.managed_ingress_controllers, var.ingress_controller)
 
   ingress_controller_service_names = {
     "traefik" = "traefik"

--- a/output.tf
+++ b/output.tf
@@ -46,6 +46,11 @@ output "ingress_public_ipv4" {
   value       = local.has_external_load_balancer ? local.first_control_plane_ip : hcloud_load_balancer.cluster[0].ipv4
 }
 
+output "load_balancer_public_ipv4" {
+  description = "The public IPv4 address of the Terraform-managed ingress load balancer, if present."
+  value       = try(one(hcloud_load_balancer.cluster[*].ipv4), null)
+}
+
 output "ingress_public_ipv6" {
   description = "The public IPv6 address of the Hetzner load balancer (with fallback to first control plane node)"
   value       = local.has_external_load_balancer ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : (var.load_balancer_disable_ipv6 ? null : hcloud_load_balancer.cluster[0].ipv6)

--- a/variables.tf
+++ b/variables.tf
@@ -700,8 +700,8 @@ variable "ingress_controller" {
   description = "The name of the ingress controller."
 
   validation {
-    condition     = contains(["traefik", "nginx", "haproxy", "none"], var.ingress_controller)
-    error_message = "Must be one of \"traefik\" or \"nginx\" or \"haproxy\" or \"none\""
+    condition     = contains(["traefik", "nginx", "haproxy", "none", "custom"], var.ingress_controller)
+    error_message = "Must be one of \"traefik\" or \"nginx\" or \"haproxy\" or \"none\" or \"custom\""
   }
 }
 


### PR DESCRIPTION
## Summary
- add `custom` as an allowed value for `ingress_controller`
- add `load_balancer_public_ipv4` output for the Terraform-managed ingress load balancer
- skip ingress service readiness wait when ingress controller is not module-managed (`custom`)

## Behavior
- managed ingress controllers remain: `traefik`, `nginx`, `haproxy`
- `custom` does not try to install module ingress manifests and does not wait for a module-managed ingress Service name
- `load_balancer_public_ipv4` returns the ingress LB IPv4 when present, otherwise `null`

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/284
