### PR TITLE
v2.19.3 patch train

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -123,7 +123,7 @@ cat locals.tf        # Core logic and computed values
 
 ```bash
 # Codex CLI for deep reasoning
-codex exec -m gpt-5.2-codex -s read-only -c model_reasoning_effort="xhigh" \
+codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort="xhigh" \
   "Analyze this issue and identify root cause: <issue description>"
 
 # Gemini for large context analysis

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -95,7 +95,7 @@ $(git diff $LATEST..HEAD --stat)"
 Use Codex for breaking change analysis:
 
 ```bash
-codex exec -m gpt-5.2-codex -s read-only -c model_reasoning_effort="xhigh" \
+codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort="xhigh" \
   "Analyze these changes for breaking changes affecting existing deployments: $(git diff $LATEST..HEAD -- variables.tf locals.tf)"
 ```
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -153,7 +153,7 @@ cloud-init*          # Server initialization
 
 ```bash
 # Codex for security analysis
-codex exec -m gpt-5.3-codex -s read-only -c model_reasoning_effort="xhigh" \
+codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort="xhigh" \
   "Analyze this PR diff for security vulnerabilities and malicious patterns: $(gh pr diff <num>)"
 
 # Gemini for broad context
@@ -254,7 +254,7 @@ Questions:
 4. Is this a legitimate bug fix or could it be malicious?"
 
 # Codex - Deep reasoning security analysis (run in parallel)
-codex exec -m gpt-5.3-codex -s read-only -c model_reasoning_effort="xhigh" \
+codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort="xhigh" \
 "Analyze this Terraform PR for the kube-hetzner module.
 
 DIFF:

--- a/.claude/skills/test-changes/SKILL.md
+++ b/.claude/skills/test-changes/SKILL.md
@@ -162,7 +162,7 @@ For complex changes, get AI review:
 
 ```bash
 # Codex for correctness
-codex exec -m gpt-5.2-codex -s read-only -c model_reasoning_effort="xhigh" \
+codex exec -m gpt-5.5 -s read-only -c model_reasoning_effort="xhigh" \
   "Review these terraform changes for issues: $(git diff)"
 
 # Gemini for broad impact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 📋 v2.19.3 Patch Release
+
+This is a patch release for the v2.19 series focused on upgrade-safe reliability fixes.
+
+**Patch fixes:**
+- **Terraform Legacy Module Regression** - Removed the child-module GitHub provider configuration that prevented callers from using `count`, `for_each`, or `depends_on`; release lookups now use unauthenticated HTTP requests instead (#2155).
+- **NAT Router Validation** - Made NAT router validations null-safe when `nat_router = null` (#2152, #2153).
+- **Autoscaler ZRAM Bootstrap** - Fixed autoscaler nodes hanging in cloud-init when `zram_size` is configured (#2161, #2162).
+- **NAT Router Fail2ban** - Fixed the Debian 12 SSH jail by applying journald/systemd backend support and starting/restarting fail2ban during NAT router provisioning (#2163).
+- **MicroOS Snapshot Growth** - Reduced snapper timeline retention to avoid disk pressure on small nodes (#2167).
+- **Longhorn Volume Reconfiguration** - Re-runs Longhorn volume setup on volume identity/size/path/fstype changes, grows filesystems correctly, and stores fstab entries by filesystem UUID instead of mutable Hetzner volume device IDs (#2174, #2180).
+- **System Upgrade Plans** - Re-applies system-upgrade-controller Plans when `system_upgrade_use_drain` or `system_upgrade_enable_eviction` changes after initial provisioning (#2172).
+- **Control Plane LB Health Check** - Added an explicit HTTPS `/readyz` health check for the control-plane load balancer while keeping the service TCP passthrough (#2176).
+- **Hetzner CSI Values Docs** - Documented existing `hetzner_csi_values` support for custom CSI Helm values (#2168).
+- **Longhorn RWX Guidance** - Documented the upstream Longhorn RWX/NFS 4.1 issue and the NFS 4.0 workaround (#2169).
+
+---
+
 ### 📋 v2.19.1 Patch Release
 
 This is a patch release for v2.19.0. **If upgrading from v2.18.x**, please review the full release notes below including upgrade notes, new features, and breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a patch release for the v2.19 series focused on upgrade-safe reliability
 
 **Patch fixes:**
 - **Terraform Legacy Module Regression** - Removed the child-module GitHub provider configuration that prevented callers from using `count`, `for_each`, or `depends_on`; release lookups now use unauthenticated HTTP requests instead (#2155).
+- **SSH Public Key Normalization** - Trimmed trailing whitespace from SSH public keys to avoid Hetzner provider apply inconsistencies when users pass keys with `file(...)`.
 - **NAT Router Validation** - Made NAT router validations null-safe when `nat_router = null` (#2152, #2153).
 - **Autoscaler ZRAM Bootstrap** - Fixed autoscaler nodes hanging in cloud-init when `zram_size` is configured (#2161, #2162).
 - **NAT Router Fail2ban** - Fixed the Debian 12 SSH jail by applying journald/systemd backend support and starting/restarting fail2ban during NAT router provisioning (#2163).

--- a/agents.tf
+++ b/agents.tf
@@ -198,10 +198,11 @@ resource "terraform_data" "configure_longhorn_volume" {
   for_each = { for k, v in local.agent_nodes : k => v if((v.longhorn_volume_size >= 10) && (v.longhorn_volume_size <= 10240) && var.enable_longhorn) }
 
   triggers_replace = {
-    agent_id = module.agents[each.key].id
+    agent_id             = module.agents[each.key].id
+    longhorn_volume_size = hcloud_volume.longhorn_volume[each.key].size
   }
 
-  # Start the k3s agent and wait for it to have started
+  # Configure and resize the longhorn volume
   provisioner "remote-exec" {
     inline = [
       "set -e",

--- a/agents.tf
+++ b/agents.tf
@@ -199,19 +199,60 @@ resource "terraform_data" "configure_longhorn_volume" {
 
   triggers_replace = {
     agent_id             = module.agents[each.key].id
+    longhorn_fstype      = var.longhorn_fstype
+    longhorn_mount_path  = each.value.longhorn_mount_path
     longhorn_volume_size = hcloud_volume.longhorn_volume[each.key].size
+    volume_id            = hcloud_volume.longhorn_volume[each.key].id
   }
 
   # Configure and resize the longhorn volume
   provisioner "remote-exec" {
     inline = [
-      "set -e",
-      "mkdir -p '${each.value.longhorn_mount_path}' >/dev/null",
-      "mountpoint -q '${each.value.longhorn_mount_path}' || mount -o discard,defaults ${hcloud_volume.longhorn_volume[each.key].linux_device} '${each.value.longhorn_mount_path}'",
-      "${var.longhorn_fstype == "ext4" ? "resize2fs" : "xfs_growfs"} ${hcloud_volume.longhorn_volume[each.key].linux_device}",
-      # Match any non-comment line (^[^#]) with any first field, followed by a space and your mount path in the second column.
-      # This prevents false positives like /data matching /data1.
-      "awk -v path='${each.value.longhorn_mount_path}' '$0 !~ /^#/ && $2 == path { found=1; exit } END { exit !found }' /etc/fstab || echo '${hcloud_volume.longhorn_volume[each.key].linux_device} ${each.value.longhorn_mount_path} ${var.longhorn_fstype} discard,nofail,defaults 0 0' | tee -a /etc/fstab >/dev/null"
+      <<-EOT
+      set -e
+
+      device='${hcloud_volume.longhorn_volume[each.key].linux_device}'
+      mount_path='${each.value.longhorn_mount_path}'
+      fstype='${var.longhorn_fstype}'
+
+      mkdir -p "$mount_path" >/dev/null
+      uuid="$(blkid -s UUID -o value "$device")"
+      if [ -z "$uuid" ]; then
+        echo "Unable to determine filesystem UUID for $device" >&2
+        exit 1
+      fi
+
+      {
+        findmnt -rn -S "$device" -o TARGET || true
+        findmnt -rn -S "UUID=$uuid" -o TARGET || true
+      } | sort -u | while read -r current_mount; do
+        if [ -n "$current_mount" ] && [ "$current_mount" != "$mount_path" ]; then
+          umount "$current_mount"
+        fi
+      done
+
+      if mountpoint -q "$mount_path"; then
+        mounted_source="$(findmnt -rn -T "$mount_path" -o SOURCE)"
+        mounted_uuid="$(blkid -s UUID -o value "$mounted_source" 2>/dev/null || true)"
+        if [ "$mounted_uuid" != "$uuid" ]; then
+          umount "$mount_path"
+        fi
+      fi
+
+      mountpoint -q "$mount_path" || mount -o discard,defaults "$device" "$mount_path"
+
+      case "$fstype" in
+        ext4) resize2fs "$device" ;;
+        xfs) xfs_growfs "$mount_path" ;;
+        *) echo "Unsupported Longhorn filesystem type: $fstype" >&2; exit 1 ;;
+      esac
+
+      tmp_fstab="$(mktemp)"
+      awk -v path="$mount_path" -v uuid="$uuid" -v device="$device" '$0 ~ /^#/ || ($1 != "UUID=" uuid && $1 != device && $2 != path) { print }' /etc/fstab > "$tmp_fstab"
+      cat "$tmp_fstab" > /etc/fstab
+      rm -f "$tmp_fstab"
+      printf 'UUID=%s %s %s discard,nofail,defaults 0 0\n' "$uuid" "$mount_path" "$fstype" >> /etc/fstab
+      EOT
     ]
   }
 

--- a/agents.tf
+++ b/agents.tf
@@ -12,9 +12,9 @@ module "agents" {
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port
-  ssh_public_key                   = var.ssh_public_key
+  ssh_public_key                   = local.ssh_public_key
   ssh_private_key                  = var.ssh_private_key
-  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(local.ssh_additional_public_keys, [for key in data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key : trimspace(key)]) : local.ssh_additional_public_keys
   firewall_ids                     = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
   placement_group_id               = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.agent[each.value.placement_group_compat_idx].id : hcloud_placement_group.agent_named[each.value.placement_group].id)
   location                         = each.value.location

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -117,7 +117,7 @@ data "cloudinit_config" "autoscaler_config" {
         hostname          = "autoscaler"
         dns_servers       = var.dns_servers
         has_dns_servers   = local.has_dns_servers
-        sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys = local.ssh_authorized_keys
         swap_size         = var.autoscaler_nodepools[count.index].swap_size
         zram_size         = var.autoscaler_nodepools[count.index].zram_size
         k3s_config = yamlencode(merge(
@@ -160,7 +160,7 @@ data "cloudinit_config" "autoscaler_legacy_config" {
         hostname          = "autoscaler"
         dns_servers       = var.dns_servers
         has_dns_servers   = local.has_dns_servers
-        sshAuthorizedKeys = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys = local.ssh_authorized_keys
         swap_size         = ""
         zram_size         = ""
         k3s_config = yamlencode(merge(

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -101,6 +101,20 @@ resource "hcloud_load_balancer_service" "control_plane" {
   protocol         = "tcp"
   destination_port = "6443"
   listen_port      = "6443"
+
+  health_check {
+    protocol = "https"
+    port     = 6443
+    interval = tonumber(trimsuffix(var.load_balancer_health_check_interval, "s"))
+    timeout  = tonumber(trimsuffix(var.load_balancer_health_check_timeout, "s"))
+    retries  = var.load_balancer_health_check_retries
+
+    http {
+      path         = "/readyz"
+      tls          = false
+      status_codes = ["200", "401"]
+    }
+  }
 }
 
 locals {

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -12,9 +12,9 @@ module "control_planes" {
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port
-  ssh_public_key                   = var.ssh_public_key
+  ssh_public_key                   = local.ssh_public_key
   ssh_private_key                  = var.ssh_private_key
-  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(var.ssh_additional_public_keys, data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key) : var.ssh_additional_public_keys
+  ssh_additional_public_keys       = length(var.ssh_hcloud_key_label) > 0 ? concat(local.ssh_additional_public_keys, [for key in data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.public_key : trimspace(key)]) : local.ssh_additional_public_keys
   firewall_ids                     = each.value.disable_ipv4 && each.value.disable_ipv6 ? [] : [hcloud_firewall.k3s.id] # Cannot attach a firewall when public interfaces are disabled
   placement_group_id               = var.placement_group_disable ? null : (each.value.placement_group == null ? hcloud_placement_group.control_plane[each.value.placement_group_compat_idx].id : hcloud_placement_group.control_plane_named[each.value.placement_group].id)
   location                         = each.value.location

--- a/data.tf
+++ b/data.tf
@@ -1,31 +1,37 @@
-data "github_release" "hetzner_ccm" {
-  count       = var.hetzner_ccm_version == null ? 1 : 0
-  repository  = "hcloud-cloud-controller-manager"
-  owner       = "hetznercloud"
-  retrieve_by = "latest"
+data "http" "hetzner_ccm_release" {
+  count = var.hetzner_ccm_version == null ? 1 : 0
+  url   = "https://api.github.com/repos/hetznercloud/hcloud-cloud-controller-manager/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
 }
 
-data "github_release" "hetzner_csi" {
-  count       = var.hetzner_csi_version == null && !var.disable_hetzner_csi ? 1 : 0
-  repository  = "csi-driver"
-  owner       = "hetznercloud"
-  retrieve_by = "latest"
+data "http" "hetzner_csi_release" {
+  count = var.hetzner_csi_version == null && !var.disable_hetzner_csi ? 1 : 0
+  url   = "https://api.github.com/repos/hetznercloud/csi-driver/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
 }
 
-// github_release for kured
-data "github_release" "kured" {
-  count       = var.kured_version == null ? 1 : 0
-  repository  = "kured"
-  owner       = "kubereboot"
-  retrieve_by = "latest"
+data "http" "kured_release" {
+  count = var.kured_version == null ? 1 : 0
+  url   = "https://api.github.com/repos/kubereboot/kured/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
 }
 
-// github_release for kured
-data "github_release" "calico" {
-  count       = var.calico_version == null && var.cni_plugin == "calico" ? 1 : 0
-  repository  = "calico"
-  owner       = "projectcalico"
-  retrieve_by = "latest"
+data "http" "calico_release" {
+  count = var.calico_version == null && var.cni_plugin == "calico" ? 1 : 0
+  url   = "https://api.github.com/repos/projectcalico/calico/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
 }
 
 data "hcloud_ssh_keys" "keys_by_selector" {

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1142,6 +1142,16 @@ The example shows three control plane nodepools, each with one node, in differen
   * **Purpose:** Allows pinning the Hetzner Cloud CSI driver to a specific version (if `disable_hetzner_csi` is `false`).
   * **Reference:** The GitHub releases link provides available versions.
 
+```terraform
+  # To pass custom Helm values to the Hetzner CSI driver, use hetzner_csi_values.
+  # hetzner_csi_values = file("${path.module}/chart-values/hcloud-csi.yaml")
+```
+
+* **`hetzner_csi_values` (String, Optional):**
+  * **Default:** `""`.
+  * **Purpose:** Passes custom Helm values to the Hetzner CSI `HelmChart` as `valuesContent`.
+  * **Usage:** Use a heredoc or `file(...)` when you need to customize the CSI chart without managing the driver outside the module.
+
 ---
 
 Excellent! Let's continue our meticulous dissection.
@@ -3053,6 +3063,12 @@ The following variables allow deep customization of various components through H
   # networking:
   #   enabled: true
   # EOT
+
+  # Custom Hetzner CSI values
+  # hetzner_csi_values = <<-EOT
+  # controller:
+  #   replicas: 2
+  # EOT
   
   # Custom CSI driver SMB values
   # csi_driver_smb_values = <<-EOT
@@ -3061,6 +3077,9 @@ The following variables allow deep customization of various components through H
   # EOT
   
   # Custom Longhorn values
+  # Note: Longhorn RWX volumes may be affected by upstream NFS 4.1/4.2 client hangs.
+  # Workaround: create a dedicated StorageClass for affected RWX PVCs with
+  # parameters.nfsOptions = "vers=4.0,noresvport,softerr,timeo=600,retrans=5".
   # longhorn_values = <<-EOT
   # defaultSettings:
   #   defaultDataPath: /var/longhorn

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,8 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.1 |
 | <a name="requirement_assert"></a> [assert](#requirement\_assert) | >= 0.16.0 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.4.0 |
 | <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | >= 1.59.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.5.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.5.2 |
 | <a name="requirement_semvers"></a> [semvers](#requirement\_semvers) | >= 0.7.1 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
@@ -16,8 +16,8 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_github"></a> [github](#provider\_github) | >= 6.4.0 |
 | <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.59.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | >= 3.5.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.5.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
@@ -100,18 +100,19 @@
 | [terraform_data.kustomization_user](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.kustomization_user_deploy](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.nat_router_await_cloud_init](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.nat_router_fail2ban](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [cloudinit_config.autoscaler_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.autoscaler_legacy_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.nat_router_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
-| [github_release.calico](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [github_release.hetzner_ccm](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [github_release.hetzner_csi](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
-| [github_release.kured](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) | data source |
 | [hcloud_image.microos_arm_snapshot](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/image) | data source |
 | [hcloud_image.microos_x86_snapshot](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/image) | data source |
 | [hcloud_network.k3s](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/network) | data source |
 | [hcloud_servers.autoscaled_nodes](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/servers) | data source |
 | [hcloud_ssh_keys.keys_by_selector](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/ssh_keys) | data source |
+| [http_http.calico_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.hetzner_ccm_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.hetzner_csi_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.kured_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ### Inputs
 

--- a/init.tf
+++ b/init.tf
@@ -301,6 +301,8 @@ resource "terraform_data" "kustomization" {
     ])
     ccm_use_helm                   = var.hetzner_ccm_use_helm
     system_upgrade_schedule_window = jsonencode(var.system_upgrade_schedule_window)
+    system_upgrade_use_drain       = tostring(var.system_upgrade_use_drain)
+    system_upgrade_enable_eviction = tostring(var.system_upgrade_enable_eviction)
   }
 
   connection {

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -587,6 +587,9 @@ module "kube-hetzner" {
   # See https://github.com/hetznercloud/csi-driver/releases for the available versions.
   # hetzner_csi_version = ""
 
+  # To pass custom Helm values to the Hetzner CSI driver, use hetzner_csi_values.
+  # hetzner_csi_values = file("${path.module}/chart-values/hcloud-csi.yaml")
+
   # If you want to specify the Kured version, set it below - otherwise it'll use the latest version available.
   # See https://github.com/kubereboot/kured/releases for the available versions.
   # kured_version = ""
@@ -1247,6 +1250,8 @@ controller:
   # Longhorn, all Longhorn helm values can be found at https://github.com/longhorn/longhorn/blob/master/chart/values.yaml
   # If you want to merge extra values into defaults (or longhorn_values), use longhorn_merge_values.
   # longhorn_values replaces the module defaults. For targeted overrides (for example hotfix image tags), prefer longhorn_merge_values.
+  # Longhorn RWX volumes may be affected by upstream NFS 4.1/4.2 client hangs.
+  # Workaround: create a dedicated StorageClass for affected RWX PVCs with parameters.nfsOptions = "vers=4.0,noresvport,softerr,timeo=600,retrans=5".
   # The following is an example, please note that the current indentation inside the EOT is important.
   /*   longhorn_values = <<-EOT
 defaultSettings:

--- a/locals.tf
+++ b/locals.tf
@@ -1344,9 +1344,21 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/#SystemMaxUse=/SystemMaxUse=3G/g', /etc/systemd/journald.conf]
 - [sed, '-i', 's/#MaxRetentionSec=/MaxRetentionSec=1week/g', /etc/systemd/journald.conf]
 
-# Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 2
+# Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 3
 - [sed, '-i', 's/NUMBER_LIMIT="2-10"/NUMBER_LIMIT="4"/g', /etc/snapper/configs/root]
 - [sed, '-i', 's/NUMBER_LIMIT_IMPORTANT="4-10"/NUMBER_LIMIT_IMPORTANT="3"/g', /etc/snapper/configs/root]
+
+# Reduce timeline snapshot limits to prevent disk fill on small Hetzner VMs (40-80GB).
+# Default MicroOS values (10 hourly, 10 daily, 10 monthly, 10 yearly) are too aggressive
+# for typical cloud VMs and cause DiskPressure within weeks.
+# See: discussions #1319, #1310, #1078, #1993
+- [sed, '-i', 's/TIMELINE_LIMIT_HOURLY="10"/TIMELINE_LIMIT_HOURLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_DAILY="10"/TIMELINE_LIMIT_DAILY="3"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_MONTHLY="10"/TIMELINE_LIMIT_MONTHLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/TIMELINE_LIMIT_YEARLY="10"/TIMELINE_LIMIT_YEARLY="0"/g', /etc/snapper/configs/root]
+
+# Disable timeline snapshots entirely — transactional-update already creates pre/post snapshots
+- [systemctl, disable, '--now', 'snapper-timeline.timer']
 
 # Allow network interface
 - [chmod, '+x', '/etc/cloud/rename_interface.sh']

--- a/locals.tf
+++ b/locals.tf
@@ -13,10 +13,10 @@ locals {
   # k3s endpoint used for agent registration, respects control_plane_endpoint override
   k3s_endpoint = coalesce(var.control_plane_endpoint, "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443")
 
-  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : data.github_release.hetzner_ccm[0].release_tag
-  csi_version    = length(data.github_release.hetzner_csi) == 0 ? var.hetzner_csi_version : data.github_release.hetzner_csi[0].release_tag
-  kured_version  = length(data.github_release.kured) == 0 ? var.kured_version : data.github_release.kured[0].release_tag
-  calico_version = length(data.github_release.calico) == 0 ? var.calico_version : data.github_release.calico[0].release_tag
+  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : jsondecode(data.http.hetzner_ccm_release[0].response_body).tag_name
+  csi_version    = length(data.http.hetzner_csi_release) == 0 ? var.hetzner_csi_version : jsondecode(data.http.hetzner_csi_release[0].response_body).tag_name
+  kured_version  = length(data.http.kured_release) == 0 ? var.kured_version : jsondecode(data.http.kured_release[0].response_body).tag_name
+  calico_version = length(data.http.calico_release) == 0 ? var.calico_version : jsondecode(data.http.calico_release[0].response_body).tag_name
 
   # Determine kured YAML suffix based on version (>= 1.20.0 uses -combined.yaml, < 1.20.0 uses -dockerhub.yaml)
   kured_yaml_suffix = provider::semvers::compare(local.kured_version, "1.20.0") >= 0 ? "combined" : "dockerhub"
@@ -1357,8 +1357,8 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/^TIMELINE_LIMIT_MONTHLY=".*"/TIMELINE_LIMIT_MONTHLY="0"/', /etc/snapper/configs/root]
 - [sed, '-i', 's/^TIMELINE_LIMIT_YEARLY=".*"/TIMELINE_LIMIT_YEARLY="0"/', /etc/snapper/configs/root]
 
-# Disable timeline snapshots entirely — transactional-update already creates pre/post snapshots
-- [systemctl, disable, '--now', 'snapper-timeline.timer']
+# Disable timeline snapshots entirely; transactional-update already creates pre/post snapshots.
+- [sh, '-c', 'systemctl disable --now snapper-timeline.timer || true']
 
 # Allow network interface
 - [chmod, '+x', '/etc/cloud/rename_interface.sh']

--- a/locals.tf
+++ b/locals.tf
@@ -1345,17 +1345,17 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/#MaxRetentionSec=/MaxRetentionSec=1week/g', /etc/systemd/journald.conf]
 
 # Reduces the default number of snapshots from 2-10 number limit, to 4 and from 4-10 number limit important, to 3
-- [sed, '-i', 's/NUMBER_LIMIT="2-10"/NUMBER_LIMIT="4"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/NUMBER_LIMIT_IMPORTANT="4-10"/NUMBER_LIMIT_IMPORTANT="3"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/^NUMBER_LIMIT=".*"/NUMBER_LIMIT="4"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^NUMBER_LIMIT_IMPORTANT=".*"/NUMBER_LIMIT_IMPORTANT="3"/', /etc/snapper/configs/root]
 
 # Reduce timeline snapshot limits to prevent disk fill on small Hetzner VMs (40-80GB).
 # Default MicroOS values (10 hourly, 10 daily, 10 monthly, 10 yearly) are too aggressive
 # for typical cloud VMs and cause DiskPressure within weeks.
 # See: discussions #1319, #1310, #1078, #1993
-- [sed, '-i', 's/TIMELINE_LIMIT_HOURLY="10"/TIMELINE_LIMIT_HOURLY="0"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_DAILY="10"/TIMELINE_LIMIT_DAILY="3"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_MONTHLY="10"/TIMELINE_LIMIT_MONTHLY="0"/g', /etc/snapper/configs/root]
-- [sed, '-i', 's/TIMELINE_LIMIT_YEARLY="10"/TIMELINE_LIMIT_YEARLY="0"/g', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_HOURLY=".*"/TIMELINE_LIMIT_HOURLY="0"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_DAILY=".*"/TIMELINE_LIMIT_DAILY="3"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_MONTHLY=".*"/TIMELINE_LIMIT_MONTHLY="0"/', /etc/snapper/configs/root]
+- [sed, '-i', 's/^TIMELINE_LIMIT_YEARLY=".*"/TIMELINE_LIMIT_YEARLY="0"/', /etc/snapper/configs/root]
 
 # Disable timeline snapshots entirely — transactional-update already creates pre/post snapshots
 - [systemctl, disable, '--now', 'snapper-timeline.timer']

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,11 @@
 locals {
+  ssh_public_key             = trimspace(var.ssh_public_key)
+  ssh_additional_public_keys = [for key in var.ssh_additional_public_keys : trimspace(key) if trimspace(key) != ""]
+  ssh_authorized_keys        = concat([local.ssh_public_key], local.ssh_additional_public_keys)
+
   # ssh_agent_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
-  ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
+  ssh_agent_identity = var.ssh_private_key == null ? local.ssh_public_key : null
 
   # If passed, a key already registered within hetzner is used.
   # Otherwise, a new one will be created by the module.

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "hcloud_image" "microos_arm_snapshot" {
 resource "hcloud_ssh_key" "k3s" {
   count      = var.hcloud_ssh_key_id == null ? 1 : 0
   name       = var.cluster_name
-  public_key = var.ssh_public_key
+  public_key = local.ssh_public_key
   labels     = local.labels
 }
 

--- a/modules/host/locals.tf
+++ b/modules/host/locals.tf
@@ -1,7 +1,11 @@
 locals {
+  ssh_public_key             = trimspace(var.ssh_public_key)
+  ssh_additional_public_keys = [for key in var.ssh_additional_public_keys : trimspace(key) if trimspace(key) != ""]
+  ssh_authorized_keys        = concat([local.ssh_public_key], local.ssh_additional_public_keys)
+
   # ssh_agent_identity is not set if the private key is passed directly, but if ssh agent is used, the public key tells ssh agent which private key to use.
   # For terraforms provisioner.connection.agent_identity, we need the public key as a string.
-  ssh_agent_identity = var.ssh_private_key == null ? var.ssh_public_key : null
+  ssh_agent_identity = var.ssh_private_key == null ? local.ssh_public_key : null
 
   # the hosts name with its unique suffix attached
   name = "${var.name}-${random_string.server.id}"

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -234,7 +234,7 @@ data "cloudinit_config" "config" {
         hostname                     = local.name
         dns_servers                  = var.dns_servers
         has_dns_servers              = local.has_dns_servers
-        sshAuthorizedKeys            = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys            = local.ssh_authorized_keys
         cloudinit_write_files_common = var.cloudinit_write_files_common
         cloudinit_runcmd_common      = var.cloudinit_runcmd_common
         swap_size                    = var.swap_size

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -14,6 +14,37 @@ locals {
 
   nat_router_name_basename = "nat-router"
   nat_router_name          = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${local.nat_router_name_basename}"
+
+  nat_router_fail2ban_script = <<-EOT
+set -e
+
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+if ! dpkg -s fail2ban python3-systemd >/dev/null 2>&1; then
+  as_root apt-get update
+  as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y fail2ban python3-systemd
+fi
+
+as_root mkdir -p /etc/fail2ban/jail.d
+as_root tee /etc/fail2ban/jail.d/sshd.local >/dev/null <<'EOF'
+[sshd]
+enabled = true
+port = ${var.ssh_port}
+backend = systemd
+journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
+maxretry = 5
+bantime = 86400
+EOF
+
+as_root systemctl enable --now fail2ban
+as_root systemctl restart fail2ban
+EOT
 }
 
 resource "random_string" "nat_router" {
@@ -189,7 +220,7 @@ resource "terraform_data" "nat_router_fail2ban" {
 
   triggers_replace = {
     server_id  = hcloud_server.nat_router[count.index].id
-    config_sha = sha256("fail2ban-systemd-ssh-service-v3")
+    config_sha = sha256(local.nat_router_fail2ban_script)
   }
 
   connection {
@@ -202,36 +233,7 @@ resource "terraform_data" "nat_router_fail2ban" {
 
   provisioner "remote-exec" {
     inline = [
-      <<-EOT
-      set -e
-
-      as_root() {
-        if [ "$(id -u)" -eq 0 ]; then
-          "$@"
-        else
-          sudo "$@"
-        fi
-      }
-
-      if ! dpkg -s fail2ban python3-systemd >/dev/null 2>&1; then
-        as_root apt-get update
-        as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y fail2ban python3-systemd
-      fi
-
-      as_root mkdir -p /etc/fail2ban/jail.d
-      as_root tee /etc/fail2ban/jail.d/sshd.local >/dev/null <<'EOF'
-      [sshd]
-      enabled = true
-      port = ${var.ssh_port}
-      backend = systemd
-      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
-      maxretry = 5
-      bantime = 86400
-      EOF
-
-      as_root systemctl enable --now fail2ban
-      as_root systemctl restart fail2ban
-      EOT
+      local.nat_router_fail2ban_script,
     ]
   }
 }

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -53,7 +53,7 @@ data "cloudinit_config" "nat_router_config" {
         hostname                   = var.nat_router.enable_redundancy ? "nat-router-${count.index}" : "nat-router"
         dns_servers                = var.dns_servers
         has_dns_servers            = local.has_dns_servers
-        sshAuthorizedKeys          = concat([var.ssh_public_key], var.ssh_additional_public_keys)
+        sshAuthorizedKeys          = local.ssh_authorized_keys
         enable_sudo                = var.nat_router.enable_sudo
         enable_redundancy          = var.nat_router.enable_redundancy
         priority                   = count.index == 0 ? 150 : 100

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -144,7 +144,8 @@ resource "hcloud_server" "nat_router" {
 
   lifecycle {
     # Keepalived manages alias IPs during failover.
-    ignore_changes = [network]
+    # Cloud-init is creation-only; upgrade fixes for existing routers must run through terraform_data provisioners.
+    ignore_changes = [network, user_data]
   }
 
 }
@@ -188,7 +189,7 @@ resource "terraform_data" "nat_router_fail2ban" {
 
   triggers_replace = {
     server_id  = hcloud_server.nat_router[count.index].id
-    config_sha = sha256("fail2ban-systemd-ssh-service-v1")
+    config_sha = sha256("fail2ban-systemd-ssh-service-v3")
   }
 
   connection {
@@ -221,7 +222,7 @@ resource "terraform_data" "nat_router_fail2ban" {
       as_root tee /etc/fail2ban/jail.d/sshd.local >/dev/null <<'EOF'
       [sshd]
       enabled = true
-      port = ssh
+      port = ${var.ssh_port}
       backend = systemd
       journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
       maxretry = 5

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -178,3 +178,59 @@ moved {
   from = null_resource.nat_router_await_cloud_init
   to   = terraform_data.nat_router_await_cloud_init
 }
+
+resource "terraform_data" "nat_router_fail2ban" {
+  count = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+
+  depends_on = [
+    terraform_data.nat_router_await_cloud_init,
+  ]
+
+  triggers_replace = {
+    server_id  = hcloud_server.nat_router[count.index].id
+    config_sha = sha256("fail2ban-systemd-ssh-service-v1")
+  }
+
+  connection {
+    user           = var.nat_router.enable_sudo ? "nat-router" : "root"
+    private_key    = var.ssh_private_key
+    agent_identity = local.ssh_agent_identity
+    host           = hcloud_server.nat_router[count.index].ipv4_address
+    port           = var.ssh_port
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOT
+      set -e
+
+      as_root() {
+        if [ "$(id -u)" -eq 0 ]; then
+          "$@"
+        else
+          sudo "$@"
+        fi
+      }
+
+      if ! dpkg -s fail2ban python3-systemd >/dev/null 2>&1; then
+        as_root apt-get update
+        as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y fail2ban python3-systemd
+      fi
+
+      as_root mkdir -p /etc/fail2ban/jail.d
+      as_root tee /etc/fail2ban/jail.d/sshd.local >/dev/null <<'EOF'
+      [sshd]
+      enabled = true
+      port = ssh
+      backend = systemd
+      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
+      maxretry = 5
+      bantime = 86400
+      EOF
+
+      as_root systemctl enable --now fail2ban
+      as_root systemctl restart fail2ban
+      EOT
+    ]
+  }
+}

--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -140,7 +140,6 @@ ${cloudinit_runcmd_common}
   cat <<'  EOF' > /etc/systemd/system/zram.service
   [Unit]
   Description=Swap with zram
-  After=multi-user.target
 
   [Service]
   Type=oneshot

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -2,8 +2,9 @@
 package_reboot_if_required: false
 package_update: true
 package_upgrade: true
-packages: 
+packages:
 - fail2ban
+- python3-systemd
 %{ if enable_redundancy ~}
 - jq
 - keepalived
@@ -40,7 +41,8 @@ write_files:
       [sshd]
       enabled = true
       port = ssh
-      logpath = %(sshd_log)s
+      backend = systemd
+      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
       maxretry = 5
       bantime = 86400
 

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -2,9 +2,8 @@
 package_reboot_if_required: false
 package_update: true
 package_upgrade: true
-packages:
+packages: 
 - fail2ban
-- python3-systemd
 %{ if enable_redundancy ~}
 - jq
 - keepalived
@@ -41,8 +40,7 @@ write_files:
       [sshd]
       enabled = true
       port = ssh
-      backend = systemd
-      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
+      logpath = %(sshd_log)s
       maxretry = 5
       bantime = 86400
 

--- a/templates/nat-router-cloudinit.yaml.tpl
+++ b/templates/nat-router-cloudinit.yaml.tpl
@@ -2,8 +2,9 @@
 package_reboot_if_required: false
 package_update: true
 package_upgrade: true
-packages: 
+packages:
 - fail2ban
+- python3-systemd
 %{ if enable_redundancy ~}
 - jq
 - keepalived
@@ -39,8 +40,9 @@ write_files:
     content: |
       [sshd]
       enabled = true
-      port = ssh
-      logpath = %(sshd_log)s
+      port = ${ ssh_port }
+      backend = systemd
+      journalmatch = _SYSTEMD_UNIT=ssh.service + _COMM=sshd
       maxretry = 5
       bantime = 86400
 
@@ -232,7 +234,8 @@ resolv_conf:
 
 
 runcmd:
-  - [systemctl, 'enable', 'fail2ban']
+  - [systemctl, 'enable', '--now', 'fail2ban']
+  - [systemctl, 'restart', 'fail2ban']
   - [systemctl, 'restart', 'sshd']
   - [systemctl, 'restart', 'networking']
 %{ if enable_redundancy ~}

--- a/variables.tf
+++ b/variables.tf
@@ -174,7 +174,7 @@ variable "nat_router" {
   })
 
   validation {
-    condition     = var.nat_router == null || !var.nat_router.enable_redundancy || var.nat_router.standby_location != ""
+    condition     = var.nat_router == null || !try(var.nat_router.enable_redundancy, false) || try(var.nat_router.standby_location, "") != ""
     error_message = "When nat_router.enable_redundancy is true, standby_location must be provided."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,7 @@ variable "subnet_amount" {
     error_message = "The network CIDR is too small for the requested subnet amount. Reduce subnet_amount or use a larger network."
   }
   validation {
-    condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (var.nat_router.enable_redundancy == false ? 1 : 2))
+    condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
     error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
   }
 }
@@ -186,7 +186,7 @@ variable "nat_router_hcloud_token" {
   sensitive   = true
 
   validation {
-    condition     = var.nat_router == null || !var.nat_router.enable_redundancy || var.nat_router_hcloud_token != ""
+    condition     = var.nat_router == null || !try(var.nat_router.enable_redundancy, false) || var.nat_router_hcloud_token != ""
     error_message = "When nat_router.enable_redundancy is true, nat_router_hcloud_token must be provided."
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = ">= 1.10.1"
   required_providers {
-    github = {
-      source  = "integrations/github"
-      version = ">= 6.4.0"
-    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = ">= 1.59.0"
@@ -12,6 +8,10 @@ terraform {
     local = {
       source  = "hashicorp/local"
       version = ">= 2.5.2"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.5.0"
     }
     ssh = {
       source  = "loafoe/ssh"
@@ -26,9 +26,4 @@ terraform {
       version = ">= 0.7.1"
     }
   }
-}
-
-# Prevent provider picking up `GITHUB_TOKEN` env var and trying to authenticate
-provider "github" {
-  token = ""
 }


### PR DESCRIPTION
## Summary

Prepare the v2.19.3 patch train from `master` with upgrade-safe fixes only.

Included fixes:
- remove the child-module `github` provider block and switch GitHub release lookups to unauthenticated `hashicorp/http` data sources (#2155)
- make NAT router validations null-safe (#2153)
- fix autoscaler zram cloud-init ordering (#2162)
- fix NAT router fail2ban on Debian 12 with `python3-systemd`, journald backend, correct SSH port, and explicit start/restart (#2163)
- reduce MicroOS snapper timeline growth (#2167)
- rework Longhorn volume fstab/resize handling using filesystem UUIDs and resize triggers (#2174, #2180)
- retrigger system-upgrade Plans when drain/eviction flags change (#2172)
- add an explicit HTTPS `/readyz` health check for the control-plane LB TCP service (#2176)
- document existing `hetzner_csi_values` support (#2168)
- document Longhorn RWX/NFS 4.0 workaround (#2169)
- normalize SSH public keys to avoid Hetzner provider apply inconsistencies when using `file(...pub)`
- update project skills to use Codex `gpt-5.5` with `xhigh`

Contributor commits from accepted PRs are preserved in history; Karim-owned fixups are separate commits.

## Credits

Thanks to the contributors whose PRs are included in this patch train:
- @nacholiya for the NAT router null-validation fix (#2153)
- @acschm1d for the autoscaler zram cloud-init deadlock fix (#2162)
- @milesibastos for the Debian 12 NAT router fail2ban fix (#2163)
- @stufently for reducing snapper timeline growth (#2167)
- @amalysh for the Longhorn volume resize trigger fix (#2174)

## Test Plan

- [x] `terraform fmt -recursive`
- [x] `terraform fmt -check -recursive`
- [x] `terraform validate -no-color`
- [x] `git diff --check`
- [x] stale provider/model scans: no `integrations/github`, no `provider "github"`, no `data.github_release`, no old Codex model refs
- [x] `/Volumes/MysticalTech/Code/kube-test`: `terraform init -upgrade -no-color`
- [x] `/Volumes/MysticalTech/Code/kube-test`: targeted apply of `module.kube-hetzner.hcloud_ssh_key.k3s` to verify SSH public key normalization fixes the HCloud provider inconsistency
- [x] `/Volumes/MysticalTech/Code/kube-test`: `terraform plan -no-color` now reaches a normal plan: `22 to add, 0 to change, 0 to destroy`

## Release Notes

Target release: `v2.19.3`. Do not tag automatically from this PR.