### PR TITLE
idea #1838: rename master branch main github settings

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -2,7 +2,7 @@ name: Generate terraform docs
 on:
   push:
     branches:
-      - master
+      - main
       - staging
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <!-- HERO SECTION -->
-<img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/master/.images/kube-hetzner-logo.png" alt="Kube-Hetzner Logo" width="140" height="140">
+<img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/main/.images/kube-hetzner-logo.png" alt="Kube-Hetzner Logo" width="140" height="140">
 
 # Kube-Hetzner
 
@@ -61,7 +61,7 @@ Built on the shoulders of giants:
 - **[k3s](https://k3s.io/)** — Certified, lightweight Kubernetes distribution
 
 <div align="center">
-<img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/master/.images/kubectl-pod-all-17022022.png" alt="Kube-Hetzner Screenshot" width="700">
+<img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/main/.images/kubectl-pod-all-17022022.png" alt="Kube-Hetzner Screenshot" width="700">
 </div>
 
 ### Why Leap Micro over Ubuntu?
@@ -191,14 +191,14 @@ Built on the shoulders of giants:
 </table>
 
 ```sh
-tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/create.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"
+tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/scripts/create.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"
 ```
 
 <details>
 <summary><strong>Fish shell version</strong></summary>
 
 ```fish
-set tmp_script (mktemp); curl -sSL -o "{tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/create.sh; chmod +x "{tmp_script}"; bash "{tmp_script}"; rm "{tmp_script}"
+set tmp_script (mktemp); curl -sSL -o "{tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/scripts/create.sh; chmod +x "{tmp_script}"; bash "{tmp_script}"; rm "{tmp_script}"
 ```
 </details>
 
@@ -206,7 +206,7 @@ set tmp_script (mktemp); curl -sSL -o "{tmp_script}" https://raw.githubuserconte
 <summary><strong>Save as alias for future use</strong></summary>
 
 ```sh
-alias createkh='tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/create.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"'
+alias createkh='tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/scripts/create.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"'
 ```
 </details>
 
@@ -216,9 +216,9 @@ alias createkh='tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw
 ```sh
 mkdir /path/to/your/new/folder
 cd /path/to/your/new/folder
-curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example -o kube.tf
-curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-leapmicro-snapshots.pkr.hcl -o hcloud-leapmicro-snapshots.pkr.hcl
-curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-microos-snapshots.pkr.hcl -o hcloud-microos-snapshots.pkr.hcl
+curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/kube.tf.example -o kube.tf
+curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/packer-template/hcloud-leapmicro-snapshots.pkr.hcl -o hcloud-leapmicro-snapshots.pkr.hcl
+curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/packer-template/hcloud-microos-snapshots.pkr.hcl -o hcloud-microos-snapshots.pkr.hcl
 export HCLOUD_TOKEN="your_hcloud_token"
 packer init hcloud-leapmicro-snapshots.pkr.hcl
 packer build hcloud-leapmicro-snapshots.pkr.hcl
@@ -1107,7 +1107,7 @@ terraform destroy -auto-approve
 **If destroy hangs** (LB or autoscaled nodes), use the cleanup script:
 
 ```sh
-tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/cleanup.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"
+tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/scripts/cleanup.sh && chmod +x "${tmp_script}" && "${tmp_script}" && rm "${tmp_script}"
 ```
 
 > ⚠️ This deletes everything including volumes. Dry-run option available.
@@ -1198,7 +1198,7 @@ Your sponsorship directly funds:
 - **[openSUSE](https://www.opensuse.org)** — Leap Micro & MicroOS, next-level container OS
 
 <div align="center">
-<a href="https://www.hetzner.com"><img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/master/.images/hetzner-logo.svg" alt="Hetzner — Server · Cloud · Hosting" height="80"></a>
+<a href="https://www.hetzner.com"><img src="https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/raw/main/.images/hetzner-logo.svg" alt="Hetzner — Server · Cloud · Hosting" height="80"></a>
 <br><br>
 </div>
 

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -76,7 +76,7 @@ module "kube-hetzner" {
   # version = "2.15.3"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
-  # 3. If you want to use the latest master branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
+  # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
   # source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner"
 ```
 
@@ -2698,7 +2698,7 @@ controller:
 ```terraform
   # Override values given to the HAProxy helm chart.
   # All HAProxy helm values can be found at https://github.com/haproxytech/helm-charts/blob/main/kubernetes-ingress/values.yaml
-  # Default values can be found at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/locals.tf
+  # Default values can be found at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/main/locals.tf
   /*   haproxy_values = <<-EOT
   EOT */
 ```

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -30,7 +30,7 @@ module "kube-hetzner" {
   # version = "2.15.3"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
-  # 3. If you want to use the latest master branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
+  # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
   # source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner"
 
   # Note that some values, notably "location" and "public_key" have no effect after initializing the cluster.
@@ -585,7 +585,7 @@ module "kube-hetzner" {
   # - Create Robot Webservice credentials and set them to the `robot_user` and `robot_password` TF-variables. They are passed on via secrets to HCCM env.
   # - `hetzner_ccm_use_helm = true`
   # - `robot_ccm_enabled = true`
-  # See more from https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/docs/add-robot-server.md
+  # See more from https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/main/docs/add-robot-server.md
   # robot_ccm_enabled = false
 
   # To connect the Hetzner Cloud network to Robot servers via vSwitch subnet, create the vSwitch and set its ID to the `vswitch_id` (number).
@@ -1228,7 +1228,7 @@ webhook:
   # Hetzner Cloud Controller Manager, all Hetzner Cloud Controller Manager helm values can be found at https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
   # We advise you to not touch this and to let the defaults that are already set under the hood.
   # If you want to merge extra values into defaults (or hetzner_ccm_values), use hetzner_ccm_merge_values.
-  # For advanced use cases like adding Hetzner Robot servers, see: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/docs/add-robot-server.md
+  # For advanced use cases like adding Hetzner Robot servers, see: https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/main/docs/add-robot-server.md
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   hetzner_ccm_values = <<-EOT
 networking:
@@ -1424,7 +1424,7 @@ controller:
 
   # Override values given to the HAProxy helm chart.
   # All HAProxy helm values can be found at https://github.com/haproxytech/helm-charts/blob/main/kubernetes-ingress/values.yaml
-  # Default values can be found at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/master/locals.tf
+  # Default values can be found at https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/blob/main/locals.tf
   # If you want to merge extra values into defaults (or haproxy_values), use haproxy_merge_values.
   /*   haproxy_values = <<-EOT
   EOT */

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -47,20 +47,20 @@ fi
 
 # Download the required files only if they don't exist
 if [ ! -e "${folder_path}/kube.tf" ]; then
-    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example -o "${folder_path}/kube.tf"
+    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/kube.tf.example -o "${folder_path}/kube.tf"
 else
     echo "kube.tf already exists. Skipping download."
 fi
 
 if [ ! -e "${folder_path}/hcloud-microos-snapshots.pkr.hcl" ]; then
-    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
+    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
 else
     echo "hcloud-microos-snapshots.pkr.hcl already exists. Skipping download."
 fi
 
 # Leap Micro snapshots (recommended)
 if [ ! -e "${folder_path}/hcloud-leapmicro-snapshots.pkr.hcl" ]; then
-    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-leapmicro-snapshots.pkr.hcl -o "${folder_path}/hcloud-leapmicro-snapshots.pkr.hcl"
+    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/main/packer-template/hcloud-leapmicro-snapshots.pkr.hcl -o "${folder_path}/hcloud-leapmicro-snapshots.pkr.hcl"
 else
     echo "hcloud-leapmicro-snapshots.pkr.hcl already exists. Skipping download."
 fi


### PR DESCRIPTION
## Summary
- Implements backlog task T09 from discussion #1838.
- Branch: `codex/idea-1838-rename-master-branch-main-github-settings`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)