### PR TITLE
fix: install Gateway API CRDs before Traefik when gateway provider is enabled

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -209,6 +209,7 @@ locals {
       ],
       var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
+      var.traefik_provider_kubernetes_gateway_enabled ? ["https://github.com/kubernetes-sigs/gateway-api/releases/download/${var.gateway_api_version}/standard-install.yaml"] : [],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
       lookup(local.cni_install_resources, var.cni_plugin, []),
       var.cni_plugin == "flannel" ? ["flannel-rbac.yaml"] : [],

--- a/variables.tf
+++ b/variables.tf
@@ -650,6 +650,13 @@ variable "traefik_provider_kubernetes_gateway_enabled" {
   description = "Should traefik enable the kubernetes gateway provider. Default is false."
 }
 
+variable "gateway_api_version" {
+  type        = string
+  nullable    = false
+  default     = "v1.5.1"
+  description = "Version of the Kubernetes Gateway API CRDs to install when traefik_provider_kubernetes_gateway_enabled is true. See https://github.com/kubernetes-sigs/gateway-api/releases for available versions."
+}
+
 variable "traefik_resource_limits" {
   type        = bool
   default     = true


### PR DESCRIPTION
When traefik_provider_kubernetes_gateway_enabled is true, the Traefik Helm chart creates GatewayClass and Gateway resources that require the gateway.networking.k8s.io/v1 CRDs to already exist. Without them the helm-install-traefik job crashes with 'no matches for kind GatewayClass', the Traefik service is never created, and the 'Waiting for load-balancer to get an IP' loop times out, failing the entire apply.

Adds the Gateway API standard-install manifest to the main kustomization resources, ordered before the ingress controller entry so the CRDs are established before the Traefik HelmChart job runs. A gateway_api_version variable (default v1.2.1) allows pinning the CRD version.