### PR TITLE
fix(nat-router): drop deprecated assignee_type from hcloud_primary_ip

### DIFF
--- a/nat-router.tf
+++ b/nat-router.tf
@@ -114,12 +114,11 @@ resource "hcloud_network_route" "nat_route_public_internet" {
 resource "hcloud_primary_ip" "nat_router_primary_ipv4" {
   # explicitly declare the ipv4 address, such that the address
   # is stable against possible replacements of the nat router
-  count         = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
-  type          = "ipv4"
-  name          = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv4" : "${var.cluster_name}-nat-router-ipv4"
-  location      = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
-  auto_delete   = false
-  assignee_type = "server"
+  count       = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+  type        = "ipv4"
+  name        = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv4" : "${var.cluster_name}-nat-router-ipv4"
+  location    = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
+  auto_delete = false
 
   # Prevent recreation when user changes location after initial creation
   lifecycle {
@@ -130,12 +129,11 @@ resource "hcloud_primary_ip" "nat_router_primary_ipv4" {
 resource "hcloud_primary_ip" "nat_router_primary_ipv6" {
   # explicitly declare the ipv6 address, such that the address
   # is stable against possible replacements of the nat router
-  count         = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
-  type          = "ipv6"
-  name          = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv6" : "${var.cluster_name}-nat-router-ipv6"
-  location      = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
-  auto_delete   = false
-  assignee_type = "server"
+  count       = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+  type        = "ipv6"
+  name        = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv6" : "${var.cluster_name}-nat-router-ipv6"
+  location    = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
+  auto_delete = false
 
   # Prevent recreation when user changes location after initial creation
   lifecycle {


### PR DESCRIPTION
## What

Removes `assignee_type = \"server\"` from `hcloud_primary_ip.nat_router_primary_ipv4` and `hcloud_primary_ip.nat_router_primary_ipv6` in `nat-router.tf`. No other behavioral change.

## Why

The hcloud provider [v1.62.0](https://github.com/hetznercloud/terraform-provider-hcloud/releases/tag/v1.62.0) made `assignee_type` optional on `hcloud_primary_ip` and now emits a warning whenever it's set without a corresponding `assignee_id`:

```
Warning: Unused Attribute

  with module.kube-hetzner.hcloud_primary_ip.nat_router_primary_ipv4,
  on .terraform/modules/kube-hetzner/nat-router.tf line 122, in resource \"hcloud_primary_ip\" \"nat_router_primary_ipv4\":
 122:   assignee_type = \"server\"

This attribute is now optional and is only required together with the assignee_id attribute. Please remove it from your configuration.
```

(And the same warning fires for the IPv6 resource one block below.)

In this module's NAT-router setup, the Primary IPs are attached to the server later via `hcloud_server.public_net`, so `assignee_id` is never set on the `hcloud_primary_ip` resource itself — `assignee_type = \"server\"` here was always informational, never required.

## Future-proofing

Per the [provider changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned), from **2026-08-01** Hetzner will start returning `assignee_type = \"unassigned\"` on unassigned Primary IPs. After that date, hardcoding `\"server\"` on an unassigned IP will produce permanent plan diffs every apply. Removing it now avoids that.

## Testing

- `tofu validate` passes
- `tofu fmt -check` clean (formatting realigned after removing the longer key)
- No functional change — `assignee_type` was never used to drive assignment