### PR TITLE
idea #1926: create new example directory at examples

### DIFF
--- a/examples/argocd/README.md
+++ b/examples/argocd/README.md
@@ -1,0 +1,41 @@
+# ArgoCD Example (Helm + `kubeconfig_data`)
+
+This example shows how to configure both the `kubernetes` and `helm` providers from `module.kube-hetzner.kubeconfig_data`, then install ArgoCD using `helm_release`.
+
+## What this example does
+
+1. Creates a minimal kube-hetzner cluster.
+2. Reads the module output `kubeconfig_data`.
+3. Uses that output to configure:
+   - `provider "kubernetes"`
+   - `provider "helm"`
+4. Installs ArgoCD from `https://argoproj.github.io/argo-helm`.
+
+## Usage
+
+Create `terraform.tfvars`:
+
+```hcl
+hcloud_token    = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ssh_public_key  = file("~/.ssh/id_ed25519.pub")
+ssh_private_key = file("~/.ssh/id_ed25519")
+cluster_name    = "argocd-demo"
+```
+
+Run Terraform:
+
+```sh
+terraform init
+terraform apply -target=module.kube-hetzner -auto-approve
+terraform apply -auto-approve
+```
+
+The first apply creates the cluster and makes `kubeconfig_data` available.  
+The second apply installs ArgoCD through Helm.
+
+## Best practices
+
+- Prefer separating infra and app deployments into different Terraform states.
+- Pin Helm chart versions (`version = "..."`) to avoid surprise upgrades.
+- Keep `hcloud_token` and `ssh_private_key` as sensitive inputs.
+- Use ArgoCD as GitOps controller after bootstrap; avoid mixing manual in-cluster drift with Terraform-managed Helm releases.

--- a/examples/argocd/main.tf
+++ b/examples/argocd/main.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = ">= 1.59.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.32.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.15.0"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+module "kube-hetzner" {
+  source = "kube-hetzner/kube-hetzner/hcloud"
+
+  providers = {
+    hcloud = hcloud
+  }
+
+  hcloud_token    = var.hcloud_token
+  ssh_public_key  = var.ssh_public_key
+  ssh_private_key = var.ssh_private_key
+
+  cluster_name = var.cluster_name
+
+  control_plane_nodepools = [
+    {
+      name        = "control-plane"
+      server_type = "cx23"
+      location    = "nbg1"
+      labels      = []
+      taints      = []
+      count       = 1
+    }
+  ]
+
+  agent_nodepools = [
+    {
+      name        = "agent"
+      server_type = "cx23"
+      location    = "nbg1"
+      labels      = []
+      taints      = []
+      count       = 1
+    }
+  ]
+}
+
+locals {
+  kubeconfig_data = module.kube-hetzner.kubeconfig_data
+}
+
+provider "kubernetes" {
+  host                   = local.kubeconfig_data.host
+  client_certificate     = local.kubeconfig_data.client_certificate
+  client_key             = local.kubeconfig_data.client_key
+  cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kubeconfig_data.host
+    client_certificate     = local.kubeconfig_data.client_certificate
+    client_key             = local.kubeconfig_data.client_key
+    cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "8.3.6"
+  create_namespace = true
+
+  depends_on = [module.kube-hetzner]
+}
+
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token."
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content for cluster nodes."
+  type        = string
+}
+
+variable "ssh_private_key" {
+  description = "SSH private key content for Terraform provisioners."
+  type        = string
+  sensitive   = true
+}
+
+variable "cluster_name" {
+  description = "Cluster name prefix."
+  type        = string
+  default     = "argocd-demo"
+}


### PR DESCRIPTION
## Summary
- Implements backlog task T24 from discussion #1926.
- Branch: `codex/idea-1926-create-new-example-directory-at-examples`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)