### PR TITLE
fix: kured DaemonSet schedules on all nodes regardless of taints

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -103,7 +103,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
   listen_port      = "6443"
 
   health_check {
-    protocol = "https"
+    protocol = "http"
     port     = 6443
     interval = tonumber(trimsuffix(var.load_balancer_health_check_interval, "s"))
     timeout  = tonumber(trimsuffix(var.load_balancer_health_check_timeout, "s"))
@@ -111,7 +111,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
 
     http {
       path         = "/readyz"
-      tls          = false
+      tls          = true
       status_codes = ["200", "401"]
     }
   }

--- a/init.tf
+++ b/init.tf
@@ -299,6 +299,7 @@ resource "terraform_data" "kustomization" {
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"
     ])
+    kured_template_sha             = filesha256("${path.module}/templates/kured.yaml.tpl")
     ccm_use_helm                   = var.hetzner_ccm_use_helm
     system_upgrade_schedule_window = jsonencode(var.system_upgrade_schedule_window)
     system_upgrade_use_drain       = tostring(var.system_upgrade_use_drain)

--- a/templates/kured.yaml.tpl
+++ b/templates/kured.yaml.tpl
@@ -14,6 +14,8 @@ spec:
         name: kured
     spec:
       serviceAccountName: kured
+      tolerations:
+        - operator: Exists
       containers:
         - name: kured
           command:


### PR DESCRIPTION
Noticed that some node pools didn't get reboots / new kernel after the recent CopyFail vulnerabilities... Investigation why is the reason of this PR.

The kured DaemonSet ships with only two tolerations (node-role.kubernetes.io/control-plane and .../master), so any node carrying a user-defined taint — e.g. dedicated=gpu:NoSchedule or workload=ml:NoExecute — silently drops out of kured's coverage and never gets auto-rebooted after kernel updates.

This patches the kured kustomize overlay with a universal toleration ({operator: Exists}) so it runs on every node, matching the pattern Cilium already uses for the same reason. kured is node-level infrastructure with no node it shouldn't run on.

Also patches the #2188 issue