### PR TITLE
idea #1383: init tf add explicit kubectl delete

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -662,6 +662,11 @@ resource "terraform_data" "kustomization" {
         "echo 'Uninstall helm ccm manifests if they exist'",
         "kubectl delete --ignore-not-found -n kube-system helmchart.helm.cattle.io/hcloud-cloud-controller-manager",
       ],
+      compact([
+        var.ingress_controller == "traefik" ? "" : "kubectl delete helmchart -n kube-system traefik --ignore-not-found",
+        var.ingress_controller == "nginx" ? "" : "kubectl delete helmchart -n kube-system nginx --ignore-not-found",
+        var.ingress_controller == "haproxy" ? "" : "kubectl delete helmchart -n kube-system haproxy --ignore-not-found",
+      ]),
       [
         # Ready, set, go for the kustomization
         "kubectl apply -k /var/post_install",
@@ -958,6 +963,11 @@ resource "null_resource" "rke2_kustomization" {
         "echo 'Uninstall helm ccm manifests if they exist'",
         "${local.kubectl_cli} delete --ignore-not-found -n kube-system helmchart.helm.cattle.io/hcloud-cloud-controller-manager",
       ],
+      compact([
+        var.ingress_controller == "traefik" ? "" : "${local.kubectl_cli} delete helmchart -n kube-system traefik --ignore-not-found",
+        var.ingress_controller == "nginx" ? "" : "${local.kubectl_cli} delete helmchart -n kube-system nginx --ignore-not-found",
+        var.ingress_controller == "haproxy" ? "" : "${local.kubectl_cli} delete helmchart -n kube-system haproxy --ignore-not-found",
+      ]),
       [
         # Ready, set, go for the kustomization
         "echo 'Deploying the kustomization.yaml...'",


### PR DESCRIPTION
## Summary
- Implements backlog task T34 from discussion #1383.
- Branch: `codex/idea-1383-init-tf-add-explicit-kubectl-delete`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)