### PR TITLE
idea #1447: add kubeapi port variable variables tf

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -104,8 +104,8 @@ resource "hcloud_load_balancer_service" "control_plane" {
 
   load_balancer_id = hcloud_load_balancer.control_plane.*.id[0]
   protocol         = "tcp"
-  destination_port = "6443"
-  listen_port      = "6443"
+  destination_port = var.kubeapi_port
+  listen_port      = var.kubeapi_port
 }
 
 locals {
@@ -133,6 +133,7 @@ locals {
       disable-cloud-controller    = true
       disable-kube-proxy          = var.disable_kube_proxy
       disable                     = local.disable_rke2_extras
+      https-listen-port           = var.kubeapi_port
       kubelet-arg                 = concat(local.kubelet_arg, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args, v.kubelet_args)
       kube-apiserver-arg          = local.kube_apiserver_arg
       kube-controller-manager-arg = local.kube_controller_manager_arg
@@ -181,12 +182,13 @@ locals {
             module.control_planes[keys(module.control_planes)[1]].private_ipv4_address :
             module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           )
-        }:6443"
+        }:${var.kubeapi_port}"
       )
       token                    = local.k3s_token
       disable-cloud-controller = true
       disable-kube-proxy       = var.disable_kube_proxy
       disable                  = local.disable_extras
+      https-listen-port        = var.kubeapi_port
       # Kubelet arg precedence (last wins): local.kubelet_arg > v.kubelet_args > k3s_global_kubelet_args > k3s_control_plane_kubelet_args
       kubelet-arg                 = concat(local.kubelet_arg, v.kubelet_args, var.k3s_global_kubelet_args, var.k3s_control_plane_kubelet_args)
       kube-apiserver-arg          = local.kube_apiserver_arg

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -620,7 +620,10 @@ module "kube-hetzner" {
   # Please note that because the klipperLB points to all nodes, we automatically allow scheduling on the control plane when it is active.
   # enable_klipper_metal_lb = true
 
+  # Configure the Kubernetes API port (default 6443).
+  # kubeapi_port = 6443
   # When using an external load balancer, you can specify a stable control plane endpoint URL.
+  # Make sure the endpoint port matches kubeapi_port when you override it.
   # control_plane_endpoint = "https://my-external-lb:6443"
 
   # Optional map of node name => SSH host override.

--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,7 @@ locals {
   kubernetes_distribution = var.kubernetes_distribution_type
 
   # k3s endpoint used for agent registration, respects control_plane_endpoint override
-  k3s_endpoint = coalesce(var.control_plane_endpoint, "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443")
+  k3s_endpoint = coalesce(var.control_plane_endpoint, "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:${var.kubeapi_port}")
 
   ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
   csi_version    = length(data.github_release.hetzner_csi) == 0 ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
@@ -733,7 +733,7 @@ EOT
         description = "Allow Incoming Requests to Kube API Server"
         direction   = "in"
         protocol    = "tcp"
-        port        = "6443"
+        port        = tostring(var.kubeapi_port)
         source_ips  = var.firewall_kube_api_source
       }
     ],
@@ -936,7 +936,7 @@ kubeProxyReplacementHealthzBindAddr: "0.0.0.0:10256"
 
 # Access to Kube API Server (mandatory if kube-proxy is disabled)
 k8sServiceHost: "127.0.0.1"
-k8sServicePort: "${local.kubernetes_distribution == "rke2" ? "6443" : "6444"}"
+k8sServicePort: "${local.kubernetes_distribution == "rke2" ? tostring(var.kubeapi_port) : "6444"}"
 
 # Set Tunnel Mode or Native Routing Mode (supported by Hetzner CCM Route Controller)
 routingMode: "${var.cilium_routing_mode}"

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -68,6 +68,7 @@ data "cloudinit_config" "nat_router_config" {
         ssh_max_auth_tries         = var.ssh_max_auth_tries
         enable_cp_lb_port_forward  = var.use_control_plane_lb && !var.control_plane_lb_enable_public_interface
         cp_lb_private_ip           = try(hcloud_load_balancer_network.control_plane[0].ip, "")
+        kubeapi_port               = var.kubeapi_port
       }
     )
   }

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -17,8 +17,8 @@ write_files:
           post-up echo 1 > /proc/sys/net/ipv4/ip_forward
           post-up iptables -t nat -A POSTROUTING -s '${ private_network_ipv4_range }' ! -d '${ private_network_ipv4_range }' -o eth0 -j MASQUERADE
 %{ if enable_cp_lb_port_forward ~}
-          post-up iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 6443 -j DNAT --to-destination ${ cp_lb_private_ip }:6443
-          post-up iptables -t nat -A POSTROUTING -d ${ cp_lb_private_ip } -p tcp --dport 6443 -j MASQUERADE
+          post-up iptables -t nat -A PREROUTING -i eth0 -p tcp --dport ${ kubeapi_port } -j DNAT --to-destination ${ cp_lb_private_ip }:${ kubeapi_port }
+          post-up iptables -t nat -A POSTROUTING -d ${ cp_lb_private_ip } -p tcp --dport ${ kubeapi_port } -j MASQUERADE
 %{ endif ~}
     append: true
 

--- a/variables.tf
+++ b/variables.tf
@@ -190,9 +190,20 @@ variable "cluster_dns_ipv4" {
   default     = null
 }
 
+variable "kubeapi_port" {
+  description = "Kubernetes API server port used for control-plane listeners, load balancer listeners, firewall rules, and default join endpoints."
+  type        = number
+  default     = 6443
+
+  validation {
+    condition     = var.kubeapi_port >= 1 && var.kubeapi_port <= 65535
+    error_message = "kubeapi_port must be between 1 and 65535."
+  }
+}
+
 
 variable "nat_router" {
-  description = "Do you want to pipe all egress through a single nat router which is to be constructed? Note: Requires use_control_plane_lb=true when enabled. Automatically forwards port 6443 to the control plane LB when control_plane_lb_enable_public_interface=false."
+  description = "Do you want to pipe all egress through a single nat router which is to be constructed? Note: Requires use_control_plane_lb=true when enabled. Automatically forwards kubeapi_port to the control plane LB when control_plane_lb_enable_public_interface=false."
   nullable    = true
   default     = null
   type = object({
@@ -1431,7 +1442,7 @@ variable "block_icmp_ping_in" {
 variable "use_control_plane_lb" {
   type        = bool
   default     = false
-  description = "Creates a dedicated load balancer for the Kubernetes API (port 6443). When enabled, kubectl and other API clients connect through this LB instead of directly to the first control plane node. Recommended for production clusters with multiple control plane nodes for high availability. Note: This is separate from the ingress load balancer for HTTP/HTTPS traffic."
+  description = "Creates a dedicated load balancer for the Kubernetes API (kubeapi_port). When enabled, kubectl and other API clients connect through this LB instead of directly to the first control plane node. Recommended for production clusters with multiple control plane nodes for high availability. Note: This is separate from the ingress load balancer for HTTP/HTTPS traffic."
 }
 
 variable "control_plane_lb_type" {
@@ -1443,7 +1454,7 @@ variable "control_plane_lb_type" {
 variable "control_plane_lb_enable_public_interface" {
   type        = bool
   default     = true
-  description = "Enable or disable public interface for the control plane load balancer. Defaults to true. When disabled with nat_router enabled, the NAT router automatically forwards port 6443 to the private control plane LB."
+  description = "Enable or disable public interface for the control plane load balancer. Defaults to true. When disabled with nat_router enabled, the NAT router automatically forwards kubeapi_port to the private control plane LB."
 }
 
 variable "dns_servers" {
@@ -1730,11 +1741,11 @@ variable "hetzner_ccm_merge_values" {
 
 variable "control_plane_endpoint" {
   type        = string
-  description = "Optional external control plane endpoint URL (e.g. https://myapi.domain.com:6443). Used as the k3s 'server' value for agents and secondary control planes."
+  description = "Optional external control plane endpoint URL (e.g. https://myapi.domain.com:6443). Used as the k3s 'server' value for agents and secondary control planes. If kubeapi_port is overridden, use the same port in this URL."
   default     = null
   validation {
     condition     = var.control_plane_endpoint == null || can(regex("^https?://(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|\\[[0-9a-fA-F:]+\\])(?::[0-9]{1,5})?(?:/.*)?$", var.control_plane_endpoint))
-    error_message = "The control_plane_endpoint must be null or a valid URL (e.g., https://my-api.example.com:6443)."
+    error_message = "The control_plane_endpoint must be null or a valid URL (e.g., https://my-api.example.com:6443, or your configured kubeapi_port)."
   }
 }
 


### PR DESCRIPTION
## Summary
- Implements backlog task T42 from discussion #1447.
- Branch: `codex/idea-1447-add-kubeapi-port-variable-variables-tf`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)