### PR TITLE
idea #405: create tests directory configuration presets tfvars

### DIFF
--- a/.github/workflows/hetzner-test.yaml
+++ b/.github/workflows/hetzner-test.yaml
@@ -23,10 +23,14 @@ env:
 
 jobs:
   tests:
-    name: Run Hetzner Tests
+    name: Run Hetzner Tests (${{ matrix.preset }})
     runs-on: ubuntu-latest
     environment: hetzner-test
     if: ${{ vars.TEST_IN_HETZNER == '1' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [default, nginx_ingress, rke2]
 
     steps:
       - name: Add env mask
@@ -55,19 +59,35 @@ jobs:
         if: steps.prerequisites.outputs.enabled == 'true'
         uses: hashicorp/setup-terraform@v3
 
+      - name: Install kubectl
+        if: steps.prerequisites.outputs.enabled == 'true'
+        uses: azure/setup-kubectl@v4
+
       - name: Create SSH keys
         if: steps.prerequisites.outputs.enabled == 'true'
         run: ssh-keygen -f ~/.ssh/id_ed25519 -N ""
 
-      - name: Apply base example
+      - name: Apply preset
         if: steps.prerequisites.outputs.enabled == 'true'
         timeout-minutes: 20
         run: |
+          TEST_CLUSTER_NAME="kh-ci-${{ matrix.preset }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "TEST_CLUSTER_NAME=${TEST_CLUSTER_NAME}" >> "$GITHUB_ENV"
           cp kube.tf.example kube.tf
+          cp "tests/presets/${{ matrix.preset }}.tfvars" tests.auto.tfvars
           terraform init
           terraform validate
-          terraform apply -auto-approve
+          terraform apply -auto-approve -var="cluster_name=${TEST_CLUSTER_NAME}"
+
+      - name: Basic cluster health
+        if: steps.prerequisites.outputs.enabled == 'true'
+        timeout-minutes: 5
+        run: |
+          KUBECONFIG_FILE="${TEST_CLUSTER_NAME}_kubeconfig.yaml"
+          test -f "${KUBECONFIG_FILE}"
+          kubectl --kubeconfig "${KUBECONFIG_FILE}" get nodes -o wide
+          kubectl --kubeconfig "${KUBECONFIG_FILE}" get pods -A
 
       - name: Destroy cluster
         if: steps.prerequisites.outputs.enabled == 'true' && always()
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve -var="cluster_name=${TEST_CLUSTER_NAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+!tests/presets/*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Hetzner Test Presets
+
+These `.tfvars` files are used by `.github/workflows/hetzner-test.yaml` to run a
+matrix of real deployment tests.
+
+- `default.tfvars`: baseline defaults
+- `nginx_ingress.tfvars`: deploy with NGINX ingress controller
+- `rke2.tfvars`: deploy with RKE2 distribution

--- a/tests/presets/default.tfvars
+++ b/tests/presets/default.tfvars
@@ -1,0 +1,1 @@
+# Baseline k3s deployment with module defaults.

--- a/tests/presets/nginx_ingress.tfvars
+++ b/tests/presets/nginx_ingress.tfvars
@@ -1,0 +1,2 @@
+ingress_controller    = "nginx"
+ingress_replica_count = 1

--- a/tests/presets/rke2.tfvars
+++ b/tests/presets/rke2.tfvars
@@ -1,0 +1,2 @@
+kubernetes_distribution_type = "rke2"
+ingress_controller           = "traefik"


### PR DESCRIPTION
## Summary
- Implements backlog task T13 from discussion #405.
- Branch: `codex/idea-405-create-tests-directory-configuration-presets-tfvars`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)