### PR TITLE
idea #1258: verify system-upgrade-controller updates are already implemented

### DIFF
--- a/docs/ideas_v3_verification/T50-1258.md
+++ b/docs/ideas_v3_verification/T50-1258.md
@@ -1,0 +1,11 @@
+# T50 / Discussion #1258 Verification
+
+Status: already implemented in `origin/staging`.
+
+## Evidence
+- `locals.tf` downloads and applies System Upgrade Controller manifests via versioned URLs.
+- `locals.tf` applies patch data from `kustomize/system-upgrade-controller.yaml`.
+- `variables.tf` exposes `sys_upgrade_controller_version` and related schedule-window constraints.
+
+## Notes
+No further changes were required for this discussion objective.


### PR DESCRIPTION
## Summary
- Adds verification evidence for discussion #1258.
- Confirms system-upgrade-controller update path already exists in origin/staging.

## Evidence
- docs/ideas_v3_verification/T50-1258.md

## Validation
- terraform fmt -recursive
- terraform validate
- terraform init -upgrade (in /Users/karim/Code/kube-test)
- terraform plan (in /Users/karim/Code/kube-test; expected local error: entered token is invalid (must be exactly 64 characters long))