### PR TITLE
fix: trigger longhorn filesystem resize on volume size change

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -198,10 +198,11 @@ resource "terraform_data" "configure_longhorn_volume" {
   for_each = { for k, v in local.agent_nodes : k => v if((v.longhorn_volume_size >= 10) && (v.longhorn_volume_size <= 10240) && var.enable_longhorn) }
 
   triggers_replace = {
-    agent_id = module.agents[each.key].id
+    agent_id             = module.agents[each.key].id
+    longhorn_volume_size = hcloud_volume.longhorn_volume[each.key].size
   }
 
-  # Start the k3s agent and wait for it to have started
+  # Configure and resize the longhorn volume
   provisioner "remote-exec" {
     inline = [
       "set -e",


### PR DESCRIPTION
## Summary

- Adds `longhorn_volume_size` to `configure_longhorn_volume` triggers so that increasing a volume size automatically grows the filesystem
- Without this fix, changing `longhorn_volume_size` resizes the Hetzner block volume via API but the node keeps seeing the old filesystem size

## Details

The `configure_longhorn_volume` resource already runs `resize2fs` (ext4) or `xfs_growfs` (xfs) and all its inline commands are idempotent (`mkdir -p`, `mountpoint -q || mount`, `awk || echo >>`), so re-triggering on size change is safe.

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform plan` with an increased `longhorn_volume_size` shows `configure_longhorn_volume` replacement
- [ ] After apply, verify filesystem reflects the new size (`df -h`)