### PR TITLE
feat: add extra_runcmd support for nat-router cloud-init

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -2907,6 +2907,9 @@ The following variables have been added to the `kube-hetzner` module since the i
     * `location`: The location where the NAT router should be deployed
     * `labels`: (Optional) Additional labels for the NAT router
     * `enable_sudo`: (Optional, default: false) Enable sudo access for the nat-router user
+    * `enable_redundancy`: (Optional, default: false) Deploy two NAT routers with keepalived for failover
+    * `standby_location`: (Optional, default: "") Location for the standby NAT router; required when `enable_redundancy` is true
+    * `extra_runcmd`: (Optional, default: []) List of extra shell commands appended to the NAT router's cloud-init `runcmd` section. Useful for installing additional packages, fetching certificates, or running custom setup scripts.
   * **Port Forwarding:** When the control plane LB has no public interface (`control_plane_lb_enable_public_interface = false`), the NAT router automatically configures iptables rules to forward incoming traffic on port 6443 to the control plane LB's private IP. This allows external kubectl access while keeping the control plane LB completely private.
 
 **k3s Binary Configuration**

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -430,6 +430,7 @@ module "kube-hetzner" {
   #   enable_redundancy = true    # optional, default to false. Enable failover for the NAT router.
   #   standby_location  = "fsn1"  # optional, default to "". Must be set if enable_redundancy is true.
   #   labels            = {}      # optionally add labels.
+  #   extra_runcmd      = []      # optional, list of extra shell commands to append to cloud-init runcmd.
   # }
   # nat_router_hcloud_token = ""  # optional, default to "". Must be set if enable_redundancy is true. This token needs read/write to change the private alias ip in the nat_router subnetwork for failover
 

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -69,6 +69,7 @@ data "cloudinit_config" "nat_router_config" {
         enable_cp_lb_port_forward  = var.use_control_plane_lb && !var.control_plane_lb_enable_public_interface
         cp_lb_private_ip           = try(hcloud_load_balancer_network.control_plane[0].ip, "")
         kubeapi_port               = var.kubeapi_port
+        extra_runcmd               = var.nat_router.extra_runcmd
       }
     )
   }

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -239,6 +239,6 @@ runcmd:
   - [systemctl, 'enable', 'keepalived']
   - [systemctl, 'restart', 'keepalived']
 %{ endif ~}
-%{ for command in extra_runcmd ~}
-  - ${command}
-%{ endfor ~}
+%{~ if length(extra_runcmd) > 0 ~}
+${yamlencode(extra_runcmd)}
+%{~ endif ~}

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -239,3 +239,6 @@ runcmd:
   - [systemctl, 'enable', 'keepalived']
   - [systemctl, 'restart', 'keepalived']
 %{ endif ~}
+%{ for command in extra_runcmd ~}
+  - ${command}
+%{ endfor ~}

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -239,6 +239,8 @@ runcmd:
   - [systemctl, 'enable', 'keepalived']
   - [systemctl, 'restart', 'keepalived']
 %{ endif ~}
-%{~ if length(extra_runcmd) > 0 ~}
-${yamlencode(extra_runcmd)}
-%{~ endif ~}
+%{ if length(extra_runcmd) > 0 }
+%{ for cmd in extra_runcmd }
+  - ${jsonencode(cmd)}
+%{ endfor }
+%{ endif }

--- a/variables.tf
+++ b/variables.tf
@@ -250,6 +250,7 @@ variable "nat_router" {
     enable_sudo       = optional(bool, false)
     enable_redundancy = optional(bool, false)
     standby_location  = optional(string, "")
+    extra_runcmd      = optional(list(string), [])
   })
 
   validation {


### PR DESCRIPTION
## Summary

- Add optional `extra_runcmd` field to the `nat_router` variable object
- When set, the provided shell commands are appended to the nat-router's cloud-init `runcmd` section
- Document the feature in kube.tf.example and docs/llms.md

## Motivation

The nat-router's cloud-init is fully hardcoded with no extensibility hooks. Users who need custom setup on the NAT router (e.g., installing certificates, running setup scripts, adding monitoring agents) must fork the template.
K3s nodes already support `preinstall_exec`/`postinstall_exec` for this purpose — this brings similar extensibility to the nat-router.

## Changes

| File | What changed |
|---|---|
| `variables.tf` | Added `extra_runcmd = optional(list(string), [])` to the `nat_router` object type |
| `nat-router.tf` | Passes `extra_runcmd` to the cloud-init template |
| `templates/nat-router-cloudinit.yaml.tpl` | Renders extra commands at the end of the `runcmd` section |
| `kube.tf.example` | Added commented-out example in the nat_router block |
| `docs/llms.md` | Documented `extra_runcmd` (and previously undocumented `enable_redundancy`/`standby_location`) in the NAT Router Configuration section |

## Usage

```tf
nat_router = {
  server_type  = "cax21"
  location     = "nbg1"
  extra_runcmd = [
    "apt-get install -y curl",
    "echo 'custom setup complete'",
  ]
}
```

## Backward compatibility

Fully backward-compatible. The new field defaults to `[]`, which produces no additional cloud-init commands. No existing configurations are affected.

## Test plan

- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [x] `terraform plan` with no `extra_runcmd` set — unchanged behavior
- [x] `terraform plan` with `extra_runcmd` on nat_router — commands appear in rendered cloud-init