### PR TITLE
fix(agents): order agents after kustomization and surface start failures

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -154,15 +154,18 @@ resource "terraform_data" "agents" {
   # Start the k3s agent and wait for it to have started
   provisioner "remote-exec" {
     inline = concat(var.enable_longhorn || var.enable_iscsid ? ["systemctl enable --now iscsid"] : [], [
-      "timeout 120 systemctl start k3s-agent 2> /dev/null",
       <<-EOT
-      timeout 120 bash <<EOF
-        until systemctl status k3s-agent > /dev/null; do
-          systemctl start k3s-agent 2> /dev/null
-          echo "Waiting for the k3s agent to start..."
-          sleep 2
-        done
-      EOF
+      # Clear any failed unit state left by a prior attempt so the start is not
+      # blocked by start-limit rate limiting, then kick the agent off without
+      # blocking and wait for it to actually settle.
+      systemctl reset-failed k3s-agent 2> /dev/null || true
+      systemctl start --no-block k3s-agent
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
+        echo "ERROR: k3s-agent did not become active within 600s. Dumping diagnostics:" >&2
+        systemctl status k3s-agent --no-pager -l || true
+        journalctl -u k3s-agent -n 80 --no-pager || true
+        exit 1
+      fi
       EOT
     ])
   }
@@ -170,7 +173,15 @@ resource "terraform_data" "agents" {
   depends_on = [
     terraform_data.first_control_plane,
     terraform_data.agent_config,
-    hcloud_network_subnet.agent
+    hcloud_network_subnet.agent,
+    # CCM (deployed by the kustomization) is what untaints freshly-joined
+    # agents. Without this edge, agents start concurrently with the
+    # kustomization and race the untaint, so k3s-agent never settles and the
+    # start provisioner times out (exit 124) on a fresh single apply.
+    # No cycle: terraform_data.kustomization depends only on control_planes,
+    # the load balancer, rancher_bootstrap, longhorn_volume and
+    # kube_system_secrets - none of which depend on terraform_data.agents.
+    terraform_data.kustomization
   ]
 }
 moved {

--- a/agents.tf
+++ b/agents.tf
@@ -160,7 +160,7 @@ resource "terraform_data" "agents" {
       # blocking and wait for it to actually settle.
       systemctl reset-failed k3s-agent 2> /dev/null || true
       systemctl start --no-block k3s-agent
-      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do if systemctl is-failed --quiet k3s-agent; then exit 1; fi; echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
         echo "ERROR: k3s-agent did not become active within 600s. Dumping diagnostics:" >&2
         systemctl status k3s-agent --no-pager -l || true
         journalctl -u k3s-agent -n 80 --no-pager || true


### PR DESCRIPTION
Fixes #2215

> **Draft pending maintainer steer.** On the issue I asked whether this should land on `master` (current-major) or also be mirrored to `staging`/v3 (#2147). This PR proceeds on `master` since that's the current-major branch and the fix applies cleanly there, but I'm keeping it **draft** until you confirm branch/scope — happy to also open a `staging`/v3 mirror (the v3 `agents.tf` still has both halves of this bug).

## Problem

On a fresh single apply, agent nodes consistently exit 124 while starting `k3s-agent`, and the failure is undebuggable.

Two root causes in `agents.tf`:

1. **Missing dependency edge.** `terraform_data.agents` did not depend on `terraform_data.kustomization`, which deploys the Hetzner CCM that untaints freshly-joined agents. Terraform/OpenTofu scheduled both concurrently, so the agent start raced the untaint and timed out → exit 124 on every fresh deploy.
2. **Provisioner hid the failure.** The start ran `systemctl start k3s-agent 2>/dev/null` and looped on `systemctl status … >/dev/null`, swallowing the actual reason — so all you got was a bare exit 124.

## Fix

1. Add `terraform_data.kustomization` to the agents' `depends_on` so agents start only after CCM is being deployed.
2. Rework the start provisioner to be observable:
   - `systemctl reset-failed k3s-agent` first, to clear start-limit state from any prior failed attempt.
   - non-blocking start + wait on `systemctl is-active --quiet k3s-agent` (more reliable than parsing `status` exit codes).
   - on timeout, dump `systemctl status -l` + `journalctl -u k3s-agent -n 80` and `exit 1`, so the failure is **loud and diagnosable** instead of a silent 124.
   - bump the wait to **600s** as a safety margin (CCM rollout + untaint can take a couple of minutes on a cold cluster). With the ordering edge in place this is margin, not the load-bearing fix.

I dump diagnostics **only on the failure path** (rather than on every wait iteration as the issue sketch did) to avoid flooding output during normal startup.

## No dependency cycle

`terraform_data.kustomization`'s `depends_on` is `control_planes`, the load balancer, `rancher_bootstrap`, `longhorn_volume`, and `kube_system_secrets` — **none** of which depend on `terraform_data.agents`. The only dependents of `terraform_data.agents` (`hcloud_floating_ip_assignment.agents`, longhorn volume config) are outside that closure. Confirmed empirically: `tofu plan` builds the full graph with no cycle (it fails only later on the missing Hetzner token, as expected for the module planned standalone).

## Backward compatibility

`terraform_data.agents` re-runs only when `triggers_replace.agent_id` changes (i.e. node replacement). Editing the provisioner text or adding a `depends_on` does **not** force a re-run on existing clusters → no destructive plan for existing deployments.

## Testing

- ✅ `tofu fmt -check` — clean
- ✅ `tofu validate` (OpenTofu 1.10.6) — `Success! The configuration is valid.`
- ✅ `tofu plan` graph construction — no cycle
- ⚠️ **Integration gap (not run here):** the agent-start runtime behavior — agents actually exiting 124 before the fix and succeeding after — is only fully provable on a **live fresh apply** against Hetzner with a real MicroOS snapshot. The original reporter verified the patch on their cluster (v2.20.0, k3s v1.33.12+k3s1, OpenTofu v1.12.1); a maintainer fresh-apply confirmation would close the loop.