### PR TITLE
fix(nat-router): fix fail2ban sshd jail on Debian 12

### DIFF
--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -2,8 +2,9 @@
 package_reboot_if_required: false
 package_update: true
 package_upgrade: true
-packages: 
+packages:
 - fail2ban
+- python3-systemd
 %{ if enable_redundancy ~}
 - jq
 - keepalived
@@ -40,7 +41,8 @@ write_files:
       [sshd]
       enabled = true
       port = ssh
-      logpath = %(sshd_log)s
+      backend = systemd
+      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
       maxretry = 5
       bantime = 86400
 


### PR DESCRIPTION
## Problem

fail2ban has never worked on NAT router nodes provisioned with Debian 12. The sshd jail fails silently on first boot, leaving NAT routers exposed to SSH brute-force with zero protection.

Three bugs in `templates/nat-router-cloudinit.yaml.tpl`:

1. **Missing `python3-systemd` package** — fail2ban's systemd backend requires this Python module to read journald. Without it:
   ```
   Backend 'systemd' failed to initialize due to No module named 'systemd'
   ```

2. **Wrong log backend** — the jail uses `logpath = %(sshd_log)s` which resolves to `/var/log/auth.log`, a file that doesn't exist on Debian 12 (SSH logs go to journald). The correct config requires `backend = systemd`.

3. **Wrong systemd unit name** — fail2ban's built-in sshd filter matches `_SYSTEMD_UNIT=sshd.service`, but Debian 12 uses `ssh.service`. Requires explicit `journalmatch` override.

## Fix

- Add `python3-systemd` to the packages list
- Replace `logpath = %(sshd_log)s` with `backend = systemd` and explicit `journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd`

## Testing

Tested manually on two NAT routers (primary fsn1 + standby nbg1) running Debian 12 with kube-hetzner v2.19.2. After applying the fix, fail2ban immediately started banning brute-force IPs.