### PR TITLE
fix: force kvm-clock clocksource to prevent TSC instability hangs

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1366,6 +1366,14 @@ cloudinit_runcmd_common = <<EOT
 - [chmod, '750', '${dirname(var.k3s_audit_log_path)}']
 - [chown, 'root:root', '${dirname(var.k3s_audit_log_path)}']
 
+# Fix KVM clocksource: prevent node hangs caused by TSC becoming unstable
+# by forcing the kvm-clock paravirtualized clocksource from boot
+- |
+  if ! grep -q 'clocksource=kvm-clock' /etc/default/grub; then
+    sed -i 's/^\(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*\)"/\1 clocksource=kvm-clock"/' /etc/default/grub
+    transactional-update run grub2-mkconfig -o /boot/grub2/grub.cfg
+  fi
+
 # Add logic to truly disable SELinux if disable_selinux = true.
 # We'll do it by appending to cloudinit_runcmd_common.
 %{if var.disable_selinux}

--- a/locals.tf
+++ b/locals.tf
@@ -1370,7 +1370,7 @@ cloudinit_runcmd_common = <<EOT
 # by forcing the kvm-clock paravirtualized clocksource from boot
 - |
   if ! grep -q 'clocksource=kvm-clock' /etc/default/grub; then
-    sed -i 's/^\(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*\)"/\1 clocksource=kvm-clock"/' /etc/default/grub
+    sed -i 's/^\(GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 clocksource=kvm-clock"/' /etc/default/grub
     transactional-update run grub2-mkconfig -o /boot/grub2/grub.cfg
   fi
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                 
                                                                                                                                                                                                             
  - Forces `clocksource=kvm-clock` kernel boot parameter on all nodes via cloud-init `runcmd`                                                                                                                
  - Prevents node hangs caused by TSC clocksource becoming unstable at runtime (100% CPU, unresponsive)                                                                                                      
  - Applies to all node types: control planes, agents, and autoscaler-provisioned nodes                                                                                                                      
                                                                                                                                                                                                             
  ## Details

  The fix adds an idempotent block to `cloudinit_runcmd_common` in `locals.tf` that:

  1. Checks if `clocksource=kvm-clock` is already in `/etc/default/grub`
  2. If not, appends it to `GRUB_CMDLINE_LINUX_DEFAULT`
  3. Runs `transactional-update run grub2-mkconfig` to apply (needed because `/boot` is read-only on MicroOS)
  4. Takes effect on next reboot (happens naturally during provisioning)

  Both cloud-init templates (`cloudinit.yaml.tpl` and `autoscaler-cloudinit.yaml.tpl`) consume `cloudinit_runcmd_common`, so a single change covers all node types.

  ## Test plan

  - [x] `terraform fmt` passes
  - [x] `terraform validate` passes
  - [x] `terraform plan` shows only cloud-init user_data changes on existing nodes
  - [ ] New node: `grep clocksource /etc/default/grub` shows `clocksource=kvm-clock`
  - [ ] New node: `cat /sys/devices/system/clocksource/clocksource0/current_clocksource` returns `kvm-clock`