### PR TITLE
idea #1446: introduce cluster ipv6 cidr service ipv6

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -143,9 +143,9 @@ locals {
       # TODO: Fix this, currently it needs to be false
       # selinux                     = var.disable_selinux ? false : (v.selinux == true ? true : false)
       selinux               = false
-      cluster-cidr          = var.cluster_ipv4_cidr
-      service-cidr          = var.service_ipv4_cidr
-      cluster-dns           = local.cluster_dns_ipv4
+      cluster-cidr          = local.cluster_cidr
+      service-cidr          = local.service_cidr
+      cluster-dns           = local.cluster_dns
       write-kubeconfig-mode = "0644" # needed for import into rancher
       cni                   = "none"
     },
@@ -197,9 +197,9 @@ locals {
       node-label                  = v.labels
       node-taint                  = v.taints
       selinux                     = var.disable_selinux ? false : (v.selinux == true ? true : false)
-      cluster-cidr                = var.cluster_ipv4_cidr
-      service-cidr                = var.service_ipv4_cidr
-      cluster-dns                 = local.cluster_dns_ipv4
+      cluster-cidr                = local.cluster_cidr
+      service-cidr                = local.service_cidr
+      cluster-dns                 = local.cluster_dns
       write-kubeconfig-mode       = "0644" # needed for import into rancher
     },
     lookup(local.cni_k3s_settings, var.cni_plugin, {}),

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -95,6 +95,11 @@ module "kube-hetzner" {
   # The service CIDR must be a part of the network CIDR!
   # service_ipv4_cidr = "10.43.0.0/16"
 
+  # Optional IPv6 CIDRs for Pod/Service networking.
+  # Set both to enable dual-stack. If cluster_ipv4_cidr/service_ipv4_cidr are set to empty strings, this enables IPv6-only service/pod CIDRs.
+  # cluster_ipv6_cidr = "2001:cafe:42::/56"
+  # service_ipv6_cidr = "2001:cafe:43::/112"
+
   # If you must change the service IPv4 address of core-dns you can do so below, but it is highly advised against.
   # Never change this value after you already initialized a cluster. Complete cluster redeploy needed!
   # The service IPv4 address must be part of the service CIDR!

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,18 @@ variable "service_ipv4_cidr" {
   default     = "10.43.0.0/16"
 }
 
+variable "cluster_ipv6_cidr" {
+  description = "Internal Pod IPv6 CIDR. Set together with service_ipv6_cidr to enable dual-stack or IPv6-only cluster networking."
+  type        = string
+  default     = null
+}
+
+variable "service_ipv6_cidr" {
+  description = "Internal Service IPv6 CIDR. Set together with cluster_ipv6_cidr to enable dual-stack or IPv6-only cluster networking."
+  type        = string
+  default     = null
+}
+
 variable "cluster_dns_ipv4" {
   description = "Internal Service IPv4 address of core-dns."
   type        = string


### PR DESCRIPTION
## Summary
- Implements backlog task T32 from discussion #1446.
- Branch: `codex/idea-1446-introduce-cluster-ipv6-cidr-service-ipv6`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)