### PR TITLE
idea #872: refactor firewall rules terraform remove default

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -928,8 +928,9 @@ module "kube-hetzner" {
   # you would have to connect to any control plane node via SSH, as you can run kubectl from within these.
   # Please be advised that this setting has no effect on the load balancer when the use_control_plane_lb variable is set to true. This is
   # because firewall rules cannot be applied to load balancers yet.
-  # You can use "myipv4" as a placeholder and it will resolve to your current public IPv4/32 during apply.
-  # firewall_kube_api_source = null
+  # Default is ["myipv4"] (resolved to your current public IPv4/32 during apply).
+  # Set to null to disable this rule entirely, or provide your own CIDR list.
+  # firewall_kube_api_source = ["myipv4", "203.0.113.10/32"]
 
   # Allow SSH access from the specified networks. Default: ["0.0.0.0/0", "::/0"]
   # Allowed values: null (disable SSH rule entirely) or a list of allowed networks with CIDR notation.

--- a/variables.tf
+++ b/variables.tf
@@ -1030,8 +1030,8 @@ variable "extra_firewall_rules" {
 
 variable "firewall_kube_api_source" {
   type        = list(string)
-  default     = ["0.0.0.0/0", "::/0"]
-  description = "Source networks that have Kube API access to the servers."
+  default     = ["myipv4"]
+  description = "Source networks that have Kube API access to the servers. Default is the current apply runner public IPv4 (/32) via the myipv4 placeholder."
 }
 
 variable "firewall_ssh_source" {


### PR DESCRIPTION
## Summary
- Implements backlog task T26 from discussion #872.
- Branch: `codex/idea-872-refactor-firewall-rules-terraform-remove-default`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)