### PR TITLE
idea #1311: verify robot credentials support is already implemented

### DIFF
--- a/docs/ideas_v3_verification/T03-1311.md
+++ b/docs/ideas_v3_verification/T03-1311.md
@@ -1,0 +1,11 @@
+# T03 / Discussion #1311 Verification
+
+Status: already implemented in `origin/staging`.
+
+## Evidence
+- `variables.tf` defines `robot_user` and `robot_password`.
+- `locals.tf` includes both values in `kube_system_secrets` when Robot CCM is enabled.
+- `templates/kube_system_secrets.yaml.tpl` renders `kube_system_secrets` entries into Kubernetes secrets.
+
+## Notes
+No additional code changes were required for this discussion objective.


### PR DESCRIPTION
## Summary
- Adds verification evidence for discussion #1311.
- Confirms robot_user and robot_password are already implemented in origin/staging.

## Evidence
- docs/ideas_v3_verification/T03-1311.md

## Validation
- terraform fmt -recursive
- terraform validate
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; expected local error: entered token is invalid (must be exactly 64 characters long))