### PR TITLE
fix: make MicroOS snapshot lookup architecture-aware

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -8,7 +8,7 @@ module "agents" {
   for_each = local.agent_nodes
 
   name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}${try(each.value.node_name_suffix, "")}"
-  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -1,12 +1,12 @@
 locals {
   cluster_prefix = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""
   first_nodepool_snapshot_id = length(var.autoscaler_nodepools) == 0 ? "" : (
-    substr(var.autoscaler_nodepools[0].server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+    substr(var.autoscaler_nodepools[0].server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   )
 
   imageList = {
-    arm64 : tostring(data.hcloud_image.microos_arm_snapshot.id)
-    amd64 : tostring(data.hcloud_image.microos_x86_snapshot.id)
+    arm64 : tostring(local.microos_arm_snapshot_id)
+    amd64 : tostring(local.microos_x86_snapshot_id)
   }
 
   nodeConfigName = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -8,7 +8,7 @@ module "control_planes" {
   for_each = local.control_plane_nodes
 
   name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port

--- a/main.tf
+++ b/main.tf
@@ -21,11 +21,11 @@ locals {
   ]) > 0
 
   microos_x86_snapshot_id = var.microos_x86_snapshot_id != "" ? var.microos_x86_snapshot_id : (
-    local.uses_microos_x86_snapshot ? data.hcloud_image.microos_x86_snapshot[0].id : ""
+    join("", data.hcloud_image.microos_x86_snapshot[*].id)
   )
 
   microos_arm_snapshot_id = var.microos_arm_snapshot_id != "" ? var.microos_arm_snapshot_id : (
-    local.uses_microos_arm_snapshot ? data.hcloud_image.microos_arm_snapshot[0].id : ""
+    join("", data.hcloud_image.microos_arm_snapshot[*].id)
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,13 +3,41 @@ resource "random_password" "k3s_token" {
   special = false
 }
 
+locals {
+  microos_nodepool_server_types = concat(
+    [for node in values(local.control_plane_nodes) : node.server_type],
+    [for node in values(local.agent_nodes) : node.server_type],
+    [for nodepool in var.autoscaler_nodepools : nodepool.server_type],
+  )
+
+  uses_microos_arm_snapshot = length([
+    for server_type in local.microos_nodepool_server_types : server_type
+    if substr(server_type, 0, 3) == "cax"
+  ]) > 0
+
+  uses_microos_x86_snapshot = length([
+    for server_type in local.microos_nodepool_server_types : server_type
+    if substr(server_type, 0, 3) != "cax"
+  ]) > 0
+
+  microos_x86_snapshot_id = var.microos_x86_snapshot_id != "" ? var.microos_x86_snapshot_id : (
+    local.uses_microos_x86_snapshot ? data.hcloud_image.microos_x86_snapshot[0].id : ""
+  )
+
+  microos_arm_snapshot_id = var.microos_arm_snapshot_id != "" ? var.microos_arm_snapshot_id : (
+    local.uses_microos_arm_snapshot ? data.hcloud_image.microos_arm_snapshot[0].id : ""
+  )
+}
+
 data "hcloud_image" "microos_x86_snapshot" {
+  count             = var.microos_x86_snapshot_id == "" && local.uses_microos_x86_snapshot ? 1 : 0
   with_selector     = "microos-snapshot=yes"
   with_architecture = "x86"
   most_recent       = true
 }
 
 data "hcloud_image" "microos_arm_snapshot" {
+  count             = var.microos_arm_snapshot_id == "" && local.uses_microos_arm_snapshot ? 1 : 0
   with_selector     = "microos-snapshot=yes"
   with_architecture = "arm"
   most_recent       = true


### PR DESCRIPTION
## What

Make MicroOS snapshot lookup architecture-aware.

Today both `data.hcloud_image.microos_x86_snapshot` and `data.hcloud_image.microos_arm_snapshot` are declared unconditionally. That means an x86-only cluster still fails during plan if no ARM MicroOS snapshot exists, and an ARM-only cluster still fails if no x86 MicroOS snapshot exists. This PR only looks up the snapshot architecture that is actually needed by configured control-plane, agent, or autoscaler nodepools, unless the corresponding explicit `microos_*_snapshot_id` input is already provided.

This keeps the existing behavior for mixed-architecture clusters: if both x86 and ARM nodepools are configured, both snapshots are still required.

## Why

This is the issue shape described in #1259, and it also shows up for the opposite direction in x86-only clusters when ARM/CAX capacity is unavailable. In that case the ARM snapshot cannot be built, but Terraform still fails before it can plan an x86-only cluster because the unused ARM image data source is evaluated.

The failure looks like:

```text
Error: no image found matching the selection

  with data.hcloud_image.microos_arm_snapshot,
  on main.tf line 12, in data "hcloud_image" "microos_arm_snapshot":
  12: data "hcloud_image" "microos_arm_snapshot" {
```

## Validation

- `terraform fmt -recursive -check`
- `git diff --check`
- `terraform init -backend=false -input=false -no-color`
- `terraform validate -no-color`

`terraform validate` still reports the existing unrelated `hcloud_primary_ip.assignee_type` warning.
