### PR TITLE
idea #1554: configure helm and kubernetes providers using dynamically fetched kubeconfig

### DIFF
--- a/ccm-helm-release.tf
+++ b/ccm-helm-release.tf
@@ -1,0 +1,21 @@
+resource "helm_release" "hcloud_ccm" {
+  count = var.hetzner_ccm_use_helm ? 1 : 0
+
+  name             = "hcloud-cloud-controller-manager"
+  repository       = "https://charts.hetzner.cloud"
+  chart            = "hcloud-cloud-controller-manager"
+  namespace        = "kube-system"
+  create_namespace = false
+  version          = local.ccm_version
+  values           = [local.hetzner_ccm_values]
+
+  wait            = true
+  timeout         = 600
+  cleanup_on_fail = true
+
+  depends_on = [
+    terraform_data.kube_system_secrets,
+    terraform_data.control_planes,
+    null_resource.control_planes_rke2
+  ]
+}

--- a/init.tf
+++ b/init.tf
@@ -689,6 +689,7 @@ resource "terraform_data" "kustomization" {
   depends_on = [
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets
@@ -984,6 +985,7 @@ resource "null_resource" "rke2_kustomization" {
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
     null_resource.control_planes_rke2,
+    helm_release.hcloud_ccm,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume,
     terraform_data.kube_system_secrets

--- a/locals.tf
+++ b/locals.tf
@@ -248,7 +248,7 @@ locals {
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
       ],
-      var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
+      var.hetzner_ccm_use_helm ? [] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       local.kubernetes_distribution == "k3s" ? lookup(local.cni_install_resources, var.cni_plugin, []) : [],

--- a/providers-k8s.tf
+++ b/providers-k8s.tf
@@ -1,0 +1,15 @@
+provider "kubernetes" {
+  host                   = local.kubeconfig_data.host
+  cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+  client_certificate     = local.kubeconfig_data.client_certificate
+  client_key             = local.kubeconfig_data.client_key
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = local.kubeconfig_data.host
+    cluster_ca_certificate = local.kubeconfig_data.cluster_ca_certificate
+    client_certificate     = local.kubeconfig_data.client_certificate
+    client_key             = local.kubeconfig_data.client_key
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "integrations/github"
       version = ">= 6.4.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.14.0"
+    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = ">= 1.59.0"
@@ -12,6 +16,10 @@ terraform {
     http = {
       source  = "hashicorp/http"
       version = ">= 3.4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.31.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Summary
- Implements backlog task T07 from discussion #1554.
- Branch: `codex/idea-1554-configure-helm-kubernetes-providers-using-dynamically`.

## Validation
- terraform fmt -recursive (repo)
- terraform validate (repo)
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; fails in this environment with expected HCLOUD token error: `entered token is invalid (must be exactly 64 characters long)`)