### PR TITLE
idea #911: verify cilium routing mode support is already implemented

### DIFF
--- a/docs/ideas_v3_verification/T28-911.md
+++ b/docs/ideas_v3_verification/T28-911.md
@@ -1,0 +1,11 @@
+# T28 / Discussion #911 Verification
+
+Status: already implemented in `origin/staging`.
+
+## Evidence
+- `variables.tf` defines `cilium_routing_mode` with validation (`tunnel` or `native`).
+- `variables.tf` defines `cilium_ipv4_native_routing_cidr`.
+- `locals.tf` contains Cilium routing settings consumed by rendered values.
+
+## Notes
+No further code changes were required for this objective.


### PR DESCRIPTION
## Summary
- Adds verification evidence for discussion #911.
- Confirms cilium routing mode support already exists in origin/staging.

## Evidence
- docs/ideas_v3_verification/T28-911.md

## Validation
- terraform fmt -recursive
- terraform validate
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; expected local error: entered token is invalid (must be exactly 64 characters long))