### PR TITLE
Prepare v2.20.0 candidate fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### ⚠️ Upgrade Notes
+
+- **Cluster Autoscaler Config File** - Autoscaler nodepools now mount the generated Hetzner cluster config through a Secret-backed file to avoid Kubernetes annotation size failures on large configurations. If `autoscaler_nodepools` is enabled and you override `cluster_autoscaler_version`, use `v1.33.0` or newer. The module default remains compatible.
+
+### 🚀 New Features
+
+- **Autoscaler DRA Permissions** - Added read-only Cluster Autoscaler RBAC for Kubernetes Dynamic Resource Allocation resources (`deviceclasses`, `resourceclaims`, `resourceslices`) (#2202).
+
+### 🐛 Bug Fixes
+
+- **Control Plane LB Health Check** - Fixed the Hetzner control-plane load balancer health check to use HTTP protocol with TLS enabled for the Kubernetes `/readyz` endpoint, avoiding invalid `https` protocol validation failures (#2188, #2199, #2200, #2205).
+- **Terraform 1.11 Null Validation Compatibility** - Fixed null-safe NAT router and flannel backend validation paths so Terraform 1.11 can initialize and validate default configurations without `nat_router` or `flannel_backend` set (#2197).
+- **Subnet Validation Contract** - Preserved hard validation for `subnet_amount` and `network_ipv4_cidr` cross-variable constraints without using Terraform variable validations that fail during module initialization under Terraform 1.11.
+- **NAT Router Primary IP Drift** - Removed the deprecated fixed `assignee_type` argument from NAT router primary IP resources to avoid provider warnings and future drift (#2201).
+- **MicroOS Snapshot Lookup** - Made default MicroOS snapshot lookup architecture-aware so ARM autoscaler pools do not depend on x86-only snapshot data sources (#2206).
+- **Autoscaler Large Configs** - Moved large autoscaler cluster config JSON out of the Deployment environment and into a mounted Secret file, and switched apply to server-side field management to avoid annotation size limits (#2194, #2195).
+- **Kured on Tainted Nodes** - Added a universal toleration to Kured so OS reboot management still runs on tainted nodes (#2196).
+- **Kustomize Release Assets** - Upload Kured, system-upgrade-controller, and non-Helm CCM release manifests locally before running Kustomize, avoiding remote-base build failures on nodes without sufficient network access (#2186).
+
+### 📚 Documentation
+
+- Clarified Cluster Autoscaler scale-down behavior for pods using local storage and the safe overrides available for intentional eviction (#2187).
+- Clarified that `ingress_controller = "nginx"` installs Kubernetes ingress-nginx, not the F5 NGINX Ingress Controller; use `ingress_controller = "none"` when installing F5 independently (#2204).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Clarified Cluster Autoscaler scale-down behavior for pods using local storage and the safe overrides available for intentional eviction (#2187).
 - Clarified that `ingress_controller = "nginx"` installs Kubernetes ingress-nginx, not the F5 NGINX Ingress Controller; use `ingress_controller = "none"` when installing F5 independently (#2204).
+- Fixed the `kube.tf.example` HA control-plane example so every nodepool name is unique and the example validates as a root Terraform configuration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Enable with `autoscaler_nodepools`. Powered by [Cluster Autoscaler](https://gith
 
 > ⚠️ Autoscaled nodes use a snapshot from the initial control plane. Ensure disk sizes match.
 
+Cluster Autoscaler will not scale down nodes that run pods with local storage unless explicitly configured to do so. For disposable local data, add `--skip-nodes-with-local-storage=false` to `cluster_autoscaler_extra_args` or annotate individual pods with `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`.
+
 ---
 
 ## 🛡️ High Availability
@@ -556,6 +558,8 @@ spec:
 [Full Traefik + Cert-Manager guide](https://traefik.io/blog/secure-web-applications-with-traefik-proxy-cert-manager-and-lets-encrypt/)
 
 > **Ingress-Nginx with HTTP challenge:** Add `lb_hostname = "cluster.example.org"` to work around [this known issue](https://github.com/cert-manager/cert-manager/issues/466).
+
+> **F5 NGINX Ingress Controller:** `ingress_controller = "nginx"` installs the Kubernetes ingress-nginx controller. To run the F5 controller, set `ingress_controller = "none"` and install F5's chart separately.
 </details>
 
 <details>

--- a/agents.tf
+++ b/agents.tf
@@ -8,7 +8,7 @@ module "agents" {
   for_each = local.agent_nodes
 
   name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}${try(each.value.node_name_suffix, "")}"
-  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -92,16 +92,31 @@ resource "terraform_data" "configure_autoscaler" {
   # of KB), client-side apply would fail with
   # "metadata.annotations: Too long: may not be more than 262144 bytes".
   provisioner "remote-exec" {
-    inline = ["kubectl apply --server-side --force-conflicts -f /tmp/autoscaler.yaml"]
+    inline = ["kubectl apply --server-side --field-manager=kube-hetzner --force-conflicts -f /tmp/autoscaler.yaml"]
   }
 
   depends_on = [
+    terraform_data.autoscaler_version_contract,
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
     random_password.rancher_bootstrap,
     hcloud_volume.longhorn_volume
   ]
 }
+
+resource "terraform_data" "autoscaler_version_contract" {
+  count = length(var.autoscaler_nodepools) > 0 ? 1 : 0
+
+  input = var.cluster_autoscaler_version
+
+  lifecycle {
+    precondition {
+      condition     = try(provider::semvers::compare(trimprefix(var.cluster_autoscaler_version, "v"), "1.33.0"), -1) >= 0
+      error_message = "autoscaler_nodepools require cluster_autoscaler_version v1.33.0 or newer because kube-hetzner mounts the Hetzner cluster config through HCLOUD_CLUSTER_CONFIG_FILE."
+    }
+  }
+}
+
 moved {
   from = null_resource.configure_autoscaler
   to   = terraform_data.configure_autoscaler

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -84,8 +84,14 @@ resource "terraform_data" "configure_autoscaler" {
   }
 
   # Create/Apply the definition
+  # Server-side apply avoids the 256 KB limit on the
+  # `kubectl.kubernetes.io/last-applied-configuration` annotation that
+  # client-side apply writes to every resource. With our cluster-autoscaler-
+  # config Secret holding the full pool-config JSON (can grow to hundreds
+  # of KB), client-side apply would fail with
+  # "metadata.annotations: Too long: may not be more than 262144 bytes".
   provisioner "remote-exec" {
-    inline = ["kubectl apply -f /tmp/autoscaler.yaml"]
+    inline = ["kubectl apply --server-side --force-conflicts -f /tmp/autoscaler.yaml"]
   }
 
   depends_on = [

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -92,8 +92,7 @@ resource "terraform_data" "configure_autoscaler" {
     hcloud_load_balancer.cluster,
     terraform_data.control_planes,
     random_password.rancher_bootstrap,
-    hcloud_volume.longhorn_volume,
-    data.hcloud_image.microos_x86_snapshot
+    hcloud_volume.longhorn_volume
   ]
 }
 moved {

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -1,12 +1,12 @@
 locals {
   cluster_prefix = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""
   first_nodepool_snapshot_id = length(var.autoscaler_nodepools) == 0 ? "" : (
-    substr(var.autoscaler_nodepools[0].server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+    substr(var.autoscaler_nodepools[0].server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   )
 
   imageList = {
-    arm64 : tostring(data.hcloud_image.microos_arm_snapshot.id)
-    amd64 : tostring(data.hcloud_image.microos_x86_snapshot.id)
+    arm64 : tostring(local.microos_arm_snapshot_id)
+    amd64 : tostring(local.microos_x86_snapshot_id)
   }
 
   nodeConfigName = var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -42,6 +42,7 @@ locals {
       ipv4_subnet_id                             = data.hcloud_network.k3s.id
       snapshot_id                                = local.first_nodepool_snapshot_id
       cluster_config                             = base64encode(jsonencode(local.cluster_config))
+      cluster_config_sha256                      = sha256(jsonencode(local.cluster_config))
       firewall_id                                = hcloud_firewall.k3s.id
       cluster_name                               = local.cluster_prefix
       node_pools                                 = var.autoscaler_nodepools

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -8,7 +8,7 @@ module "control_planes" {
   for_each = local.control_plane_nodes
 
   name                             = "${var.use_cluster_name_in_node_name ? "${var.cluster_name}-" : ""}${each.value.nodepool_name}"
-  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.microos_arm_snapshot.id : data.hcloud_image.microos_x86_snapshot.id
+  microos_snapshot_id              = substr(each.value.server_type, 0, 3) == "cax" ? local.microos_arm_snapshot_id : local.microos_x86_snapshot_id
   base_domain                      = var.base_domain
   ssh_keys                         = length(var.ssh_hcloud_key_label) > 0 ? concat([local.hcloud_ssh_key_id], data.hcloud_ssh_keys.keys_by_selector[0].ssh_keys.*.id) : [local.hcloud_ssh_key_id]
   ssh_port                         = var.ssh_port

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -103,7 +103,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
   listen_port      = "6443"
 
   health_check {
-    protocol = "https"
+    protocol = "http"
     port     = 6443
     interval = tonumber(trimsuffix(var.load_balancer_health_check_interval, "s"))
     timeout  = tonumber(trimsuffix(var.load_balancer_health_check_timeout, "s"))
@@ -111,7 +111,7 @@ resource "hcloud_load_balancer_service" "control_plane" {
 
     http {
       path         = "/readyz"
-      tls          = false
+      tls          = true
       status_codes = ["200", "401"]
     }
   }

--- a/data.tf
+++ b/data.tf
@@ -25,6 +25,23 @@ data "http" "kured_release" {
   }
 }
 
+data "http" "kured_manifest" {
+  url = "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-${local.kured_yaml_suffix}.yaml"
+}
+
+data "http" "system_upgrade_controller_manifest" {
+  url = "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml"
+}
+
+data "http" "system_upgrade_controller_crd_manifest" {
+  url = "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
+}
+
+data "http" "ccm_networks_manifest" {
+  count = var.hetzner_ccm_use_helm ? 0 : 1
+  url   = "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"
+}
+
 data "http" "calico_release" {
   count = var.calico_version == null && var.cni_plugin == "calico" ? 1 : 0
   url   = "https://api.github.com/repos/projectcalico/calico/releases/latest"

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -757,6 +757,7 @@ The example shows three control plane nodepools, each with one node, in differen
   * **Enabling:** Simply defining at least one map in this list will trigger the deployment of the Cluster Autoscaler components in your cluster.
   * **Architecture Constraint (⚠️):** "you can only choose either x86 instances or ARM server types for ALL autoscaler nodepools." This implies a limitation in how the module or the Hetzner cloud provider for Cluster Autoscaler handles mixed-architecture autoscaling groups. You must commit to one architecture (e.g., all `cx` series or all `cax` series) for the pools managed by the autoscaler.
   * **Labels/Taints Versioning (⚠️):** The ability to set `labels` and `taints` directly in the `autoscaler_nodepools` definition depends on using a sufficiently new version of the Cluster Autoscaler image.
+  * **Local Storage Scale-Down:** Cluster Autoscaler does not remove nodes that run pods with local storage by default. For workloads where local data is disposable, use `cluster_autoscaler_extra_args = ["--skip-nodes-with-local-storage=false"]` or annotate only the relevant pods with `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`.
   * **Nodepool Attributes (per map within `autoscaler_nodepools`):**
     * **`name` (String, Obligatory):** A unique name for this autoscaled nodepool.
     * **`server_type` (String, Obligatory):** The Hetzner server type for nodes created in this pool (e.g., `cx33`, `cax21`). Must adhere to the single-architecture constraint mentioned above.
@@ -1201,6 +1202,7 @@ Excellent! Let's continue our meticulous dissection.
     * `"nginx"`: Deploys the [Ingress-NGINX controller](https://kubernetes.github.io/ingress-nginx/), a popular and robust choice based on NGINX.
     * `"haproxy"`: Deploys an Ingress controller based on [HAProxy](https://www.haproxy.org/), known for high performance and reliability.
     * `"none"`: Disables the automatic deployment of any Ingress controller by this module. You would then be responsible for installing one manually if needed.
+  * **F5 NGINX Note:** `"nginx"` means the Kubernetes ingress-nginx controller, not the F5 NGINX Ingress Controller. For F5, set `ingress_controller = "none"` and install F5's chart separately.
   * **Module's Role:** The module typically deploys the chosen controller using its Helm chart and applies some Hetzner-specific optimal configurations (e.g., annotations for the Hetzner Load Balancer).
   * **Customization:** Further customization is possible via `traefik_values`, `nginx_values`, or `haproxy_values` blocks (discussed later).
 * **`ingress_target_namespace` (String, Optional):**

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,11 +15,11 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | >= 1.59.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 3.5.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.5.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.4.0 |
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.64.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.6.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
@@ -89,6 +89,7 @@
 | [terraform_data.authentication_config](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.autoscaled_nodes_kubelet_config](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.autoscaled_nodes_registries](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.autoscaler_version_contract](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.configure_autoscaler](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.configure_floating_ip](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.configure_longhorn_volume](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
@@ -101,6 +102,7 @@
 | [terraform_data.kustomization_user_deploy](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.nat_router_await_cloud_init](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.nat_router_fail2ban](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.subnet_contract](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [cloudinit_config.autoscaler_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.autoscaler_legacy_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [cloudinit_config.nat_router_config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
@@ -110,9 +112,13 @@
 | [hcloud_servers.autoscaled_nodes](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/servers) | data source |
 | [hcloud_ssh_keys.keys_by_selector](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/data-sources/ssh_keys) | data source |
 | [http_http.calico_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.ccm_networks_manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.hetzner_ccm_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.hetzner_csi_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.kured_manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.kured_release](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.system_upgrade_controller_crd_manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.system_upgrade_controller_manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ### Inputs
 

--- a/init.tf
+++ b/init.tf
@@ -299,6 +299,14 @@ resource "terraform_data" "kustomization" {
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"
     ])
+    upstream_release_manifest_sha = sha256(join("\n", concat(
+      [
+        data.http.kured_manifest.response_body,
+        data.http.system_upgrade_controller_manifest.response_body,
+        data.http.system_upgrade_controller_crd_manifest.response_body,
+      ],
+      data.http.ccm_networks_manifest[*].response_body
+    )))
     kured_template_sha             = filesha256("${path.module}/templates/kured.yaml.tpl")
     ccm_use_helm                   = var.hetzner_ccm_use_helm
     system_upgrade_schedule_window = jsonencode(var.system_upgrade_schedule_window)
@@ -492,6 +500,28 @@ resource "terraform_data" "kustomization" {
         values                  = indent(4, local.rancher_values)
     })
     destination = "/var/post_install/rancher.yaml"
+  }
+
+  # Upload release-asset manifests as local files because kustomize >= 5
+  # treats GitHub releases/download URLs as git repository sources.
+  provisioner "file" {
+    content     = data.http.kured_manifest.response_body
+    destination = "/var/post_install/kured-base.yaml"
+  }
+
+  provisioner "file" {
+    content     = data.http.system_upgrade_controller_manifest.response_body
+    destination = "/var/post_install/system-upgrade-controller.yaml"
+  }
+
+  provisioner "file" {
+    content     = data.http.system_upgrade_controller_crd_manifest.response_body
+    destination = "/var/post_install/system-upgrade-controller-crd.yaml"
+  }
+
+  provisioner "file" {
+    content     = var.hetzner_ccm_use_helm ? "# unused when hetzner_ccm_use_helm=true\n" : data.http.ccm_networks_manifest[0].response_body
+    destination = "/var/post_install/ccm-networks.yaml"
   }
 
   provisioner "file" {

--- a/init.tf
+++ b/init.tf
@@ -79,6 +79,25 @@ locals {
   )
 }
 
+resource "terraform_data" "subnet_contract" {
+  input = {
+    network_ipv4_cidr = var.network_ipv4_cidr
+    subnet_amount     = var.subnet_amount
+  }
+
+  lifecycle {
+    precondition {
+      condition     = pow(2, 32 - tonumber(split("/", var.network_ipv4_cidr)[1])) >= var.subnet_amount
+      error_message = "The network CIDR is too small for the requested subnet amount. Reduce subnet_amount or use a larger network."
+    }
+
+    precondition {
+      condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
+      error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
+    }
+  }
+}
+
 resource "terraform_data" "first_control_plane" {
   connection {
     user           = "root"

--- a/init.tf
+++ b/init.tf
@@ -95,6 +95,16 @@ resource "terraform_data" "subnet_contract" {
       condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
       error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
     }
+
+    precondition {
+      condition     = var.nat_router == null || var.nat_router_subnet_index < var.subnet_amount
+      error_message = "NAT router subnet index must be lower than subnet_amount when nat_router is enabled."
+    }
+
+    precondition {
+      condition     = var.vswitch_id == null || var.vswitch_subnet_index < var.subnet_amount
+      error_message = "vSwitch subnet index must be lower than subnet_amount when vswitch_id is set."
+    }
   }
 }
 

--- a/init.tf
+++ b/init.tf
@@ -549,7 +549,7 @@ resource "terraform_data" "kustomization" {
   }
 
   provisioner "file" {
-    content     = var.hetzner_ccm_use_helm ? "# unused when hetzner_ccm_use_helm=true\n" : data.http.ccm_networks_manifest[0].response_body
+    content     = var.hetzner_ccm_use_helm ? "# unused when hetzner_ccm_use_helm=true\n" : one(data.http.ccm_networks_manifest[*].response_body)
     destination = "/var/post_install/ccm-networks.yaml"
   }
 

--- a/init.tf
+++ b/init.tf
@@ -299,6 +299,7 @@ resource "terraform_data" "kustomization" {
     options = join("\n", [
       for option, value in local.kured_options : "${option}=${value}"
     ])
+    kured_template_sha             = filesha256("${path.module}/templates/kured.yaml.tpl")
     ccm_use_helm                   = var.hetzner_ccm_use_helm
     system_upgrade_schedule_window = jsonencode(var.system_upgrade_schedule_window)
     system_upgrade_use_drain       = tostring(var.system_upgrade_use_drain)

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -151,9 +151,9 @@ module "kube-hetzner" {
       # disable_ipv6 = true
     },
     {
-      name        = "control-plane-nbg1",
+      name        = "control-plane-fsn1",
       server_type = "cx23",
-      location    = "nbg1",
+      location    = "fsn1",
       labels      = [],
       taints      = [],
       count       = 1

--- a/locals.tf
+++ b/locals.tf
@@ -203,11 +203,11 @@ locals {
     kind       = "Kustomization"
     resources = concat(
       [
-        "https://github.com/kubereboot/kured/releases/download/${local.kured_version}/kured-${local.kured_version}-${local.kured_yaml_suffix}.yaml",
-        "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/system-upgrade-controller.yaml",
-        "https://github.com/rancher/system-upgrade-controller/releases/download/${var.sys_upgrade_controller_version}/crd.yaml"
+        "kured-base.yaml",
+        "system-upgrade-controller.yaml",
+        "system-upgrade-controller-crd.yaml"
       ],
-      var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/${local.ccm_version}/ccm-networks.yaml"],
+      var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       lookup(local.cni_install_resources, var.cni_plugin, []),

--- a/locals.tf
+++ b/locals.tf
@@ -1393,21 +1393,6 @@ EOT
 
 }
 
-# Cross-variable validations that can't be done in variable validation blocks
-check "network_cidr_supports_subnet_amount" {
-  assert {
-    condition     = pow(2, 32 - tonumber(split("/", var.network_ipv4_cidr)[1])) >= var.subnet_amount
-    error_message = "The network CIDR is too small for the requested subnet amount. Reduce subnet_amount or use a larger network."
-  }
-}
-
-check "subnet_amount_covers_nodepools_and_nat_router" {
-  assert {
-    condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
-    error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
-  }
-}
-
 check "nat_router_requires_control_plane_lb" {
   assert {
     condition     = var.nat_router == null || var.use_control_plane_lb

--- a/locals.tf
+++ b/locals.tf
@@ -1394,6 +1394,20 @@ EOT
 }
 
 # Cross-variable validations that can't be done in variable validation blocks
+check "network_cidr_supports_subnet_amount" {
+  assert {
+    condition     = pow(2, 32 - tonumber(split("/", var.network_ipv4_cidr)[1])) >= var.subnet_amount
+    error_message = "The network CIDR is too small for the requested subnet amount. Reduce subnet_amount or use a larger network."
+  }
+}
+
+check "subnet_amount_covers_nodepools_and_nat_router" {
+  assert {
+    condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
+    error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
+  }
+}
+
 check "nat_router_requires_control_plane_lb" {
   assert {
     condition     = var.nat_router == null || var.use_control_plane_lb

--- a/main.tf
+++ b/main.tf
@@ -21,11 +21,11 @@ locals {
   ]) > 0
 
   microos_x86_snapshot_id = var.microos_x86_snapshot_id != "" ? var.microos_x86_snapshot_id : (
-    local.uses_microos_x86_snapshot ? data.hcloud_image.microos_x86_snapshot[0].id : ""
+    join("", data.hcloud_image.microos_x86_snapshot[*].id)
   )
 
   microos_arm_snapshot_id = var.microos_arm_snapshot_id != "" ? var.microos_arm_snapshot_id : (
-    local.uses_microos_arm_snapshot ? data.hcloud_image.microos_arm_snapshot[0].id : ""
+    join("", data.hcloud_image.microos_arm_snapshot[*].id)
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,13 +3,41 @@ resource "random_password" "k3s_token" {
   special = false
 }
 
+locals {
+  microos_nodepool_server_types = concat(
+    [for node in values(local.control_plane_nodes) : node.server_type],
+    [for node in values(local.agent_nodes) : node.server_type],
+    [for nodepool in var.autoscaler_nodepools : nodepool.server_type],
+  )
+
+  uses_microos_arm_snapshot = length([
+    for server_type in local.microos_nodepool_server_types : server_type
+    if substr(server_type, 0, 3) == "cax"
+  ]) > 0
+
+  uses_microos_x86_snapshot = length([
+    for server_type in local.microos_nodepool_server_types : server_type
+    if substr(server_type, 0, 3) != "cax"
+  ]) > 0
+
+  microos_x86_snapshot_id = var.microos_x86_snapshot_id != "" ? var.microos_x86_snapshot_id : (
+    local.uses_microos_x86_snapshot ? data.hcloud_image.microos_x86_snapshot[0].id : ""
+  )
+
+  microos_arm_snapshot_id = var.microos_arm_snapshot_id != "" ? var.microos_arm_snapshot_id : (
+    local.uses_microos_arm_snapshot ? data.hcloud_image.microos_arm_snapshot[0].id : ""
+  )
+}
+
 data "hcloud_image" "microos_x86_snapshot" {
+  count             = var.microos_x86_snapshot_id == "" && local.uses_microos_x86_snapshot ? 1 : 0
   with_selector     = "microos-snapshot=yes"
   with_architecture = "x86"
   most_recent       = true
 }
 
 data "hcloud_image" "microos_arm_snapshot" {
+  count             = var.microos_arm_snapshot_id == "" && local.uses_microos_arm_snapshot ? 1 : 0
   with_selector     = "microos-snapshot=yes"
   with_architecture = "arm"
   most_recent       = true

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -2,7 +2,7 @@ locals {
   nat_gateway_ip = var.nat_router != null ? cidrhost(hcloud_network_subnet.nat_router[0].ip_range, 1) : ""
 
   nat_router_ip = (
-    var.nat_router != null && var.nat_router.enable_redundancy ?
+    try(var.nat_router.enable_redundancy, false) ?
     {
       0 = cidrhost(hcloud_network_subnet.nat_router[0].ip_range, 2),
       1 = cidrhost(hcloud_network_subnet.nat_router[0].ip_range, 3)
@@ -48,7 +48,7 @@ EOT
 }
 
 resource "random_string" "nat_router" {
-  count = var.nat_router != null && var.nat_router.enable_redundancy ? 2 : 0
+  count = try(var.nat_router.enable_redundancy, false) ? 2 : 0
 
   length  = 3
   lower   = true
@@ -63,7 +63,7 @@ resource "random_string" "nat_router" {
 }
 
 resource "random_password" "nat_router_vip_auth_pass" {
-  count   = var.nat_router != null && var.nat_router.enable_redundancy ? 1 : 0
+  count   = try(var.nat_router.enable_redundancy, false) ? 1 : 0
   length  = 8
   special = false
 }

--- a/nat-router.tf
+++ b/nat-router.tf
@@ -114,12 +114,11 @@ resource "hcloud_network_route" "nat_route_public_internet" {
 resource "hcloud_primary_ip" "nat_router_primary_ipv4" {
   # explicitly declare the ipv4 address, such that the address
   # is stable against possible replacements of the nat router
-  count         = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
-  type          = "ipv4"
-  name          = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv4" : "${var.cluster_name}-nat-router-ipv4"
-  location      = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
-  auto_delete   = false
-  assignee_type = "server"
+  count       = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+  type        = "ipv4"
+  name        = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv4" : "${var.cluster_name}-nat-router-ipv4"
+  location    = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
+  auto_delete = false
 
   # Prevent recreation when user changes location after initial creation
   lifecycle {
@@ -130,12 +129,11 @@ resource "hcloud_primary_ip" "nat_router_primary_ipv4" {
 resource "hcloud_primary_ip" "nat_router_primary_ipv6" {
   # explicitly declare the ipv6 address, such that the address
   # is stable against possible replacements of the nat router
-  count         = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
-  type          = "ipv6"
-  name          = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv6" : "${var.cluster_name}-nat-router-ipv6"
-  location      = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
-  auto_delete   = false
-  assignee_type = "server"
+  count       = var.nat_router != null ? (var.nat_router.enable_redundancy ? 2 : 1) : 0
+  type        = "ipv6"
+  name        = var.nat_router.enable_redundancy ? "${local.nat_router_name}-${random_string.nat_router[count.index].id}-ipv6" : "${var.cluster_name}-nat-router-ipv6"
+  location    = var.nat_router.enable_redundancy && count.index == 1 ? var.nat_router.standby_location : var.nat_router.location
+  auto_delete = false
 
   # Prevent recreation when user changes location after initial creation
   lifecycle {

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -117,6 +117,23 @@ subjects:
     namespace: kube-system
 
 ---
+# Cluster-Autoscaler-Config als Secret statt env-Variable.
+# Hintergrund: HCLOUD_CLUSTER_CONFIG enthält pro Pool eine ~22 KB cloud-init-
+# Kopie (~99% identisch über Pools). Bei ≥6 Pools überschreitet die env-Var
+# das Linux-Kernel-Limit MAX_ARG_STRLEN (128 KB) → CA-Pod failt mit
+# "exec ./cluster-autoscaler: argument list too long".
+# File-Mount via Secret umgeht das Limit komplett (Secrets dürfen 1 MB groß
+# sein). Der CA-Code unterstützt das bereits via HCLOUD_CLUSTER_CONFIG_FILE
+# (siehe cloudprovider/hetzner/hetzner_manager.go).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-autoscaler-config
+  namespace: kube-system
+type: Opaque
+data:
+  config.json: ${cluster_config}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -186,8 +203,11 @@ spec:
                   key: token
           - name: HCLOUD_CLOUD_INIT
             value: ${cloudinit_config}
-          - name: HCLOUD_CLUSTER_CONFIG
-            value: ${cluster_config}
+          # HCLOUD_CLUSTER_CONFIG_FILE statt HCLOUD_CLUSTER_CONFIG (env-Var):
+          # umgeht Linux MAX_ARG_STRLEN (128 KB) → keine Pool-Anzahl-Begrenzung
+          # mehr durch env-Var-Size. Siehe Secret cluster-autoscaler-config oben.
+          - name: HCLOUD_CLUSTER_CONFIG_FILE
+            value: /etc/hetzner-autoscaler/config.json
           - name: HCLOUD_SSH_KEY
             value: '${ssh_key}'
           - name: HCLOUD_IMAGE
@@ -208,8 +228,17 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+            - name: cluster-config
+              mountPath: /etc/hetzner-autoscaler
+              readOnly: true
           imagePullPolicy: "Always"
       volumes:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs" # right place on MicroOS?
+        - name: cluster-config
+          secret:
+            secretName: cluster-autoscaler-config
+            items:
+              - key: config.json
+                path: config.json

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -63,6 +63,9 @@ rules:
     resourceNames: ["cluster-autoscaler"]
     resources: ["leases"]
     verbs: ["get", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["deviceclasses", "resourceclaims", "resourceslices"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/templates/autoscaler.yaml.tpl
+++ b/templates/autoscaler.yaml.tpl
@@ -117,19 +117,22 @@ subjects:
     namespace: kube-system
 
 ---
-# Cluster-Autoscaler-Config als Secret statt env-Variable.
-# Hintergrund: HCLOUD_CLUSTER_CONFIG enthält pro Pool eine ~22 KB cloud-init-
-# Kopie (~99% identisch über Pools). Bei ≥6 Pools überschreitet die env-Var
-# das Linux-Kernel-Limit MAX_ARG_STRLEN (128 KB) → CA-Pod failt mit
+# Cluster-Autoscaler config as a Secret instead of an env var.
+# Background: HCLOUD_CLUSTER_CONFIG carries a ~22 KB cloud-init copy per
+# pool (~99% identical across pools). With ≥6 pools the env var exceeds the
+# Linux kernel limit MAX_ARG_STRLEN (128 KB) and the CA pod fails with
 # "exec ./cluster-autoscaler: argument list too long".
-# File-Mount via Secret umgeht das Limit komplett (Secrets dürfen 1 MB groß
-# sein). Der CA-Code unterstützt das bereits via HCLOUD_CLUSTER_CONFIG_FILE
-# (siehe cloudprovider/hetzner/hetzner_manager.go).
+# File-mount via Secret bypasses the limit entirely (Secrets are capped at
+# 1 MB). The CA already supports this via HCLOUD_CLUSTER_CONFIG_FILE
+# (see cloudprovider/hetzner/hetzner_manager.go).
 apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-autoscaler-config
   namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 type: Opaque
 data:
   config.json: ${cluster_config}
@@ -153,6 +156,13 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'
+        # Rolling-restart trigger: when the cluster-autoscaler-config Secret
+        # content changes (new pool added, cloud-init updated, etc.), this
+        # checksum changes too → the pod template hash changes → Deployment
+        # rolls the pod automatically. Without this, the CA would keep running
+        # against the stale config until manually restarted, since it only
+        # reads HCLOUD_CLUSTER_CONFIG_FILE at startup.
+        checksum/config: '${cluster_config_sha256}'
     spec:
       serviceAccountName: cluster-autoscaler
       tolerations:
@@ -203,9 +213,10 @@ spec:
                   key: token
           - name: HCLOUD_CLOUD_INIT
             value: ${cloudinit_config}
-          # HCLOUD_CLUSTER_CONFIG_FILE statt HCLOUD_CLUSTER_CONFIG (env-Var):
-          # umgeht Linux MAX_ARG_STRLEN (128 KB) → keine Pool-Anzahl-Begrenzung
-          # mehr durch env-Var-Size. Siehe Secret cluster-autoscaler-config oben.
+          # HCLOUD_CLUSTER_CONFIG_FILE instead of HCLOUD_CLUSTER_CONFIG (env var):
+          # bypasses the Linux MAX_ARG_STRLEN limit (128 KB), so the number of
+          # autoscaler nodepools is no longer constrained by env-var size.
+          # See the cluster-autoscaler-config Secret above.
           - name: HCLOUD_CLUSTER_CONFIG_FILE
             value: /etc/hetzner-autoscaler/config.json
           - name: HCLOUD_SSH_KEY

--- a/templates/kured.yaml.tpl
+++ b/templates/kured.yaml.tpl
@@ -14,6 +14,8 @@ spec:
         name: kured
     spec:
       serviceAccountName: kured
+      tolerations:
+        - operator: Exists
       containers:
         - name: kured
           command:

--- a/variables.tf
+++ b/variables.tf
@@ -188,8 +188,8 @@ variable "nat_router_subnet_index" {
   description = "Subnet index for NAT router. Default 200 is safe for most deployments. Must not conflict with control plane (counting down from 255) or agent pools (counting up from 0)."
 
   validation {
-    condition     = var.nat_router_subnet_index >= 0 && var.nat_router_subnet_index < var.subnet_amount
-    error_message = "NAT router subnet index must be between 0 and subnet_amount."
+    condition     = var.nat_router_subnet_index >= 0
+    error_message = "NAT router subnet index must be zero or greater."
   }
 }
 
@@ -199,8 +199,8 @@ variable "vswitch_subnet_index" {
   description = "Subnet index (0-255) for vSwitch. Default 201 is safe for most deployments. Must not conflict with control plane (counting down from 255) or agent pools (counting up from 0)."
 
   validation {
-    condition     = var.vswitch_subnet_index >= 0 && var.vswitch_subnet_index <= 255
-    error_message = "vSwitch subnet index must be between 0 and 255."
+    condition     = var.vswitch_subnet_index >= 0
+    error_message = "vSwitch subnet index must be zero or greater."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1410,7 +1410,7 @@ variable "flannel_backend" {
   description = "Override the flannel backend used by k3s. When set, this takes precedence over enable_wireguard. Valid values: vxlan, host-gw, wireguard-native. See https://docs.k3s.io/networking/basic-network-options for details. Use wireguard-native for Robot nodes with vSwitch to avoid MTU issues."
 
   validation {
-    condition     = var.flannel_backend == null || contains(["vxlan", "host-gw", "wireguard-native"], var.flannel_backend)
+    condition     = var.flannel_backend == null ? true : contains(["vxlan", "host-gw", "wireguard-native"], var.flannel_backend)
     error_message = "The flannel_backend must be one of: vxlan, host-gw, wireguard-native."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -130,15 +130,6 @@ variable "subnet_amount" {
     condition     = floor(log(var.subnet_amount, 2)) == log(var.subnet_amount, 2)
     error_message = "Subnet amount must be a power of 2."
   }
-  validation {
-    # Host bits = 32 - prefix, must have enough bits to create subnet_amount subnets
-    condition     = pow(2, 32 - tonumber(split("/", var.network_ipv4_cidr)[1])) >= var.subnet_amount
-    error_message = "The network CIDR is too small for the requested subnet amount. Reduce subnet_amount or use a larger network."
-  }
-  validation {
-    condition     = var.subnet_amount >= length(var.control_plane_nodepools) + length(var.agent_nodepools) + (var.nat_router == null ? 0 : (try(var.nat_router.enable_redundancy, false) ? 2 : 1))
-    error_message = "Subnet amount must be large enough so that a subnet for each agent pool, each control plane pool and (if enabled) the nat router can be created in the network."
-  }
 }
 
 variable "cluster_ipv4_cidr" {


### PR DESCRIPTION
## Summary

Prepares the current-major v2.20.0 candidate by integrating the safe, backward-compatible fixes from the current open issue/PR sweep:

- fixes Hetzner control-plane load balancer health checks by using HTTP checks with TLS enabled
- removes the deprecated NAT-router primary IP `assignee_type`
- hardens Terraform 1.11+ validation paths for nullable NAT and Flannel inputs
- adds DRA RBAC for Cluster Autoscaler
- makes Leap Micro snapshot lookup architecture-aware
- mounts large Cluster Autoscaler config as a Secret-backed file for v1.33+
- schedules kured on tainted nodes
- vendors release-asset manifests locally to avoid kustomize remote URL failures
- preserves subnet-index validation without breaking disabled NAT/vSwitch configurations
- updates changelog/docs/examples for the accepted fixes

Fixes #2188.
Fixes #2194.
Fixes #2197.
Fixes #2199.
Fixes #2205.

Supersedes accepted changes from #2186, #2195, #2196, #2200, #2201, #2202, and #2206.

## Verification

- [x] `terraform fmt -recursive`
- [x] null-resource/provider ban
- [x] `terraform init -backend=false -input=false -no-color`
- [x] `terraform validate -no-color`
- [x] `tfsec --ignore-hcl-errors .`
- [x] OpenTofu temp-copy init/validate
- [x] `kube.tf.example` parse validation
- [x] Terraform 1.11.1 repro for #2197 on master, then verified fixed on this branch
- [x] autoscaler v1.32 negative guard verifies `HCLOUD_CLUSTER_CONFIG_FILE` requires v1.33+
- [x] #2186 targeted HTTP data plan and local kustomization render checks
- [x] NAT/vSwitch subnet-index negative precondition checks
- [x] `/Volumes/MysticalTech/Code/kube-test` temp-copy `terraform init -upgrade` and `terraform plan -detailed-exitcode` with no destroy/replace actions
- [x] Gemini whole-diff review: ALL CLEAR
- [x] Codex CLI xhigh review: ALL CLEAR

## Compatibility

This branch is scoped to current-major-safe changes. No resource removals, state migrations, required variable additions, default-breaking behavior changes, or expected resource replacement were accepted.
