### PR TITLE
idea #1728: update default value firewall ssh source

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ terraform output -json kubeconfig | jq
 ssh root@<control-plane-ip> -i /path/to/private_key -o StrictHostKeyChecking=no
 ```
 
-Restrict SSH access by configuring `firewall_ssh_source` in your kube.tf. See [SSH docs](docs/ssh.md#firewall-ssh-source-and-changing-ips) for dynamic IP handling.
+Restrict SSH access by configuring `firewall_ssh_source` in your kube.tf (default is `["myipv4"]`). For CI/CD runners, override it with your runner CIDRs. See [SSH docs](docs/ssh.md#firewall-ssh-source-and-changing-ips) for dynamic IP handling.
 
 ### Connect via Kube API
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -931,10 +931,11 @@ module "kube-hetzner" {
   # You can use "myipv4" as a placeholder and it will resolve to your current public IPv4/32 during apply.
   # firewall_kube_api_source = null
 
-  # Allow SSH access from the specified networks. Default: ["0.0.0.0/0", "::/0"]
+  # Allow SSH access from the specified networks. Default: ["myipv4"]
   # Allowed values: null (disable SSH rule entirely) or a list of allowed networks with CIDR notation.
   # Ideally you would set your IP there. And if it changes after cluster deploy, you can always update this variable and apply again.
   # You can use "myipv4" as a placeholder and it will resolve to your current public IPv4/32 during apply.
+  # For CI/CD runners or dynamic office IP ranges, override this explicitly with the required CIDRs.
   # firewall_ssh_source = ["myipv4", "1.2.3.4/32"]
 
   # By default, SELinux is enabled in enforcing mode on all nodes. For container-specific SELinux issues,

--- a/variables.tf
+++ b/variables.tf
@@ -1036,7 +1036,7 @@ variable "firewall_kube_api_source" {
 
 variable "firewall_ssh_source" {
   type        = list(string)
-  default     = ["0.0.0.0/0", "::/0"]
+  default     = ["myipv4"]
   description = "Source networks that have SSH access to the servers."
 }
 


### PR DESCRIPTION
## Summary
- Implements backlog task T51 from discussion #1728.
- Branch: `codex/idea-1728-update-default-value-firewall-ssh-source`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)