### PR TITLE
idea #1357: standardize explicitly export full module control

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -82,6 +82,16 @@ output "agent_nodes" {
   value       = [for node in module.agents : node]
 }
 
+output "control_planes" {
+  description = "Full control plane module map keyed by node identifier."
+  value       = module.control_planes
+}
+
+output "agents" {
+  description = "Full agent module map keyed by node identifier."
+  value       = module.agents
+}
+
 output "domain_assignments" {
   description = "Assignments of domains to IPs based on reverse DNS"
   value = concat(


### PR DESCRIPTION
## Summary
- Implements backlog task T36 from discussion #1357.
- Branch: `codex/idea-1357-standardize-explicitly-export-full-module-control`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)