### PR TITLE
feat: add use_private_bastion for egress-only NAT router hardening

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -2902,6 +2902,7 @@ The following variables have been added to the `kube-hetzner` module since the i
     * Simplifies firewall rules and security auditing
     * Automatically forwards Kubernetes API traffic (port 6443) when `control_plane_lb_enable_public_interface = false`
   * **Trade-offs:** Introduces a single point of failure for egress traffic
+  * **Private Bastion Mode:** Set `use_private_bastion = true` to use the NAT router's private IP as the SSH bastion instead of its public IP. This allows hardening the NAT router to be egress-only (no inbound ports on the public IP). Requires the operator to have network-level access to the private network (e.g. via Tailscale, Cloudflare Tunnel, WireGuard).
   * **Configuration:**
     * `server_type`: The Hetzner server type for the NAT router
     * `location`: The location where the NAT router should be deployed

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -432,6 +432,7 @@ module "kube-hetzner" {
   #   labels            = {}      # optionally add labels.
   # }
   # nat_router_hcloud_token = ""  # optional, default to "". Must be set if enable_redundancy is true. This token needs read/write to change the private alias ip in the nat_router subnetwork for failover
+  # use_private_bastion = true    # Use NAT router's private IP as bastion. Requires network access to the private network (e.g. Tailscale, WireGuard).
 
 
   ### The following values are entirely optional (and can be removed from this if unused)

--- a/locals.tf
+++ b/locals.tf
@@ -801,7 +801,7 @@ EOT
 
   ssh_bastion = coalesce(
     local.use_nat_router ? {
-      bastion_host        = hcloud_server.nat_router[0].ipv4_address
+      bastion_host        = var.use_private_bastion ? local.nat_router_ip[0] : hcloud_server.nat_router[0].ipv4_address
       bastion_port        = var.ssh_port
       bastion_user        = "nat-router"
       bastion_private_key = var.ssh_private_key

--- a/variables.tf
+++ b/variables.tf
@@ -258,6 +258,17 @@ variable "nat_router" {
   }
 }
 
+variable "use_private_bastion" {
+  type        = bool
+  default     = false
+  description = "Use the NAT router's private IP as the SSH bastion instead of its public IP. Requires the operator to have network-level access to the private network (e.g. via Tailscale, Cloudflare Tunnel, WireGuard VPN, etc)."
+
+  validation {
+    condition     = !var.use_private_bastion || var.nat_router != null
+    error_message = "use_private_bastion requires nat_router to be configured."
+  }
+}
+
 variable "nat_router_hcloud_token" {
   description = "API Token used by the nat-router to change ip assignment when nat_router.enable_redundancy is true."
   type        = string


### PR DESCRIPTION
## Summary

- Add `use_private_bastion` boolean variable (default `false`)
- When enabled, the module uses the NAT router's private IP as the SSH bastion instead of its public IP
- Document the feature in kube.tf.example and docs/llms.md

## Motivation

When the NAT router is used as a bastion, its public IP must accept inbound SSH — exposing an attack surface. Operators who already have network-level access to the Hetzner private network (via Tailscale, Cloudflare Tunnel, WireGuard, etc.) can harden the NAT router to be **egress-only** by bastioning through the private IP instead. The module doesn't need to know how the operator reaches the private network — just whether they can.

## Changes

| File | What changed |
|---|---|
| `variables.tf` | Added `use_private_bastion` variable with validation requiring `nat_router` to be configured |
| `locals.tf` | Bastion host conditionally resolves to `local.nat_router_ip[0]` (private) or `hcloud_server.nat_router[0].ipv4_address` (public) |
| `kube.tf.example` | Added commented-out example in the NAT router block |
| `docs/llms.md` | Documented private bastion mode in the NAT Router Configuration section |

## Usage

```tf
nat_router = {
  server_type = "cax21"
  location    = "nbg1"
}

use_private_bastion = true
```

## Backward compatibility

Fully backward-compatible. The new variable defaults to `false`, preserving the existing behavior of using the NAT router's public IP as bastion. No existing configurations are affected.

## Test plan

- [x] `terraform fmt` passes
- [x] `terraform plan` with `use_private_bastion = false` (default) — unchanged behavior
- [x] `terraform plan` with `use_private_bastion = true` + `nat_router` configured — bastion uses private IP
- [x] `terraform plan` with `use_private_bastion = true` + no `nat_router` — validation error