### PR TITLE
Fix nat_router validation when variable is null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "nat_router" {
   })
 
   validation {
-    condition     = var.nat_router == null || !var.nat_router.enable_redundancy || var.nat_router.standby_location != ""
+    condition     = var.nat_router == null || !try(var.nat_router.enable_redundancy, false) || try(var.nat_router.standby_location, "") != ""
     error_message = "When nat_router.enable_redundancy is true, standby_location must be provided."
   }
 }


### PR DESCRIPTION
When `nat_router` is set to null, the validation block attempted to access
attributes like `enable_redundancy` and `standby_location`, causing:

"Attempt to get attribute from null value"

This change makes the validation null-safe using `try()` while preserving
the original redundancy validation logic.

Closes #2152
