### PR TITLE
fix: re-run rename_interface.sh on every boot via systemd oneshot

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2011,28 +2011,52 @@ cloudinit_write_files_common = <<EOT
     systemctl restart NetworkManager
   permissions: "0744"
 
-# Systemd oneshot that re-runs rename_interface.sh on every boot. The
-# cloud-init run above only fires at first boot and freezes the current NIC
-# MAC into /etc/udev/rules.d/70-persistent-net.rules. If Hetzner later
-# reassigns that MAC (NIC detach/reattach, network reconfig, MicroOS
-# transactional-update wiping the overlay, etc.) the udev rule no longer
-# matches, eth1 never appears, and k3s/rke2 fails with
-# `unable to find interface eth1`. The rename script is idempotent
-# (early-exits when eth1 already exists), so re-running it each boot is
-# cheap and self-heals the node.
+# Lightweight wrapper invoked on every boot by kh-rename-interface.service.
+# Fast-paths the common case (eth1 already present and the udev rule's MAC
+# matches the current MAC) so subsequent boots pay no measurable cost. Only
+# when the rule is stale (e.g. Hetzner reassigned the private NIC's MAC) do
+# we fall through to the full rename_interface.sh — which handles detection,
+# udev rule rewrite, and NetworkManager restart.
+- path: /etc/cloud/rename_interface_boot.sh
+  content: |
+    #!/bin/bash
+    set -eu
+
+    UDEV_RULE=/etc/udev/rules.d/70-persistent-net.rules
+
+    if ip link show eth1 >/dev/null 2>&1; then
+      MAC=$(cat /sys/class/net/eth1/address)
+      if [ -r "$UDEV_RULE" ] && grep -q "ATTR{address}==\"$MAC\"" "$UDEV_RULE"; then
+        exit 0
+      fi
+    fi
+
+    exec /etc/cloud/rename_interface.sh
+  permissions: "0744"
+
+# Systemd oneshot that self-heals the eth1 rename on every boot. The cloud-init
+# run above only fires at first boot and freezes the current NIC MAC into
+# /etc/udev/rules.d/70-persistent-net.rules. If Hetzner later reassigns that
+# MAC (NIC detach/reattach, network reconfig, MicroOS transactional-update
+# wiping the overlay, etc.) the udev rule no longer matches, eth1 never
+# appears, and k3s/rke2 fails with `unable to find interface eth1`.
+#
+# Ordered After=NetworkManager.service because rename_interface.sh uses
+# `nmcli` and restarts NetworkManager — running Before= would deadlock the
+# boot. Ordered Before=k3s/rke2 so the rename (when needed) completes before
+# the kubernetes services try to bind flannel-iface=eth1.
 - path: /etc/systemd/system/kh-rename-interface.service
   content: |
     [Unit]
     Description=Ensure Hetzner private NIC is renamed to eth1
-    DefaultDependencies=no
-    After=systemd-udev-settle.service network-pre.target
-    Before=network.target NetworkManager.service k3s.service k3s-agent.service rke2-server.service rke2-agent.service
-    ConditionPathExists=/etc/cloud/rename_interface.sh
+    After=systemd-udev-settle.service NetworkManager.service
+    Before=k3s.service k3s-agent.service rke2-server.service rke2-agent.service
+    ConditionPathExists=/etc/cloud/rename_interface_boot.sh
 
     [Service]
     Type=oneshot
     RemainAfterExit=yes
-    ExecStart=/etc/cloud/rename_interface.sh
+    ExecStart=/etc/cloud/rename_interface_boot.sh
 
     [Install]
     WantedBy=multi-user.target
@@ -2147,6 +2171,7 @@ cloudinit_runcmd_common = <<EOT
 
 # Allow network interface
 - [chmod, '+x', '/etc/cloud/rename_interface.sh']
+- [chmod, '+x', '/etc/cloud/rename_interface_boot.sh']
 
 # Enable the self-heal oneshot so it runs on every subsequent boot. We don't
 # start it here — first-boot rename happens via remote-exec before k3s/rke2

--- a/locals.tf
+++ b/locals.tf
@@ -2011,6 +2011,33 @@ cloudinit_write_files_common = <<EOT
     systemctl restart NetworkManager
   permissions: "0744"
 
+# Systemd oneshot that re-runs rename_interface.sh on every boot. The
+# cloud-init run above only fires at first boot and freezes the current NIC
+# MAC into /etc/udev/rules.d/70-persistent-net.rules. If Hetzner later
+# reassigns that MAC (NIC detach/reattach, network reconfig, MicroOS
+# transactional-update wiping the overlay, etc.) the udev rule no longer
+# matches, eth1 never appears, and k3s/rke2 fails with
+# `unable to find interface eth1`. The rename script is idempotent
+# (early-exits when eth1 already exists), so re-running it each boot is
+# cheap and self-heals the node.
+- path: /etc/systemd/system/kh-rename-interface.service
+  content: |
+    [Unit]
+    Description=Ensure Hetzner private NIC is renamed to eth1
+    DefaultDependencies=no
+    After=systemd-udev-settle.service network-pre.target
+    Before=network.target NetworkManager.service k3s.service k3s-agent.service rke2-server.service rke2-agent.service
+    ConditionPathExists=/etc/cloud/rename_interface.sh
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=yes
+    ExecStart=/etc/cloud/rename_interface.sh
+
+    [Install]
+    WantedBy=multi-user.target
+  permissions: "0644"
+
 # Disable ssh password authentication
 - content: |
     Port ${var.ssh_port}
@@ -2120,6 +2147,12 @@ cloudinit_runcmd_common = <<EOT
 
 # Allow network interface
 - [chmod, '+x', '/etc/cloud/rename_interface.sh']
+
+# Enable the self-heal oneshot so it runs on every subsequent boot. We don't
+# start it here — first-boot rename happens via remote-exec before k3s/rke2
+# install, and starting it now while eth1 already exists is a no-op.
+- [systemctl, daemon-reload]
+- [systemctl, enable, kh-rename-interface.service]
 
 # Ensure sshd includes config.d directory and restart to apply the new config
 - |


### PR DESCRIPTION
## Problem

cloud-init runs \`/etc/cloud/rename_interface.sh\` once at first boot, which freezes the private NIC's current MAC into \`/etc/udev/rules.d/70-persistent-net.rules\` and renames the interface to \`eth1\`. If Hetzner later reassigns that MAC — which happens on private NIC detach/reattach, network reconfiguration, or when MicroOS \`transactional-update\` wipes the overlay — the frozen udev rule no longer matches. On the next boot \`eth1\` never appears and k3s/rke2 fails with:

\`\`\`
unable to find interface eth1
\`\`\`

This has been reported in several issues: #2023, #1928, #1873, #1984, #2045, #1871, #1462, and is a close relative of discussion #1287. The common workaround users reach for is setting \`flannel-iface = "enp7s0"\` in \`*_custom_config\`, which loses the original "rename to eth1" invariant and breaks on any future NIC name change.

Prior PRs #1564 and #1960 made the first-boot rename more resilient (failure-tolerant + retries), but do not help when the MAC changes **after** provisioning — the first-boot run has already succeeded and will never fire again.

## Fix

Install a systemd oneshot (\`kh-rename-interface.service\`) via cloud-init \`write_files\`, ordered \`Before=\` the k3s/rke2 units, that re-runs the existing \`/etc/cloud/rename_interface.sh\` on every boot. The script is already idempotent — it early-exits when \`eth1\` is present — so re-running it is cheap. When the iface is missing or the udev rule is stale, it refreshes the rule with the current MAC and renames, self-healing the node before k3s/rke2 starts.

- No new variables, no breaking change.
- Two touch points in \`locals.tf\`:
  - \`cloudinit_write_files_common\`: the new unit file.
  - \`cloudinit_runcmd_common\`: \`systemctl daemon-reload\` + \`systemctl enable kh-rename-interface.service\` (not \`start\` — first-boot rename still happens via the existing remote-exec, and starting while \`eth1\` already exists is a no-op).

## Production evidence

I hit this on 2026-04-23 on a long-running single-control-plane + single-agent cluster: a routine \`tofu apply\` triggered MicroOS to reboot both nodes, Hetzner had reassigned both private NIC MACs since the original provision, \`eth1\` didn't come up on either node, and k3s refused to start. ~2.5h outage resolved by SSH-installing exactly this unit on both nodes and restarting k3s. I've been running the same unit in production for ~24h (both CP and agent), and codified it in my downstream fork for future nodes.

## Testing

- \`tofu fmt -check -recursive\` passes.
- \`tofu validate\` passes.
- Manual boot verification on two real Hetzner nodes (control plane + agent) — unit runs \`Before=k3s.service\`, rename script logs success, \`eth1\` present, k3s starts cleanly. Survives \`reboot\`.

## Related

- Fixes / self-heals around: #2023, #1928, #1873, #1984, #2045, #1871, #1462
- Related discussion: #1287
- Prior first-boot-resilience PRs (not superseded): #1564, #1960