### PR TITLE
Fix zram.service After=multi-user.target deadlocks autoscaler cloud-init 

### DIFF
--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -140,7 +140,6 @@ ${cloudinit_runcmd_common}
   cat <<'  EOF' > /etc/systemd/system/zram.service
   [Unit]
   Description=Swap with zram
-  After=multi-user.target
 
   [Service]
   Type=oneshot


### PR DESCRIPTION
## Problem

When `zram_size` is set on an autoscaler nodepool, the generated cloud-init includes this sequence in `runcmd`:

```ini
[Unit]
Description=Swap with zram
After=multi-user.target        # <-- the problem

[Install]
WantedBy=multi-user.target
```

followed by:

```bash
systemctl enable --now zram.service
```

This creates an **infinite deadlock** on autoscaler nodes:

1. `cloud-final.service` is running the `runcmd`
2. `runcmd` calls `systemctl enable --now zram.service`
3. systemd queues the start job - but `zram.service` has `After=multi-user.target`, so it won't start until `multi-user.target` is active
4. `multi-user.target` is waiting for `cloud-final.service` to complete
5. `cloud-final.service` is blocked waiting for the `systemctl` call to return

The node hangs until the cluster-autoscaler's `HCLOUD_SERVER_CREATION_TIMEOUT` expires and deletes the server. **Autoscaler nodes with `zram_size` set can never join the cluster.**

This does not affect regular agent/control-plane nodes because they use a Terraform `remote-exec` provisioner over SSH, which runs after boot when `multi-user.target` is already active.

Verified by observing `systemctl list-jobs` on a stuck autoscaler node:

```
JOB  UNIT                   TYPE   STATE
167  multi-user.target      start  waiting
1635 zram.service           start  waiting    # waiting for multi-user.target
307  cloud-final.service    start  running    # blocked on systemctl
```

## Fix

Remove `After=multi-user.target` from the zram service unit in the autoscaler cloud-init template. The `WantedBy=multi-user.target` install directive is kept intact, so the service still starts correctly on subsequent boots as part of `multi-user.target`. Without the `After=` ordering constraint, systemd can start the service immediately when requested from within `cloud-final.service`.

## Testing

Reproduced and fixed on a live autoscaler node (kube-hetzner v2.19.1, OpenSUSE MicroOS, hel1 datacenter). After manually breaking the deadlock, cloud-init completed and the k3s agent joined the cluster successfully.

Fixes https://github.com/mysticaltech/terraform-hcloud-kube-hetzner/issues/2161
