### PR TITLE
idea #1359: add clear troubleshooting note fix selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,8 @@ See `/examples/external-overlay-tailscale/README.md` for a concrete outer-module
 
 Create targeted SELinux profiles instead of weakening cluster-wide security:
 
+> **Troubleshooting note:** When using large attached volumes (for example large Longhorn disks), first boot can hit cloud-init/systemd timeouts while SELinux relabeling completes. If you hit this repeatedly, a practical workaround is to disable SELinux only on the affected nodepool(s) instead of disabling it cluster-wide.
+
 ```sh
 # Find container
 crictl ps


### PR DESCRIPTION
## Summary
- Implements backlog task T33 from discussion #1359.
- Branch: `codex/idea-1359-add-clear-troubleshooting-note-fix-selinux`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)