### PR TITLE
idea #1418: migrate all remaining helm based manifest

### DIFF
--- a/kube.tf.example
+++ b/kube.tf.example
@@ -595,6 +595,7 @@ module "kube-hetzner" {
 
   # See https://github.com/hetznercloud/csi-driver/releases for the available versions.
   # hetzner_csi_version = ""
+  # You can customize Helm values with hetzner_csi_values, or overlay defaults with hetzner_csi_merge_values.
 
   # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available.
   # See https://github.com/kubereboot/kured/releases for the available versions.
@@ -1170,6 +1171,7 @@ module "kube-hetzner" {
   # Or you can create a thepackage-values.yaml file with the content and use it here with the following syntax:
   # thepackage_values = file("thepackage-values.yaml")
   # _values fully replaces the chart values used by the module. _merge_values keeps the defaults (or *_values if set) and overlays your YAML on top.
+  # Prefer *_merge_values as the standard customization API for incremental, upgrade-safe tuning.
 
   # Cilium, all Cilium helm values can be found at https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml
   # Be careful when maintaining your own cilium_values, as the choice of available settings depends on the Cilium version used. See also the cilium_version setting to fix a specific version.
@@ -1255,7 +1257,23 @@ env:
     value: "nbg1"
   EOT */
 
+  # Hetzner CSI, all Hetzner CSI helm values can be found at https://github.com/hetznercloud/csi-driver/tree/main/charts/hcloud-csi
+  # If you want to merge extra values into defaults (or hetzner_csi_values), use hetzner_csi_merge_values.
+  /*   hetzner_csi_values = <<-EOT
+controller:
+  replicas: 2
+EOT */
+
+  /*   hetzner_csi_merge_values = <<-EOT
+node:
+  tolerations:
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"
+EOT */
+
   # csi-driver-smb, all csi-driver-smb helm values can be found at https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/latest/csi-driver-smb/values.yaml
+  # If you want to merge extra values into defaults (or csi_driver_smb_values), use csi_driver_smb_merge_values.
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   csi_driver_smb_values = <<-EOT
 controller:
@@ -1283,6 +1301,11 @@ controller:
         cpu: 10m
         memory: 20Mi
   EOT */
+
+  /*   csi_driver_smb_merge_values = <<-EOT
+controller:
+  replicas: 2
+EOT */
 
   # Longhorn, all Longhorn helm values can be found at https://github.com/longhorn/longhorn/blob/master/chart/values.yaml
   # If you want to merge extra values into defaults (or longhorn_values), use longhorn_merge_values.

--- a/locals.tf
+++ b/locals.tf
@@ -1038,10 +1038,12 @@ persistence:
 
   longhorn_values = module.values_merger_longhorn.values
 
-  csi_driver_smb_values = var.csi_driver_smb_values != "" ? var.csi_driver_smb_values : <<EOT
-  EOT
+  csi_driver_smb_values_default = <<EOT
+EOT
 
-  hetzner_csi_values = var.hetzner_csi_values != "" ? var.hetzner_csi_values : <<-EOT
+  csi_driver_smb_values = module.values_merger_csi_driver_smb.values
+
+  hetzner_csi_values_default = <<-EOT
 node:
   affinity:
     nodeAffinity:
@@ -1057,6 +1059,8 @@ node:
                 values:
                   - robot
 EOT
+
+  hetzner_csi_values = module.values_merger_hetzner_csi.values
 
   nginx_values_default = <<EOT
 controller:

--- a/values-merger.tf
+++ b/values-merger.tf
@@ -26,6 +26,13 @@ module "values_merger_hetzner_ccm" {
   merge_values    = var.hetzner_ccm_merge_values
 }
 
+module "values_merger_hetzner_csi" {
+  source          = "./modules/values_merger"
+  default_values  = local.hetzner_csi_values_default
+  override_values = var.hetzner_csi_values
+  merge_values    = var.hetzner_csi_merge_values
+}
+
 module "values_merger_haproxy" {
   source          = "./modules/values_merger"
   default_values  = local.haproxy_values_default
@@ -52,4 +59,11 @@ module "values_merger_cert_manager" {
   default_values  = local.cert_manager_values_default
   override_values = var.cert_manager_values
   merge_values    = var.cert_manager_merge_values
+}
+
+module "values_merger_csi_driver_smb" {
+  source          = "./modules/values_merger"
+  default_values  = local.csi_driver_smb_values_default
+  override_values = var.csi_driver_smb_values
+  merge_values    = var.csi_driver_smb_merge_values
 }

--- a/variables.tf
+++ b/variables.tf
@@ -674,6 +674,17 @@ variable "hetzner_csi_values" {
   description = "Additional helm values file to pass to hetzner csi as 'valuesContent' at the HelmChart."
 }
 
+variable "hetzner_csi_merge_values" {
+  type        = string
+  default     = ""
+  description = "Additional Helm values to merge with defaults (or hetzner_csi_values if set). User values take precedence. Requires valid YAML format."
+
+  validation {
+    condition     = var.hetzner_csi_merge_values == "" || can(yamldecode(var.hetzner_csi_merge_values))
+    error_message = "hetzner_csi_merge_values must be valid YAML format or empty string."
+  }
+}
+
 
 variable "restrict_outbound_traffic" {
   type        = bool
@@ -1281,6 +1292,17 @@ variable "csi_driver_smb_values" {
   type        = string
   default     = ""
   description = "Additional helm values file to pass to csi-driver-smb as 'valuesContent' at the HelmChart."
+}
+
+variable "csi_driver_smb_merge_values" {
+  type        = string
+  default     = ""
+  description = "Additional Helm values to merge with defaults (or csi_driver_smb_values if set). User values take precedence. Requires valid YAML format."
+
+  validation {
+    condition     = var.csi_driver_smb_merge_values == "" || can(yamldecode(var.csi_driver_smb_merge_values))
+    error_message = "csi_driver_smb_merge_values must be valid YAML format or empty string."
+  }
 }
 
 variable "enable_cert_manager" {


### PR DESCRIPTION
## Summary
- Implements backlog task T27 from discussion #1418.
- Branch: `codex/idea-1418-migrate-all-remaining-helm-based-manifest`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)