### PR TITLE
fix(kustomize): vendor kured manifest via data.http to avoid github.com release-asset URL bug

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -25,6 +25,19 @@ data "http" "kured_release" {
   }
 }
 
+# Fetch the kured base manifest at plan time so kustomize on the control
+# plane reads it from a local file under /var/post_install/ instead of
+# from `https://github.com/kubereboot/kured/releases/download/...`.
+# Kustomize >=5 mis-detects github.com release-asset URLs as git
+# repository sources and fails `kubectl apply -k` with
+# `URL is a git repository`. Following the redirect server-side via
+# `data "http"` returns the YAML body, which we then upload as a flat
+# file (see init.tf) and reference by name in
+# `local.kustomization_backup_yaml.resources` (locals.tf).
+data "http" "kured_manifest" {
+  url = "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-${local.kured_yaml_suffix}.yaml"
+}
+
 data "http" "calico_release" {
   count = var.calico_version == null && var.cni_plugin == "calico" ? 1 : 0
   url   = "https://api.github.com/repos/projectcalico/calico/releases/latest"

--- a/init.tf
+++ b/init.tf
@@ -493,6 +493,16 @@ resource "terraform_data" "kustomization" {
     destination = "/var/post_install/rancher.yaml"
   }
 
+  # Upload the kured base manifest (DaemonSet + RBAC) fetched at plan
+  # time by data.http.kured_manifest. Pairs with the `kured-base.yaml`
+  # entry in local.kustomization_backup_yaml.resources; the kured.yaml
+  # uploaded just below is the patch overlay that injects
+  # `local.kured_options` as DaemonSet container args.
+  provisioner "file" {
+    content     = data.http.kured_manifest.response_body
+    destination = "/var/post_install/kured-base.yaml"
+  }
+
   provisioner "file" {
     content = templatefile(
       "${path.module}/templates/kured.yaml.tpl",

--- a/locals.tf
+++ b/locals.tf
@@ -203,7 +203,11 @@ locals {
     kind       = "Kustomization"
     resources = concat(
       [
-        "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-${local.kured_yaml_suffix}.yaml",
+        # kured base manifest is fetched at plan time via data.http and
+        # uploaded as a local file (see data.tf and init.tf). Inlining the
+        # github.com release-asset URL here breaks `kubectl apply -k` on
+        # kustomize >=5, which mis-detects it as a git repository source.
+        "kured-base.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
         "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
       ],


### PR DESCRIPTION
## Why

\`kustomize\` >=5 mis-detects URLs of the form \`https://github.com/{owner}/{repo}/releases/download/.../X.yaml\` as **git repository** sources, refuses to fetch them as plain files, and fails the post-install hook (\`kubectl apply -k /var/post_install\`) with:

\`\`\`
accumulating resources from
'https://github.com/kubereboot/kured/releases/download/X/kured-X-combined.yaml':
URL is a git repository
\`\`\`

This blocks every \`terraform apply\` that triggers a \`terraform_data.kustomization\` recreate (e.g. nodepool changes that mutate helm values, source / module bumps), making downstream cluster work intermittently impossible.

The current \`locals.tf::kustomization_backup_yaml\` references the kured release asset directly, so any cluster running on a recent k3s ships a \`kubectl\` whose bundled kustomize trips this case. Hit on a real cluster today.

## What

- New \`data \"http\" \"kured_manifest\"\` in \`data.tf\` that fetches the kured manifest server-side at plan time. \`data.http\` transparently follows the github.com release-asset 302 redirect to \`objects.githubusercontent.com\`, returning the YAML body — kustomize never sees the github.com URL.
- Upload the fetched body to \`/var/post_install/kured-base.yaml\` via a \`provisioner \"file\"\` in the \`terraform_data.kustomization\` resource, alongside the existing kured patch overlay upload.
- Reference it by file name (\`\"kured-base.yaml\"\`) from \`local.kustomization_backup_yaml.resources\` instead of the URL.

The existing \`kured.yaml\` patch overlay (\`local.kured_options\` → DaemonSet container args) is unchanged.

## Behaviour

- No new variables.
- No change for users: \`var.kured_version\`, \`local.kured_yaml_suffix\`, and the \`data.http.kured_release\` version-discovery lookup all continue to determine which kured version is fetched.
- Same suffix logic respected (\`-combined.yaml\` for >= 1.20.0, \`-dockerhub.yaml\` for older).

## Diff size

3 files, +28 / -1 lines. Reviewable in a minute.

## Follow-up (intentionally out of scope)

The same \`https://github.com/.../releases/download/...\` pattern appears for:
- hetzner CCM (\`ccm-networks.yaml\` when \`hetzner_ccm_use_helm = false\`)
- rancher \`system-upgrade-controller\` (\`system-upgrade-controller.yaml\` and \`crd.yaml\`)

They could be migrated identically. Left out here to keep this PR minimal and reviewable; happy to open follow-up PRs if this approach is accepted.

## Test plan

- [x] Patch applied locally on a fork of master and pushed.
- [x] Verified \`data.http.kured_manifest.response_body\` returns the kured YAML at plan time (github.com 302 → objects.githubusercontent.com is followed transparently).
- [ ] Apply on a fresh cluster and confirm \`kubectl apply -k /var/post_install\` no longer hits the \`URL is a git repository\` error.