### PR TITLE
feat: kube_apiserver_args passthrough for raw apiserver config

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -614,7 +614,8 @@ locals {
       "audit-log-maxage=${var.k3s_audit_log_maxage}",
       "audit-log-maxbackup=${var.k3s_audit_log_maxbackup}",
       "audit-log-maxsize=${var.k3s_audit_log_maxsize}"
-    ] : []
+    ] : [],
+    var.kube_apiserver_args
   )
 
   cilium_values_default = <<EOT

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "authentication_config" {
   default     = ""
 }
 
+variable "kube_apiserver_args" {
+  description = "Additional raw kube-apiserver args appended to the control-plane config.yaml (kube-apiserver-arg), e.g. [\"service-account-issuer=https://...\", \"service-account-jwks-uri=https://...\"]. Applied in-place via the k3s config-update script (no node recreation)."
+  type        = list(string)
+  default     = []
+}
+
 variable "hcloud_ssh_key_id" {
   description = "If passed, a key already registered within hetzner is used. Otherwise, a new one will be created by the module."
   type        = string


### PR DESCRIPTION
Adds an optional `kube_apiserver_args` list appended to the control-plane `config.yaml` `kube-apiserver-arg`, so operators can set arbitrary apiserver flags (e.g. `service-account-issuer`/`service-account-jwks-uri` for OIDC workload identity) that apply **in-place** via the existing k3s config-update script — no control-plane node recreation. Mirrors the existing `authentication_config` / `k3s_audit_policy_config` pattern (same `local.kube_apiserver_arg` concat). Default `[]` = no behavior change.