### PR TITLE
feat: install Gateway API CRDs when gateway API is enabled

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -34,6 +34,15 @@ data "http" "calico_release" {
   }
 }
 
+data "http" "gateway_api_release" {
+  count = (var.gateway_api_enabled || var.traefik_provider_kubernetes_gateway_enabled) && var.gateway_api_version == null ? 1 : 0
+  url   = "https://api.github.com/repos/kubernetes-sigs/gateway-api/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
+}
+
 data "hcloud_ssh_keys" "keys_by_selector" {
   count         = length(var.ssh_hcloud_key_label) > 0 ? 1 : 0
   with_selector = var.ssh_hcloud_key_label

--- a/init.tf
+++ b/init.tf
@@ -295,6 +295,7 @@ resource "terraform_data" "kustomization" {
       coalesce(var.longhorn_version, "N/A"),
       coalesce(var.rancher_version, "N/A"),
       coalesce(var.sys_upgrade_controller_version, "N/A"),
+      coalesce(var.gateway_api_version, "N/A"),
     ])
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -639,8 +639,8 @@ module "kube-hetzner" {
   # The default is true.
   # traefik_pod_disruption_budget = false
 
-  # Enable kubernetes gateway api (https://doc.traefik.io/traefik/providers/kubernetes-gateway/) provider support.
-  # The default is false.
+  # Enable the Kubernetes Gateway provider in Traefik (https://doc.traefik.io/traefik/providers/kubernetes-gateway/).
+  # Also installs the Gateway API CRDs automatically. The default is false.
   # traefik_provider_kubernetes_gateway_enabled = true
 
   # Enable or disable default resource requests and limits for traefik. Values requested are 100m & 50Mi and limits 300m & 150Mi.
@@ -1001,6 +1001,10 @@ module "kube-hetzner" {
 
   # By default, we allow ICMP ping in to the nodes, to check for liveness for instance. If you do not want to allow that, you can. Just set this flag to true (false by default).
   # block_icmp_ping_in = true
+
+  # Enable the Kubernetes Gateway API CRDs (standard channel). Required for any Gateway API-capable controller.
+  # Automatically enabled when traefik_provider_kubernetes_gateway_enabled is true. The default is false.
+  # gateway_api_enabled = true
 
   # You can enable cert-manager (installed by Helm behind the scenes) with the following flag, the default is "true".
   # enable_cert_manager = false

--- a/locals.tf
+++ b/locals.tf
@@ -219,7 +219,7 @@ locals {
       var.enable_cert_manager || var.enable_rancher ? ["cert_manager.yaml"] : [],
       var.enable_rancher ? ["rancher.yaml"] : [],
       var.rancher_registration_manifest_url != "" ? [var.rancher_registration_manifest_url] : [],
-      local.gateway_api_enabled ? ["https://github.com/kubernetes-sigs/gateway-api/releases/download/${local.gateway_api_version}/standard-install.yaml"] : []
+      local.gateway_api_enabled ? ["https://github.com/kubernetes-sigs/gateway-api/releases/download/${coalesce(local.gateway_api_version, "none")}/standard-install.yaml"] : []
     ),
     patches = concat([
       {

--- a/locals.tf
+++ b/locals.tf
@@ -17,10 +17,12 @@ locals {
   # k3s endpoint used for agent registration, respects control_plane_endpoint override
   k3s_endpoint = coalesce(var.control_plane_endpoint, "https://${var.use_control_plane_lb ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address}:6443")
 
-  ccm_version    = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : jsondecode(data.http.hetzner_ccm_release[0].response_body).tag_name
-  csi_version    = length(data.http.hetzner_csi_release) == 0 ? var.hetzner_csi_version : jsondecode(data.http.hetzner_csi_release[0].response_body).tag_name
-  kured_version  = length(data.http.kured_release) == 0 ? var.kured_version : jsondecode(data.http.kured_release[0].response_body).tag_name
-  calico_version = length(data.http.calico_release) == 0 ? var.calico_version : jsondecode(data.http.calico_release[0].response_body).tag_name
+  ccm_version         = var.hetzner_ccm_version != null ? var.hetzner_ccm_version : jsondecode(data.http.hetzner_ccm_release[0].response_body).tag_name
+  csi_version         = length(data.http.hetzner_csi_release) == 0 ? var.hetzner_csi_version : jsondecode(data.http.hetzner_csi_release[0].response_body).tag_name
+  kured_version       = length(data.http.kured_release) == 0 ? var.kured_version : jsondecode(data.http.kured_release[0].response_body).tag_name
+  calico_version      = length(data.http.calico_release) == 0 ? var.calico_version : jsondecode(data.http.calico_release[0].response_body).tag_name
+  gateway_api_enabled = var.gateway_api_enabled || var.traefik_provider_kubernetes_gateway_enabled
+  gateway_api_version = length(data.http.gateway_api_release) == 0 ? var.gateway_api_version : jsondecode(data.http.gateway_api_release[0].response_body).tag_name
 
   # Determine kured YAML suffix based on version (>= 1.20.0 uses -combined.yaml, < 1.20.0 uses -dockerhub.yaml)
   kured_yaml_suffix = provider::semvers::compare(local.kured_version, "1.20.0") >= 0 ? "combined" : "dockerhub"
@@ -216,7 +218,8 @@ locals {
       var.enable_csi_driver_smb ? ["csi-driver-smb.yaml"] : [],
       var.enable_cert_manager || var.enable_rancher ? ["cert_manager.yaml"] : [],
       var.enable_rancher ? ["rancher.yaml"] : [],
-      var.rancher_registration_manifest_url != "" ? [var.rancher_registration_manifest_url] : []
+      var.rancher_registration_manifest_url != "" ? [var.rancher_registration_manifest_url] : [],
+      local.gateway_api_enabled ? ["https://github.com/kubernetes-sigs/gateway-api/releases/download/${local.gateway_api_version}/standard-install.yaml"] : []
     ),
     patches = concat([
       {

--- a/variables.tf
+++ b/variables.tf
@@ -1153,6 +1153,18 @@ variable "csi_driver_smb_values" {
   description = "Additional helm values file to pass to csi-driver-smb as 'valuesContent' at the HelmChart."
 }
 
+variable "gateway_api_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable the Kubernetes Gateway API CRDs (standard channel). Default is false."
+}
+
+variable "gateway_api_version" {
+  type        = string
+  default     = null
+  description = "Version of the Gateway API CRDs. See https://github.com/kubernetes-sigs/gateway-api/releases for available versions."
+}
+
 variable "enable_cert_manager" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Summary

- Fixes a gap where `traefik_provider_kubernetes_gateway_enabled = true` configured Traefik's gateway provider without installing the required Gateway API CRDs, causing Traefik to crash on startup
- Adds `gateway_api_enabled` to install the standard-channel CRDs independently of any specific controller (also works with Cilium, cert-manager, etc.)
- Enabling `traefik_provider_kubernetes_gateway_enabled = true` automatically implies `gateway_api_enabled`, so existing users get the fix with no config changes required

## Changes

- New `gateway_api_enabled` variable — installs Gateway API CRDs (standard channel), auto-fetches latest version from GitHub
- New `gateway_api_version` variable — optional version pin
- CRDs installed via upstream manifest URL, consistent with how `kured` and `system-upgrade-controller` are handled
- `kube.tf.example` updated with `gateway_api_enabled` example and updated Traefik gateway comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)