### PR TITLE
feat: add configurable kubectl apply options for user kustomization

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,10 @@ Change folder name with `extra_kustomize_folder`. See [example](examples/kustomi
 <details>
 <summary><strong>Custom post-install actions (ArgoCD, etc.)</strong></summary>
 
-For CRD-dependent applications:
+For CRD-dependent applications (use `kustomize_apply_options` with `--server-side` when CRDs hit the annotation size limit):
 
 ```tf
+kustomize_apply_options = "--server-side --field-manager=kube-hetzner --force-conflicts --wait=true"
 extra_kustomize_deployment_commands = <<-EOT
   kubectl -n argocd wait --for condition=established --timeout=120s crd/appprojects.argoproj.io
   kubectl -n argocd wait --for condition=established --timeout=120s crd/applications.argoproj.io

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -2332,9 +2332,17 @@ Locked and loaded! Let's continue the detailed exploration.
 **Section 2.21: Kustomize and Post-Deployment Operations**
 
 ```terraform
+  # Flags for `kubectl apply` when deploying user kustomization (e.g. large CRDs that exceed the annotation size limit).
+  # kustomize_apply_options = "--server-side --field-manager=kube-hetzner --force-conflicts --wait=true"
+
   # Extra commands to be executed after the `kubectl apply -k` (useful for post-install actions, e.g. wait for CRD, apply additional manifests, etc.).
   # extra_kustomize_deployment_commands=""
 ```
+
+* **`kustomize_apply_options` (String, Optional):**
+  * **Default:** `"--wait=true"`
+  * **Purpose:** Extra flags appended to the user kustomization `kubectl apply -k <dir>` command.
+  * **Use Case:** Server-side apply for large CRDs (e.g. Argo CD `ApplicationSet`) that exceed the 262144-byte `last-applied-configuration` annotation limit.
 
 * **`extra_kustomize_deployment_commands` (String or List of Strings, Optional):**
   * **Purpose:** Allows you to specify shell commands that will be executed *after* the module has run its main Kustomize deployment (which applies manifests for core components like CCM, CSI, Ingress, etc., based on your selections).

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -1096,6 +1096,9 @@ module "kube-hetzner" {
   # More information about the registration can be found here https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/registered-clusters/
   # rancher_registration_manifest_url = "https://rancher.xyz.dev/v3/import/xxxxxxxxxxxxxxxxxxYYYYYYYYYYYYYYYYYYYzzzzzzzzzzzzzzzzzzzzz.yaml"
 
+  # Flags for `kubectl apply` when deploying user kustomization (e.g. large CRDs that exceed the annotation size limit).
+  # kustomize_apply_options = "--wait=true --server-side --field-manager=kube-hetzner --force-conflicts"
+
   # Extra commands to be executed after the `kubectl apply -k` (useful for post-install actions, e.g. wait for CRD, apply additional manifests, etc.).
   # extra_kustomize_deployment_commands=""
 

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -66,7 +66,7 @@ resource "terraform_data" "kustomization_user_deploy" {
     inline = compact([
       "rm -f /var/user_kustomize/**/*.yaml.tpl",
       "echo 'Applying user kustomization...'",
-      "kubectl apply -k /var/user_kustomize/ --wait=true",
+      "kubectl apply -k /var/user_kustomize/ ${var.kustomize_apply_options}",
       var.extra_kustomize_deployment_commands
     ])
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1353,6 +1353,12 @@ variable "postinstall_exec" {
 }
 
 
+variable "kustomize_apply_options" {
+  type        = string
+  default     = "--wait=true"
+  description = "Flags passed to `kubectl apply` when deploying user kustomization (e.g. `--server-side --field-manager=kube-hetzner --force-conflicts --wait=true`)."
+}
+
 variable "extra_kustomize_deployment_commands" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Add configurable `kubectl apply` options for user kustomization

### Problem

When deploying large CRDs (e.g. Argo CD `applicationsets.argoproj.io`), client-side `kubectl apply` can fail with:
```
metadata.annotations: Too long: may not be more than 262144 bytes
```


This happens because kubectl stores the full manifest in the `kubectl.kubernetes.io/last-applied-configuration` annotation, which has a 262144-byte limit. **Server-side apply** avoids that.

### Solution

The hardcoded apply command in `kustomization_user.tf`:

```hcl
kubectl apply -k /var/user_kustomize/ --wait=true
```
is now:

```hcl
kubectl apply -k /var/user_kustomize/ ${var.kustomize_apply_options}
```

New variable kustomize_apply_options (default: "--wait=true") — existing behavior is unchanged unless overridden.



NON-AI MY COMMENT

you can try to install this or this:
  - https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.crds.yaml
  - https://github.com/argoproj/argo-cd/manifests/crds?ref=v3.4.4