### PR TITLE
fix(control-plane-lb): use protocol="http" with tls=true (Hetzner API rejects "https")

### DIFF
--- a/control_planes.tf
+++ b/control_planes.tf
@@ -103,7 +103,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
   listen_port      = "6443"
 
   health_check {
-    protocol = "https"
+    protocol = "http"
     port     = 6443
     interval = tonumber(trimsuffix(var.load_balancer_health_check_interval, "s"))
     timeout  = tonumber(trimsuffix(var.load_balancer_health_check_timeout, "s"))
@@ -111,7 +111,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
 
     http {
       path         = "/readyz"
-      tls          = false
+      tls          = true
       status_codes = ["200", "401"]
     }
   }


### PR DESCRIPTION
## What

Changes `hcloud_load_balancer_service.control_plane`'s `health_check.protocol` from `"https"` to `"http"`, and sets `http.tls = true`. The original behavior intent (HTTPS health check against `/readyz`, accepting `200` or `401`) is preserved.

## Why

The Hetzner Cloud LB API only accepts `protocol = "tcp"` or `protocol = "http"`. There is no `"https"` enum value — HTTPS is expressed as `protocol = "http"` with the nested `http.tls = true` flag. Apply with the current `"https"` value fails:

```
Error: invalid input in field 'health_check' (invalid_input, ...):
  [health_check.protocol => [Not a valid choice.]]
  with module.kube-hetzner.hcloud_load_balancer_service.control_plane[0],
  on .terraform/modules/kube-hetzner/control_planes.tf line 97
```

This regression was introduced in v2.19.3 (commit 7fa297eb, "prepare v2.19.3 patch train"). v2.19.2 had no `health_check` block on the CP LB service and worked via the LB's default TCP health checking.

Fixes #2188
Fixes #2199

## Testing

Verified locally against a Hetzner Cloud project with `use_control_plane_lb = true` on an existing 3-node CP cluster. With the patch applied, `hcloud_load_balancer_service.control_plane` is created successfully and the LB's health check shows the CP targets healthy within ~30 seconds.