### PR TITLE
Add permissions for resource classes and claims

### DIFF
--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -63,6 +63,9 @@ rules:
     resourceNames: ["cluster-autoscaler"]
     resources: ["leases"]
     verbs: ["get", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["deviceclasses", "resourceclaims", "resourceslices"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION

This pull request adds new RBAC permissions to the `templates/autoscaler.yaml.tpl` file, allowing the autoscaler to interact with additional Kubernetes resources. These changes expand the autoscaler's capabilities to support device and resource management.

Upstream change can be found here: https://github.com/kubernetes/autoscaler/blob/d4a3ca1d9bf76b3a4166a4c2ada90d93e6b9ee54/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml#L65

**RBAC Permission Updates:**

* Added permissions for the `deviceclasses`, `resourceclaims`, and `resourceslices` resources in the `resource.k8s.io` API group, with `get`, `list`, and `watch` verbs.