### PR TITLE
fix(autoscaler): mount cluster-config as Secret-file to bypass ARG_MAX limit on >=6 nodepools

### DIFF
--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -84,8 +84,14 @@ resource "terraform_data" "configure_autoscaler" {
   }
 
   # Create/Apply the definition
+  # Server-side apply avoids the 256 KB limit on the
+  # `kubectl.kubernetes.io/last-applied-configuration` annotation that
+  # client-side apply writes to every resource. With our cluster-autoscaler-
+  # config Secret holding the full pool-config JSON (can grow to hundreds
+  # of KB), client-side apply would fail with
+  # "metadata.annotations: Too long: may not be more than 262144 bytes".
   provisioner "remote-exec" {
-    inline = ["kubectl apply -f /tmp/autoscaler.yaml"]
+    inline = ["kubectl apply --server-side --force-conflicts -f /tmp/autoscaler.yaml"]
   }
 
   depends_on = [

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -42,6 +42,7 @@ locals {
       ipv4_subnet_id                             = data.hcloud_network.k3s.id
       snapshot_id                                = local.first_nodepool_snapshot_id
       cluster_config                             = base64encode(jsonencode(local.cluster_config))
+      cluster_config_sha256                      = sha256(jsonencode(local.cluster_config))
       firewall_id                                = hcloud_firewall.k3s.id
       cluster_name                               = local.cluster_prefix
       node_pools                                 = var.autoscaler_nodepools

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -117,6 +117,23 @@ subjects:
     namespace: kube-system
 
 ---
+# Cluster-Autoscaler-Config als Secret statt env-Variable.
+# Hintergrund: HCLOUD_CLUSTER_CONFIG enthält pro Pool eine ~22 KB cloud-init-
+# Kopie (~99% identisch über Pools). Bei ≥6 Pools überschreitet die env-Var
+# das Linux-Kernel-Limit MAX_ARG_STRLEN (128 KB) → CA-Pod failt mit
+# "exec ./cluster-autoscaler: argument list too long".
+# File-Mount via Secret umgeht das Limit komplett (Secrets dürfen 1 MB groß
+# sein). Der CA-Code unterstützt das bereits via HCLOUD_CLUSTER_CONFIG_FILE
+# (siehe cloudprovider/hetzner/hetzner_manager.go).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-autoscaler-config
+  namespace: kube-system
+type: Opaque
+data:
+  config.json: ${cluster_config}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -186,8 +203,11 @@ spec:
                   key: token
           - name: HCLOUD_CLOUD_INIT
             value: ${cloudinit_config}
-          - name: HCLOUD_CLUSTER_CONFIG
-            value: ${cluster_config}
+          # HCLOUD_CLUSTER_CONFIG_FILE statt HCLOUD_CLUSTER_CONFIG (env-Var):
+          # umgeht Linux MAX_ARG_STRLEN (128 KB) → keine Pool-Anzahl-Begrenzung
+          # mehr durch env-Var-Size. Siehe Secret cluster-autoscaler-config oben.
+          - name: HCLOUD_CLUSTER_CONFIG_FILE
+            value: /etc/hetzner-autoscaler/config.json
           - name: HCLOUD_SSH_KEY
             value: '${ssh_key}'
           - name: HCLOUD_IMAGE
@@ -208,8 +228,17 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+            - name: cluster-config
+              mountPath: /etc/hetzner-autoscaler
+              readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs" # right place on MicroOS?
+        - name: cluster-config
+          secret:
+            secretName: cluster-autoscaler-config
+            items:
+              - key: config.json
+                path: config.json

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -117,19 +117,22 @@ subjects:
     namespace: kube-system
 
 ---
-# Cluster-Autoscaler-Config als Secret statt env-Variable.
-# Hintergrund: HCLOUD_CLUSTER_CONFIG enthält pro Pool eine ~22 KB cloud-init-
-# Kopie (~99% identisch über Pools). Bei ≥6 Pools überschreitet die env-Var
-# das Linux-Kernel-Limit MAX_ARG_STRLEN (128 KB) → CA-Pod failt mit
+# Cluster-Autoscaler config as a Secret instead of an env var.
+# Background: HCLOUD_CLUSTER_CONFIG carries a ~22 KB cloud-init copy per
+# pool (~99% identical across pools). With ≥6 pools the env var exceeds the
+# Linux kernel limit MAX_ARG_STRLEN (128 KB) and the CA pod fails with
 # "exec ./cluster-autoscaler: argument list too long".
-# File-Mount via Secret umgeht das Limit komplett (Secrets dürfen 1 MB groß
-# sein). Der CA-Code unterstützt das bereits via HCLOUD_CLUSTER_CONFIG_FILE
-# (siehe cloudprovider/hetzner/hetzner_manager.go).
+# File-mount via Secret bypasses the limit entirely (Secrets are capped at
+# 1 MB). The CA already supports this via HCLOUD_CLUSTER_CONFIG_FILE
+# (see cloudprovider/hetzner/hetzner_manager.go).
 apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-autoscaler-config
   namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 type: Opaque
 data:
   config.json: ${cluster_config}
@@ -153,6 +156,13 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
+        # Rolling-restart trigger: when the cluster-autoscaler-config Secret
+        # content changes (new pool added, cloud-init updated, etc.), this
+        # checksum changes too → the pod template hash changes → Deployment
+        # rolls the pod automatically. Without this, the CA would keep running
+        # against the stale config until manually restarted, since it only
+        # reads HCLOUD_CLUSTER_CONFIG_FILE at startup.
+        checksum/config: '${cluster_config_sha256}'
     spec:
       serviceAccountName: cluster-autoscaler
       tolerations:
@@ -203,9 +213,10 @@ spec:
                   key: token
           - name: HCLOUD_CLOUD_INIT
             value: ${cloudinit_config}
-          # HCLOUD_CLUSTER_CONFIG_FILE statt HCLOUD_CLUSTER_CONFIG (env-Var):
-          # umgeht Linux MAX_ARG_STRLEN (128 KB) → keine Pool-Anzahl-Begrenzung
-          # mehr durch env-Var-Size. Siehe Secret cluster-autoscaler-config oben.
+          # HCLOUD_CLUSTER_CONFIG_FILE instead of HCLOUD_CLUSTER_CONFIG (env var):
+          # bypasses the Linux MAX_ARG_STRLEN limit (128 KB), so the number of
+          # autoscaler nodepools is no longer constrained by env-var size.
+          # See the cluster-autoscaler-config Secret above.
           - name: HCLOUD_CLUSTER_CONFIG_FILE
             value: /etc/hetzner-autoscaler/config.json
           - name: HCLOUD_SSH_KEY


### PR DESCRIPTION
Fixes #2194

## TL;DR

`HCLOUD_CLUSTER_CONFIG` is currently passed to the cluster-autoscaler pod as an inline env-var. With ≥6-7 `autoscaler_nodepools` the env-var exceeds the **Linux Kernel hard limit of `MAX_ARG_STRLEN = 128 KB`** (32 × 4 KB pages, hard-coded since 2.6.23) and the pod crashes with:

```
exec ./cluster-autoscaler: argument list too long
```

This PR switches the deployment template to **mount the config as a file via a Kubernetes Secret** and points the CA to it with `HCLOUD_CLUSTER_CONFIG_FILE`. The CA upstream already supports this env-var (`cloudprovider/hetzner/hetzner_manager.go`) — **no upstream Go change required**.

## The Root Cause

Each pool's `nodeConfigs[poolName].cloudInit` carries the full **~22 KB cloud-init** (gzip+base64-encoded). With more than a handful of pools, sizes pile up:

| Pools | base64 env size | failed? |
|---|---|---|
| 4 | ~66 KB | no |
| 7 | 132 KB | **yes** |
| 10 | 198 KB | **yes** |
| 17 | ~340 KB | **yes** |

Verified on a real cluster: across pools the cloud-init is **almost entirely redundant**. Only the ARM pool differed slightly; the three x86 pools had byte-identical cloud-init:

```
canou-prod-worker-cax11  size=22375  sha256=297afe964e93a6e3
canou-prod-worker-cpx21  size=22347  sha256=cdca23fa21b2ad00
canou-prod-worker-cpx22  size=22347  sha256=cdca23fa21b2ad00
canou-prod-worker-cx23   size=22347  sha256=cdca23fa21b2ad00
```

A proper deduplication (cloud-init-by-arch + per-pool ref) would be even better, but requires a coordinated change in the upstream cluster-autoscaler Go provider. The file-mount approach achieves the same practical effect (no ARG_MAX hit, no pool-count limit) **using machinery the upstream CA already supports**, without coordinating two repos.

## What's in the patch

`templates/autoscaler.yaml.tpl`:
- Add a `Secret` named `cluster-autoscaler-config` in `kube-system` carrying the config as `config.json` (base64 just as before).
- Replace the `HCLOUD_CLUSTER_CONFIG` env-var with `HCLOUD_CLUSTER_CONFIG_FILE` pointing to `/etc/hetzner-autoscaler/config.json`.
- Mount the Secret read-only at that path.

`autoscaler-agents.tf`:
- Switch the provisioner from client-side `kubectl apply` to **`kubectl apply --server-side --force-conflicts`**. Client-side apply writes the entire manifest into `kubectl.kubernetes.io/last-applied-configuration` (limit 256 KB), which fails for the same reason on multi-pool clusters:

```
The Secret "cluster-autoscaler-config" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

Server-side apply uses managed-fields ownership tracking, no annotation size limit. `--force-conflicts` ensures a smooth transition from any client-side-managed state of pre-existing resources.

## Verified

- **Local cluster**: 17 autoscaler_nodepools (max_cores=16, full cx/cax/cpx cascade), CA `Running 1/1`, secret `cluster-autoscaler-config` mounted, env shows `HCLOUD_CLUSTER_CONFIG_FILE=/etc/hetzner-autoscaler/config.json`. Cluster-autoscaler logs show successful reflector watches across all node groups, no `argument list too long` errors.
- **kube-hetzner version**: v2.19.3
- **k3s**: 1.35.4
- **CA image**: `registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0`

## Backwards compatibility

The legacy `HCLOUD_CLUSTER_CONFIG` env-var is removed in favor of `HCLOUD_CLUSTER_CONFIG_FILE`. The upstream CA accepts either since [autoscaler/pull/6649](https://github.com/kubernetes/autoscaler/pull/6649) (2024-04); both code paths exist in current `v1.30+` images.

Users will see one additional Kubernetes Secret (~22 KB to a few hundred KB) appear in `kube-system`. The previous `HCLOUD_CLUSTER_CONFIG` env-var disappears from the deployment spec.