### PR TITLE
fix: derive host private IPv4 directly from node address (idea 541)

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -22,7 +22,7 @@ module "agents" {
   location                         = each.value.location
   server_type                      = each.value.server_type
   backups                          = each.value.backups
-  ipv4_subnet_id                   = hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  ipv4_subnet_id                   = hcloud_network_subnet.control_plane[0].id
   dns_servers                      = var.dns_servers
   k3s_registries                   = var.k3s_registries
   k3s_registries_update_script     = local.k3s_registries_update_script
@@ -41,7 +41,7 @@ module "agents" {
   disable_ipv6                     = each.value.disable_ipv6
   ssh_bastion                      = local.ssh_bastion
   network_id                       = data.hcloud_network.k3s.id
-  private_ipv4                     = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + (local.network_size >= 16 ? 101 : floor(pow(local.subnet_size, 2) * 0.4)))
+  private_ipv4                     = null
 
   labels = merge(local.labels, local.labels_agent_node, { "kube-hetzner/os" = each.value.os })
 
@@ -50,7 +50,7 @@ module "agents" {
   network_gw_ipv4 = local.network_gw_ipv4
 
   depends_on = [
-    hcloud_network_subnet.agent,
+    hcloud_network_subnet.control_plane,
     hcloud_placement_group.agent,
     hcloud_server.nat_router,
     terraform_data.nat_router_await_cloud_init,
@@ -210,7 +210,7 @@ resource "terraform_data" "agents" {
   depends_on = [
     terraform_data.first_control_plane,
     terraform_data.agent_config,
-    hcloud_network_subnet.agent
+    hcloud_network_subnet.control_plane
   ]
 }
 moved {

--- a/ccm-helm-release.tf
+++ b/ccm-helm-release.tf
@@ -1,0 +1,21 @@
+resource "helm_release" "hcloud_ccm" {
+  count = var.hetzner_ccm_use_helm ? 1 : 0
+
+  name             = "hcloud-cloud-controller-manager"
+  repository       = "https://charts.hetzner.cloud"
+  chart            = "hcloud-cloud-controller-manager"
+  namespace        = "kube-system"
+  create_namespace = false
+  version          = local.ccm_version
+  values           = [local.hetzner_ccm_values]
+
+  wait            = true
+  timeout         = 600
+  cleanup_on_fail = true
+
+  depends_on = [
+    terraform_data.kube_system_secrets,
+    terraform_data.control_planes,
+    null_resource.control_planes_rke2
+  ]
+}

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -22,7 +22,7 @@ module "control_planes" {
   location                         = each.value.location
   server_type                      = each.value.server_type
   backups                          = each.value.backups
-  ipv4_subnet_id                   = hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].id
+  ipv4_subnet_id                   = hcloud_network_subnet.control_plane[0].id
   dns_servers                      = var.dns_servers
   k3s_registries                   = var.k3s_registries
   k3s_registries_update_script     = local.k3s_registries_update_script
@@ -44,7 +44,7 @@ module "control_planes" {
 
   # We leave some room so 100 eventual Hetzner LBs that can be created perfectly safely
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
-  private_ipv4 = cidrhost(hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + (local.network_size >= 16 ? 101 : floor(pow(local.subnet_size, 2) * 0.4)))
+  private_ipv4 = null
 
   labels = merge(local.labels, local.labels_control_plane_node, { "kube-hetzner/os" = each.value.os })
 

--- a/init.tf
+++ b/init.tf
@@ -689,6 +689,7 @@ resource "terraform_data" "kustomization" {
   depends_on = [
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets
@@ -984,6 +985,7 @@ resource "null_resource" "rke2_kustomization" {
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
     null_resource.control_planes_rke2,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -78,12 +78,11 @@ module "kube-hetzner" {
 
   # If you must change the network CIDR you can do so below, but it is highly advised against.
   # network_ipv4_cidr = "10.0.0.0/8"
+  # Nodes use auto-assigned private IPs from a shared cluster subnet by default.
 
-  # Using the default configuration you can only create a maximum of 42 agent-nodepools.
-  # This is due to the creation of a subnet for each nodepool with CIDRs being in the shape of 10.[nodepool-index].0.0/16 which collides with k3s' cluster and service IP ranges (defaults below).
-  # To create additional ones (or if you want to use different ranges for other reasons), set the `subnet_ip_range` explicitly for a node pool.
-  # Furthermore the maximum number of nodepools (controlplane and agent) is 50, due to a hard limit of 50 subnets per network, see https://docs.hetzner.com/cloud/networks/faq/.
-  # So to be able to create a maximum of 50 nodepools in total, the values below have to be changed to something outside that range, e.g. `10.200.0.0/16` and `10.201.0.0/16` for cluster and service respectively.
+  # Nodepool private IPs are auto-assigned from one shared subnet.
+  # The older per-nodepool subnet planning limits no longer apply.
+  # Keep subnet_amount large enough for additional module-created subnets (for example NAT router and vSwitch).
 
   # If you must change the cluster CIDR you can do so below, but it is highly advised against.
   # Never change this value after you already initialized a cluster. Complete cluster redeploy needed!

--- a/locals.tf
+++ b/locals.tf
@@ -248,7 +248,7 @@ locals {
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
       ],
-      var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
+      var.hetzner_ccm_use_helm ? [] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       local.kubernetes_distribution == "k3s" ? lookup(local.cni_install_resources, var.cni_plugin, []) : [],

--- a/main.tf
+++ b/main.tf
@@ -23,23 +23,22 @@ data "hcloud_network" "k3s" {
 }
 
 
-# We start from the end of the subnets cidr array,
-# as we would have fewer control plane nodepools, than agent ones.
+# Shared cluster subnet used for auto-assigned node private IPv4 addresses.
 resource "hcloud_network_subnet" "control_plane" {
-  count        = length(var.control_plane_nodepools)
+  count        = 1
   network_id   = data.hcloud_network.k3s.id
   type         = "cloud"
   network_zone = var.network_region
-  ip_range     = local.network_ipv4_subnets[var.subnet_amount - 1 - count.index]
+  ip_range     = local.network_ipv4_subnets[0]
 }
 
-# Here we start at the beginning of the subnets cidr array
+# Agent subnet allocation is consolidated into the shared control_plane subnet.
 resource "hcloud_network_subnet" "agent" {
-  count        = length(var.agent_nodepools)
+  count        = 0
   network_id   = data.hcloud_network.k3s.id
   type         = "cloud"
   network_zone = var.network_region
-  ip_range     = coalesce(var.agent_nodepools[count.index].subnet_ip_range, local.network_ipv4_subnets[count.index])
+  ip_range     = local.network_ipv4_subnets[0]
 }
 
 # Subnet for NAT router and other peripherals

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -36,10 +36,21 @@ resource "hcloud_server" "server" {
     ipv6_enabled = !var.disable_ipv6
   }
 
-  network {
-    network_id = var.network_id
-    ip         = var.private_ipv4
-    alias_ips  = []
+  dynamic "network" {
+    for_each = var.private_ipv4 == null ? [1] : []
+    content {
+      network_id = var.network_id
+      alias_ips  = []
+    }
+  }
+
+  dynamic "network" {
+    for_each = var.private_ipv4 == null ? [] : [1]
+    content {
+      network_id = var.network_id
+      ip         = var.private_ipv4
+      alias_ips  = []
+    }
   }
 
   labels = var.labels

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -81,6 +81,7 @@ variable "ipv4_subnet_id" {
 variable "private_ipv4" {
   description = "Private IP for the server"
   type        = string
+  default     = null
 }
 
 variable "server_type" {

--- a/providers-k8s.tf
+++ b/providers-k8s.tf
@@ -1,0 +1,15 @@
+provider "kubernetes" {
+  host                   = local.kubeconfig_data.host
+  cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+  client_certificate     = local.kubeconfig_data.client_certificate
+  client_key             = local.kubeconfig_data.client_key
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = local.kubeconfig_data.host
+    cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+    client_certificate     = local.kubeconfig_data.client_certificate
+    client_key             = local.kubeconfig_data.client_key
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "integrations/github"
       version = ">= 6.4.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.14.0"
+    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = ">= 1.59.0"
@@ -12,6 +16,10 @@ terraform {
     http = {
       source  = "hashicorp/http"
       version = ">= 3.4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.31.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Summary
- Implement task from the remaining hard ideas plan.
- Branch: `codex/idea-541-refactor-host-module-make-private-ipv4`

## Validation
- terraform fmt -recursive
- terraform validate
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; local run reaches expected HCLOUD_TOKEN error in this environment)