### PR TITLE
feat(v3): add k3s/rke2 config outputs and warning note (#1435)

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -310,6 +310,8 @@ module "kube-hetzner" {
   ]
   # Add additional configuration options for control planes here.
   # E.g to enable monitoring for etcd, proxy etc:
+  # WARNING: avoid overriding core bootstrap keys (token/server/node-ip/cluster-cidr/service-cidr)
+  # unless you fully understand upgrade and compatibility implications.
   # control_planes_custom_config = {
   #  etcd-expose-metrics = true,
   #  kube-controller-manager-arg = "bind-address=0.0.0.0",

--- a/output.tf
+++ b/output.tf
@@ -72,6 +72,18 @@ output "k3s_token" {
   sensitive   = true
 }
 
+output "k3s_config" {
+  description = "Rendered k3s control plane config by node."
+  value       = local.k3s-config
+  sensitive   = true
+}
+
+output "rke2_config" {
+  description = "Rendered rke2 control plane config by node."
+  value       = local.rke2-config
+  sensitive   = true
+}
+
 output "control_plane_nodes" {
   description = "The control plane nodes"
   value       = [for node in module.control_planes : node]


### PR DESCRIPTION
## Summary
- add `k3s_config` output (sensitive) with rendered control plane k3s config by node
- add `rke2_config` output (sensitive) with rendered control plane rke2 config by node
- add an explicit warning comment in `kube.tf.example` near `control_planes_custom_config`

## Validation
- `terraform fmt -recursive` (module): passed
- `terraform validate` (module): passed
- `terraform init -upgrade` (kube-test): passed
- `terraform plan -no-color` (kube-test): fails without valid 64-char Hetzner token
- `TF_VAR_hcloud_token=<64-char-placeholder> terraform plan -lock=false -no-color` (kube-test): reaches graphing and then fails with Hetzner API `401` on data sources in this environment

## Discussion
- Implements: https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/discussions/1435
