### PR TITLE
idea #1038: extend control plane nodepools variable schema

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -469,9 +469,9 @@ EOT
     )
   }
 
-  control_plane_nodes = merge([
+  control_plane_nodes_from_integer_counts = merge([
     for pool_index, nodepool_obj in var.control_plane_nodepools : {
-      for node_index in range(nodepool_obj.count) :
+      for node_index in range(coalesce(nodepool_obj.count, 0)) :
       format("%s-%s-%s", pool_index, node_index, nodepool_obj.name) => {
         nodepool_name : nodepool_obj.name,
         server_type : nodepool_obj.server_type,
@@ -495,6 +495,47 @@ EOT
       }
     }
   ]...)
+
+  control_plane_nodes_from_maps_for_counts = merge([
+    for pool_index, nodepool_obj in var.control_plane_nodepools : {
+      for node_key, node_obj in coalesce(nodepool_obj.nodes, {}) :
+      format("%s-%s-%s", pool_index, node_key, nodepool_obj.name) => merge(
+        {
+          nodepool_name : nodepool_obj.name,
+          server_type : nodepool_obj.server_type,
+          location : nodepool_obj.location,
+          labels : concat(local.default_control_plane_labels, nodepool_obj.swap_size != "" || nodepool_obj.zram_size != "" ? local.swap_node_label : [], nodepool_obj.labels),
+          taints : compact(concat(local.default_control_plane_taints, nodepool_obj.taints)),
+          kubelet_args : nodepool_obj.kubelet_args,
+          backups : nodepool_obj.backups,
+          swap_size : nodepool_obj.swap_size,
+          zram_size : nodepool_obj.zram_size,
+          selinux : nodepool_obj.selinux,
+          os : coalesce(nodepool_obj.os, local.control_plane_nodepool_default_os[nodepool_obj.name]),
+          placement_group_compat_idx : nodepool_obj.placement_group_compat_idx,
+          placement_group : nodepool_obj.placement_group,
+          index : floor(tonumber(node_key)),
+          disable_ipv4 : nodepool_obj.disable_ipv4 || local.use_nat_router,
+          disable_ipv6 : nodepool_obj.disable_ipv6 || local.use_nat_router,
+          network_id : nodepool_obj.network_id,
+          extra_write_files : nodepool_obj.extra_write_files,
+          extra_runcmd : nodepool_obj.extra_runcmd,
+        },
+        { for key, value in node_obj : key => value if value != null },
+        {
+          labels : concat(local.default_control_plane_labels, nodepool_obj.swap_size != "" || nodepool_obj.zram_size != "" ? local.swap_node_label : [], nodepool_obj.labels, coalesce(node_obj.labels, [])),
+          taints : compact(concat(local.default_control_plane_taints, nodepool_obj.taints, coalesce(node_obj.taints, []))),
+          extra_write_files : concat(nodepool_obj.extra_write_files, coalesce(node_obj.extra_write_files, [])),
+          extra_runcmd : concat(nodepool_obj.extra_runcmd, coalesce(node_obj.extra_runcmd, [])),
+        }
+      )
+    }
+  ]...)
+
+  control_plane_nodes = merge(
+    local.control_plane_nodes_from_integer_counts,
+    local.control_plane_nodes_from_maps_for_counts,
+  )
 
   agent_nodes_from_integer_counts = merge([
     for pool_index, nodepool_obj in var.agent_nodepools : {
@@ -654,7 +695,7 @@ EOT
   network_gw_ipv4 = cidrhost(var.network_ipv4_cidr, 1)
 
   # if we are in a single cluster config, we use the default klipper lb instead of Hetzner LB
-  control_plane_count    = sum([for v in var.control_plane_nodepools : v.count])
+  control_plane_count    = length(var.control_plane_nodepools) > 0 ? sum([for v in var.control_plane_nodepools : length(coalesce(v.nodes, {})) + coalesce(v.count, 0)]) : 0
   agent_count            = length(var.agent_nodepools) > 0 ? sum([for v in var.agent_nodepools : length(coalesce(v.nodes, {})) + coalesce(v.count, 0)]) : 0
   autoscaler_max_count   = length(var.autoscaler_nodepools) > 0 ? sum([for v in var.autoscaler_nodepools : v.max_nodes]) : 0
   is_single_node_cluster = (local.control_plane_count + local.agent_count + local.autoscaler_max_count) == 1

--- a/variables.tf
+++ b/variables.tf
@@ -325,7 +325,7 @@ variable "control_plane_nodepools" {
     backups                    = optional(bool)
     labels                     = list(string)
     taints                     = list(string)
-    count                      = number
+    count                      = optional(number, null)
     swap_size                  = optional(string, "")
     zram_size                  = optional(string, "")
     kubelet_args               = optional(list(string), ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"])
@@ -338,6 +338,25 @@ variable "control_plane_nodepools" {
     network_id                 = optional(number, 0)
     extra_write_files          = optional(list(any), [])
     extra_runcmd               = optional(list(any), [])
+    nodes = optional(map(object({
+      server_type                = optional(string)
+      location                   = optional(string)
+      backups                    = optional(bool)
+      labels                     = optional(list(string))
+      taints                     = optional(list(string))
+      swap_size                  = optional(string, "")
+      zram_size                  = optional(string, "")
+      kubelet_args               = optional(list(string), ["kube-reserved=cpu=250m,memory=1500Mi,ephemeral-storage=1Gi", "system-reserved=cpu=250m,memory=300Mi"])
+      selinux                    = optional(bool, true)
+      placement_group_compat_idx = optional(number, 0)
+      placement_group            = optional(string, null)
+      os                         = optional(string)
+      disable_ipv4               = optional(bool, false)
+      disable_ipv6               = optional(bool, false)
+      network_id                 = optional(number, 0)
+      extra_write_files          = optional(list(any), [])
+      extra_runcmd               = optional(list(any), [])
+    })))
   }))
   default = []
   validation {
@@ -360,11 +379,35 @@ variable "control_plane_nodepools" {
   }
 
   validation {
+    condition = alltrue([
+      for control_plane_nodepool in var.control_plane_nodepools :
+      alltrue([
+        for _, control_plane_node in coalesce(control_plane_nodepool.nodes, {}) :
+        control_plane_node.os == null || control_plane_node.os == "microos" || control_plane_node.os == "leapmicro"
+      ])
+    ])
+    error_message = "The node os must be either 'microos' or 'leapmicro'."
+  }
+
+  validation {
+    condition     = alltrue([for control_plane_nodepool in var.control_plane_nodepools : (control_plane_nodepool.count == null) != (control_plane_nodepool.nodes == null)])
+    error_message = "Set either nodes or count per control_plane_nodepool, not both."
+  }
+
+  validation {
+    condition = alltrue([for control_plane_nodepool in var.control_plane_nodepools :
+      alltrue([for control_plane_key, _ in coalesce(control_plane_nodepool.nodes, {}) : can(tonumber(control_plane_key)) && tonumber(control_plane_key) == floor(tonumber(control_plane_key)) && 0 <= tonumber(control_plane_key) && tonumber(control_plane_key) < 154])
+    ])
+    # 154 because the private ip is derived from tonumber(key) + 101. See private_ipv4 in control_planes.tf
+    error_message = "The key for each individual control plane node in a nodepool must be a stable integer in the range [0, 153] cast as a string."
+  }
+
+  validation {
     condition     = length(var.control_plane_nodepools) > 0
     error_message = "At least one control plane nodepool is required. Kubernetes cannot run without control plane nodes."
   }
   validation {
-    condition     = length(var.control_plane_nodepools) == 0 || sum([for v in var.control_plane_nodepools : v.count]) >= 1
+    condition     = length(var.control_plane_nodepools) == 0 || sum([for v in var.control_plane_nodepools : length(coalesce(v.nodes, {})) + coalesce(v.count, 0)]) >= 1
     error_message = "At least one control plane node is required (total count across all control_plane_nodepools must be >= 1)."
   }
 }


### PR DESCRIPTION
## Summary
- Implements backlog task T39 from discussion #1038.
- Branch: `codex/idea-1038-extend-control-plane-nodepools-variable-schema`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)