### PR TITLE
idea #801: create distribution aware k8s kubelet config

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -28,7 +28,7 @@ module "agents" {
   k3s_registries_update_script     = local.k3s_registries_update_script
   cloudinit_write_files_common     = local.cloudinit_write_files_common
   k3s_kubelet_config               = var.k3s_kubelet_config
-  k3s_kubelet_config_update_script = local.k3s_kubelet_config_update_script
+  k3s_kubelet_config_update_script = local.k8s_kubelet_config_update_script
   k3s_audit_policy_config          = ""
   k3s_audit_policy_update_script   = ""
   cloudinit_runcmd_common          = local.cloudinit_runcmd_common

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -306,7 +306,7 @@ resource "terraform_data" "autoscaled_nodes_kubelet_config" {
   }
 
   provisioner "remote-exec" {
-    inline = [local.k3s_kubelet_config_update_script]
+    inline = [local.k8s_kubelet_config_update_script]
   }
 }
 moved {

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -27,7 +27,7 @@ module "control_planes" {
   k3s_registries                   = var.k3s_registries
   k3s_registries_update_script     = local.k3s_registries_update_script
   k3s_kubelet_config               = var.k3s_kubelet_config
-  k3s_kubelet_config_update_script = local.k3s_kubelet_config_update_script
+  k3s_kubelet_config_update_script = local.k8s_kubelet_config_update_script
   k3s_audit_policy_config          = var.k3s_audit_policy_config
   k3s_audit_policy_update_script   = local.k3s_audit_policy_update_script
   cloudinit_write_files_common     = local.cloudinit_write_files_common

--- a/locals.tf
+++ b/locals.tf
@@ -1413,6 +1413,51 @@ else
 fi
 EOF
 
+rke2_kubelet_config_update_script = <<EOF
+set -e
+DATE=`date +%Y-%m-%d_%H-%M-%S`
+BACKUP_FILE="/tmp/kubelet-config_$DATE.yaml"
+HAS_BACKUP=false
+
+if cmp -s /tmp/kubelet-config.yaml /etc/rancher/rke2/kubelet-config.yaml; then
+  echo "No update required to the kubelet-config.yaml file"
+else
+  if [ -f "/etc/rancher/rke2/kubelet-config.yaml" ]; then
+    echo "Backing up /etc/rancher/rke2/kubelet-config.yaml to $BACKUP_FILE"
+    cp /etc/rancher/rke2/kubelet-config.yaml "$BACKUP_FILE"
+    HAS_BACKUP=true
+  fi
+  echo "Updated kubelet-config.yaml detected, restart of rke2 service required"
+  cp /tmp/kubelet-config.yaml /etc/rancher/rke2/kubelet-config.yaml
+
+  restart_failed() {
+    local SERVICE_NAME="$1"
+    echo "Error: Failed to restart $SERVICE_NAME"
+    if [ "$HAS_BACKUP" = true ]; then
+      echo "Restoring from backup $BACKUP_FILE"
+      cp "$BACKUP_FILE" /etc/rancher/rke2/kubelet-config.yaml
+      echo "Attempting to restart $SERVICE_NAME with restored config..."
+      systemctl restart "$SERVICE_NAME" || echo "Warning: Restart after restore also failed"
+    else
+      echo "No backup available to restore (first-time config)"
+      rm -f /etc/rancher/rke2/kubelet-config.yaml
+      echo "Attempting to restart $SERVICE_NAME without kubelet config..."
+      systemctl restart "$SERVICE_NAME" || echo "Warning: Restart without config also failed"
+    fi
+    exit 1
+  }
+
+  if systemctl is-active --quiet rke2-server; then
+    systemctl restart rke2-server || restart_failed rke2-server
+  elif systemctl is-active --quiet rke2-agent; then
+    systemctl restart rke2-agent || restart_failed rke2-agent
+  else
+    echo "Warning: No active rke2-server or rke2-agent service found, skipping restart"
+  fi
+  echo "rke2-server service or rke2-agent service (re)started successfully"
+fi
+EOF
+
 k3s_config_update_script = <<EOF
 DATE=`date +%Y-%m-%d_%H-%M-%S`
 if cmp -s /tmp/config.yaml /etc/rancher/k3s/config.yaml; then
@@ -1569,6 +1614,7 @@ fi
 EOF
 
 k8s_registries_update_script            = local.kubernetes_distribution == "k3s" ? local.k3s_registries_update_script : local.rke2_registries_update_script
+k8s_kubelet_config_update_script        = local.kubernetes_distribution == "k3s" ? local.k3s_kubelet_config_update_script : local.rke2_kubelet_config_update_script
 k8s_config_update_script                = local.kubernetes_distribution == "k3s" ? local.k3s_config_update_script : local.rke2_config_update_script
 k8s_authentication_config_update_script = local.kubernetes_distribution == "k3s" ? local.k3s_authentication_config_update_script : local.rke2_authentication_config_update_script
 


### PR DESCRIPTION
## Summary
- Implements backlog task T31 from discussion #801.
- Branch: `codex/idea-801-create-distribution-aware-k8s-kubelet-config`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)