### PR TITLE
feat: add configurable secrets encryption mode (idea 368)

### DIFF
--- a/ccm-helm-release.tf
+++ b/ccm-helm-release.tf
@@ -1,0 +1,21 @@
+resource "helm_release" "hcloud_ccm" {
+  count = var.hetzner_ccm_use_helm ? 1 : 0
+
+  name             = "hcloud-cloud-controller-manager"
+  repository       = "https://charts.hetzner.cloud"
+  chart            = "hcloud-cloud-controller-manager"
+  namespace        = "kube-system"
+  create_namespace = false
+  version          = local.ccm_version
+  values           = [local.hetzner_ccm_values]
+
+  wait            = true
+  timeout         = 600
+  cleanup_on_fail = true
+
+  depends_on = [
+    terraform_data.kube_system_secrets,
+    terraform_data.control_planes,
+    null_resource.control_planes_rke2
+  ]
+}

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -134,7 +134,7 @@ locals {
       disable-kube-proxy          = var.disable_kube_proxy
       disable                     = local.disable_rke2_extras
       kubelet-arg                 = concat(local.kubelet_arg, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args, v.kubelet_args)
-      kube-apiserver-arg          = local.kube_apiserver_arg
+      kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
       kube-controller-manager-arg = local.kube_controller_manager_arg
       node-ip                     = module.control_planes[k].private_ipv4_address
       advertise-address           = module.control_planes[k].private_ipv4_address
@@ -189,7 +189,7 @@ locals {
       disable                  = local.disable_extras
       # Kubelet arg precedence (last wins): local.kubelet_arg > v.kubelet_args > k3s_global_kubelet_args > k3s_control_plane_kubelet_args
       kubelet-arg                 = concat(local.kubelet_arg, v.kubelet_args, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args)
-      kube-apiserver-arg          = local.kube_apiserver_arg
+      kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
       kube-controller-manager-arg = local.kube_controller_manager_arg
       flannel-iface               = local.flannel_iface
       node-ip                     = module.control_planes[k].private_ipv4_address
@@ -238,6 +238,7 @@ resource "null_resource" "control_plane_config_rke2" {
     control_plane_id = module.control_planes[each.key].id
     config           = sha1(yamlencode(local.rke2-config[each.key]))
     cni_values       = sha1(local.desired_cni_values)
+    encryption       = sha1(local.secrets_encryption_config)
   }
 
   connection {
@@ -257,6 +258,11 @@ resource "null_resource" "control_plane_config_rke2" {
   provisioner "file" {
     content     = yamlencode(local.rke2-config[each.key])
     destination = "/tmp/config.yaml"
+  }
+
+  provisioner "file" {
+    content     = local.secrets_encryption_config
+    destination = "/tmp/encryption-config.yaml"
   }
 
   # Create /var/lib/rancher/rke2/server/manifests directory
@@ -293,6 +299,7 @@ resource "terraform_data" "control_plane_config" {
   triggers_replace = {
     control_plane_id = module.control_planes[each.key].id
     config           = sha1(yamlencode(local.k3s-config[each.key]))
+    encryption       = sha1(local.secrets_encryption_config)
   }
 
   connection {
@@ -313,6 +320,11 @@ resource "terraform_data" "control_plane_config" {
   provisioner "file" {
     content     = yamlencode(local.k3s-config[each.key])
     destination = "/tmp/config.yaml"
+  }
+
+  provisioner "file" {
+    content     = local.secrets_encryption_config
+    destination = "/tmp/encryption-config.yaml"
   }
 
   provisioner "remote-exec" {

--- a/init.tf
+++ b/init.tf
@@ -689,6 +689,7 @@ resource "terraform_data" "kustomization" {
   depends_on = [
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets
@@ -984,6 +985,7 @@ resource "null_resource" "rke2_kustomization" {
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
     null_resource.control_planes_rke2,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets

--- a/init.tf
+++ b/init.tf
@@ -104,6 +104,7 @@ resource "terraform_data" "first_control_plane" {
           disable-kube-proxy          = var.disable_kube_proxy
           disable                     = local.disable_extras
           kubelet-arg                 = local.kubelet_arg
+          kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
           kube-controller-manager-arg = local.kube_controller_manager_arg
           flannel-iface               = local.flannel_iface
           node-ip                     = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
@@ -136,6 +137,11 @@ resource "terraform_data" "first_control_plane" {
     )
 
     destination = "/tmp/config.yaml"
+  }
+
+  provisioner "file" {
+    content     = local.secrets_encryption_config
+    destination = "/tmp/encryption-config.yaml"
   }
 
   # Install k3s server
@@ -191,6 +197,7 @@ resource "null_resource" "control_plane_setup_rke2" {
     versions = join("\n", [
       coalesce(local.desired_cni_version, "N/A"),
     ])
+    encryption = sha1(local.secrets_encryption_config)
   }
 
   connection {
@@ -219,6 +226,7 @@ resource "null_resource" "control_plane_setup_rke2" {
           disable-kube-proxy          = var.disable_kube_proxy
           disable                     = local.disable_rke2_extras
           kubelet-arg                 = concat(local.kubelet_arg, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args, local.control_plane_nodes[keys(module.control_planes)[0]].kubelet_args)
+          kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
           kube-controller-manager-arg = local.kube_controller_manager_arg
           node-ip                     = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
@@ -243,6 +251,11 @@ resource "null_resource" "control_plane_setup_rke2" {
     )
 
     destination = "/tmp/config.yaml"
+  }
+
+  provisioner "file" {
+    content     = local.secrets_encryption_config
+    destination = "/tmp/encryption-config.yaml"
   }
 
   # Upload the cilium install file

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -532,6 +532,10 @@ module "kube-hetzner" {
   #   etcd-s3-region          = "<your-s3-bucket-region|usually required for aws>"
   # }
 
+  # Enable Kubernetes Secrets encryption at rest on control plane nodes.
+  # This writes an EncryptionConfiguration file and wires kube-apiserver to use it.
+  # secrets_encryption = true
+
   # To enable Hetzner Storage Box support, you can enable csi-driver-smb, default is "false".
   # enable_csi_driver_smb = true
   # If you want to specify the version for csi-driver-smb, set it below - otherwise it'll use the latest version available.

--- a/locals.tf
+++ b/locals.tf
@@ -248,7 +248,7 @@ locals {
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
       ],
-      var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
+      var.hetzner_ccm_use_helm ? [] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       local.kubernetes_distribution == "k3s" ? lookup(local.cni_install_resources, var.cni_plugin, []) : [],

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,12 @@ resource "random_password" "k3s_token" {
   special = false
 }
 
+resource "random_password" "secrets_encryption_key" {
+  count   = var.secrets_encryption ? 1 : 0
+  length  = 32
+  special = false
+}
+
 resource "hcloud_ssh_key" "k3s" {
   count      = var.hcloud_ssh_key_id == null ? 1 : 0
   name       = var.cluster_name

--- a/providers-k8s.tf
+++ b/providers-k8s.tf
@@ -1,0 +1,15 @@
+provider "kubernetes" {
+  host                   = local.kubeconfig_data.host
+  cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+  client_certificate     = local.kubeconfig_data.client_certificate
+  client_key             = local.kubeconfig_data.client_key
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = local.kubeconfig_data.host
+    cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+    client_certificate     = local.kubeconfig_data.client_certificate
+    client_key             = local.kubeconfig_data.client_key
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -694,6 +694,12 @@ variable "etcd_s3_backup" {
   default     = {}
 }
 
+variable "secrets_encryption" {
+  description = "Enable API server EncryptionConfiguration for Kubernetes Secrets at rest."
+  type        = bool
+  default     = false
+}
+
 variable "ingress_controller" {
   type        = string
   default     = "traefik"

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "integrations/github"
       version = ">= 6.4.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.14.0"
+    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = ">= 1.59.0"
@@ -12,6 +16,10 @@ terraform {
     http = {
       source  = "hashicorp/http"
       version = ">= 3.4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.31.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Summary
- Implement task from the remaining hard ideas plan.
- Branch: `codex/idea-368-implement-secrets-encryption-variable-that-configures`

## Validation
- terraform fmt -recursive
- terraform validate
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; local run reaches expected HCLOUD_TOKEN error in this environment)