### PR TITLE
fix: reduce snapper timeline limits to prevent disk fill

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1344,9 +1344,21 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/#SystemMaxUse=/SystemMaxUse=3G/g', /etc/systemd/journald.conf]
 - [sed, '-i', 's/#MaxRetentionSec=/MaxRetentionSec=1week/g', /etc/systemd/journald.conf]
 
-# Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 2
+# Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 3
 - [sed, '-i', 's/NUMBER_LIMIT="2-10"/NUMBER_LIMIT="4"/g', /etc/snapper/configs/root]
 - [sed, '-i', 's/NUMBER_LIMIT_IMPORTANT="4-10"/NUMBER_LIMIT_IMPORTANT="3"/g', /etc/snapper/configs/root]
+
+# Reduce timeline snapshot limits to prevent disk fill on small Hetzner VMs (40-80GB).
+# Default MicroOS values (10 hourly, 10 daily, 10 monthly, 10 yearly) are too aggressive
+# for typical cloud VMs and cause DiskPressure within weeks.
+# See: discussions #1319, #1310, #1078, #1993
+- [sed, '-i', 's/TIMELINE_LIMIT_HOURLY="10"/TIMELINE_LIMIT_HOURLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_DAILY="10"/TIMELINE_LIMIT_DAILY="3"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_MONTHLY="10"/TIMELINE_LIMIT_MONTHLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_YEARLY="10"/TIMELINE_LIMIT_YEARLY="0"/g', /etc/snapper/configs/root]
+
+# Disable timeline snapshots entirely — transactional-update already creates pre/post snapshots
+- [systemctl, disable, '--now', 'snapper-timeline.timer']
 
 # Allow network interface
 - [chmod, '+x', '/etc/cloud/rename_interface.sh']

--- a/locals.tf
+++ b/locals.tf
@@ -1345,17 +1345,17 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/#MaxRetentionSec=/MaxRetentionSec=1week/g', /etc/systemd/journald.conf]
 
 # Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 3
-- [sed, '-i', 's/NUMBER_LIMIT="2-10"/NUMBER_LIMIT="4"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/NUMBER_LIMIT_IMPORTANT="4-10"/NUMBER_LIMIT_IMPORTANT="3"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/^NUMBER_LIMIT=".*"/NUMBER_LIMIT="4"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^NUMBER_LIMIT_IMPORTANT=".*"/NUMBER_LIMIT_IMPORTANT="3"/', /etc/snapper/configs/root]
 
 # Reduce timeline snapshot limits to prevent disk fill on small Hetzner VMs (40-80GB).
 # Default MicroOS values (10 hourly, 10 daily, 10 monthly, 10 yearly) are too aggressive
 # for typical cloud VMs and cause DiskPressure within weeks.
 # See: discussions #1319, #1310, #1078, #1993
-- [sed, '-i', 's/TIMELINE_LIMIT_HOURLY="10"/TIMELINE_LIMIT_HOURLY="0"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_DAILY="10"/TIMELINE_LIMIT_DAILY="3"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_MONTHLY="10"/TIMELINE_LIMIT_MONTHLY="0"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_YEARLY="10"/TIMELINE_LIMIT_YEARLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_HOURLY=".*"/TIMELINE_LIMIT_HOURLY="0"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_DAILY=".*"/TIMELINE_LIMIT_DAILY="3"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_MONTHLY=".*"/TIMELINE_LIMIT_MONTHLY="0"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_YEARLY=".*"/TIMELINE_LIMIT_YEARLY="0"/', /etc/snapper/configs/root]
 
 # Disable timeline snapshots entirely — transactional-update already creates pre/post snapshots
 - [systemctl, disable, '--now', 'snapper-timeline.timer']


### PR DESCRIPTION
## Summary

- Adds timeline snapshot limit configuration (`TIMELINE_LIMIT_*`) to the existing snapper sed block in cloud-init
- Disables `snapper-timeline.timer` — redundant since `transactional-update` already creates pre/post snapshots
- Prevents disk fill on typical Hetzner VMs (40-80GB) that hit DiskPressure within weeks due to aggressive MicroOS defaults

## Values applied

| Setting | MicroOS default | New value |
|---------|----------------|-----------|
| `NUMBER_LIMIT` | `2-10` | `4` (unchanged) |
| `NUMBER_LIMIT_IMPORTANT` | `4-10` | `3` (unchanged) |
| `TIMELINE_LIMIT_HOURLY` | `10` | `0` |
| `TIMELINE_LIMIT_DAILY` | `10` | `3` |
| `TIMELINE_LIMIT_MONTHLY` | `10` | `0` |
| `TIMELINE_LIMIT_YEARLY` | `10` | `0` |
| `snapper-timeline.timer` | enabled | disabled |

## Why these values

- **Hourly = 0**: timeline snapshots are noise when `transactional-update` already creates numbered pre/post pairs for every OS update
- **Daily = 3**: keeps a short rollback window without accumulating disk usage
- **Monthly/Yearly = 0**: useless on ephemeral cloud VMs — a full rebuild is faster than rolling back months

## Impact

- Applies to all new nodes (control planes, agents, autoscaler) via `cloudinit_runcmd_common`
- Existing nodes are unaffected (cloud-init runs only on first boot) — users can apply the same sed commands via SSH or `preinstall_exec`
- No new variables, no API changes, no breaking changes

## Related discussions

- #1319 — .snapshots folder taking up all disk space on control planes
- #1310 — Node suffers from DiskPressure due to btrfs snapshots
- #1078 — New cluster control plane nodes at 100% disk usage
- #1993 — BTRFS balance operation causes 100% disk IO

## Follow-up (if desired)

If users need fine-grained control, a `snapper_config` variable with these as defaults could be added in a follow-up PR. This keeps the current change minimal and focused.