### PR TITLE
idea #976: update readme md officially state opentofu

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -38,6 +38,21 @@ jobs:
       - name: terraform validate
         uses: dflook/terraform-validate@v2.2.3
 
+  opentofu-validate:
+    runs-on: ubuntu-latest
+    name: Validate OpenTofu compatibility
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: tofu init and validate
+        run: |
+          tofu init -backend=false
+          tofu validate
+
   fmt-check:
     runs-on: ubuntu-latest
     name: Check formatting of terraform files

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Built on the shoulders of giants:
 
 > **Required tools:** [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tofu](https://opentofu.org/docs/intro/install/), [packer](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#installing-packer) (initial setup only), [kubectl](https://kubernetes.io/docs/tasks/tools/), [hcloud](https://github.com/hetznercloud/cli)
 
+OpenTofu is officially supported. Pull requests are validated in CI with both Terraform and OpenTofu.
+
 ---
 
 ### ⚡ Quick Start


### PR DESCRIPTION
## Summary
- Implements backlog task T21 from discussion #976.
- Branch: `codex/idea-976-update-readme-md-officially-state-opentofu`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)