### PR TITLE
idea #1997: ensure cluster autoscaler resource values is

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,29 @@
 # Migration advice when updating the module
 
+# v3 migration stability note
+
+When upgrading clusters that rely on autoscaling, treat `cluster_autoscaler_resource_values` as a primary stability control.
+If autoscaler pods restart due to CPU/memory pressure, scale events can stall or flap.
+
+Use the following settings as a baseline and tune up for larger clusters:
+
+```hcl
+cluster_autoscaler_replicas       = 2
+cluster_autoscaler_resource_limits = true
+cluster_autoscaler_resource_values = {
+  requests = {
+    cpu    = "100m"
+    memory = "300Mi"
+  }
+  limits = {
+    cpu    = "200m"
+    memory = "500Mi"
+  }
+}
+```
+
+Reference example: `kube.tf.example` (Cluster Autoscaler deployment configuration section).
+
 # 2.18.3 -> 2.19.0
 
 ## User Kustomization

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -493,7 +493,9 @@ module "kube-hetzner" {
   # cluster_autoscaler_resource_limits: Enable or disable resource limits/requests (default: true)
   #   - Set to false to remove resource constraints entirely
   #
-  # cluster_autoscaler_resource_values: Customize CPU and memory resources (defaults: 100m CPU, 300Mi memory for both requests and limits)
+  # cluster_autoscaler_resource_values: Primary stability tuning for the autoscaler pod.
+  #   - Use this to prevent autoscaler restarts from low CPU/memory during scale events.
+  #   - Defaults: 100m CPU, 300Mi memory for both requests and limits.
   #
   # Example:
   #


### PR DESCRIPTION
## Summary
- Implements backlog task T20 from discussion #1997.
- Branch: `codex/idea-1997-ensure-cluster-autoscaler-resource-values-is`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)