### PR TITLE
fix(agents): order agents after kustomization and surface start failures (v3)

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -301,27 +301,33 @@ resource "terraform_data" "agents" {
   # Start the k3s agent and wait for it to have started
   provisioner "remote-exec" {
     inline = concat(["systemctl enable --now iscsid"], local.kubernetes_distribution == "rke2" ? [
-      "timeout 120 systemctl start rke2-agent 2> /dev/null",
       "systemctl enable rke2-agent",
       <<-EOT
-      timeout 120 bash <<EOF
-        until systemctl status rke2-agent > /dev/null; do
-          systemctl start rke2-agent 2> /dev/null
-          echo "Waiting for the rke2 agent to start..."
-          sleep 2
-        done
-      EOF
+      # Clear any failed unit state left by a prior attempt so the start is not
+      # blocked by start-limit rate limiting, then kick the agent off without
+      # blocking and wait for it to actually settle.
+      systemctl reset-failed rke2-agent 2> /dev/null || true
+      systemctl start --no-block rke2-agent
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet rke2-agent; do echo "Waiting for the rke2 agent to start..."; sleep 5; done'; then
+        echo "ERROR: rke2-agent did not become active within 600s. Dumping diagnostics:" >&2
+        systemctl status rke2-agent --no-pager -l || true
+        journalctl -u rke2-agent -n 80 --no-pager || true
+        exit 1
+      fi
       EOT
       ] : [
-      "timeout 120 systemctl start k3s-agent 2> /dev/null",
       <<-EOT
-      timeout 120 bash <<EOF
-        until systemctl status k3s-agent > /dev/null; do
-          systemctl start k3s-agent 2> /dev/null
-          echo "Waiting for the k3s agent to start..."
-          sleep 2
-        done
-      EOF
+      # Clear any failed unit state left by a prior attempt so the start is not
+      # blocked by start-limit rate limiting, then kick the agent off without
+      # blocking and wait for it to actually settle.
+      systemctl reset-failed k3s-agent 2> /dev/null || true
+      systemctl start --no-block k3s-agent
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
+        echo "ERROR: k3s-agent did not become active within 600s. Dumping diagnostics:" >&2
+        systemctl status k3s-agent --no-pager -l || true
+        journalctl -u k3s-agent -n 80 --no-pager || true
+        exit 1
+      fi
       EOT
     ])
   }
@@ -333,7 +339,15 @@ resource "terraform_data" "agents" {
     terraform_data.agent_config,
     hcloud_load_balancer_service.control_plane,
     hcloud_load_balancer_service.control_plane_rke2_supervisor,
-    hcloud_network_subnet.control_plane
+    hcloud_network_subnet.control_plane,
+    # CCM (deployed by the kustomization) is what untaints freshly-joined
+    # agents. Without this edge, agents start concurrently with the
+    # kustomization and race the untaint, so the agent never settles and the
+    # start provisioner times out (exit 124) on a fresh single apply.
+    # No cycle: terraform_data.kustomization depends only on control_planes,
+    # the load balancer, rancher_bootstrap, longhorn_volume and
+    # kube_system_secrets - none of which depend on terraform_data.agents.
+    terraform_data.kustomization
   ]
 }
 moved {

--- a/agents.tf
+++ b/agents.tf
@@ -308,7 +308,7 @@ resource "terraform_data" "agents" {
       # blocking and wait for it to actually settle.
       systemctl reset-failed rke2-agent 2> /dev/null || true
       systemctl start --no-block rke2-agent
-      if ! timeout 600 bash -c 'until systemctl is-active --quiet rke2-agent; do echo "Waiting for the rke2 agent to start..."; sleep 5; done'; then
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet rke2-agent; do if systemctl is-failed --quiet rke2-agent; then exit 1; fi; echo "Waiting for the rke2 agent to start..."; sleep 5; done'; then
         echo "ERROR: rke2-agent did not become active within 600s. Dumping diagnostics:" >&2
         systemctl status rke2-agent --no-pager -l || true
         journalctl -u rke2-agent -n 80 --no-pager || true
@@ -322,7 +322,7 @@ resource "terraform_data" "agents" {
       # blocking and wait for it to actually settle.
       systemctl reset-failed k3s-agent 2> /dev/null || true
       systemctl start --no-block k3s-agent
-      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
+      if ! timeout 600 bash -c 'until systemctl is-active --quiet k3s-agent; do if systemctl is-failed --quiet k3s-agent; then exit 1; fi; echo "Waiting for the k3s agent to start..."; sleep 5; done'; then
         echo "ERROR: k3s-agent did not become active within 600s. Dumping diagnostics:" >&2
         systemctl status k3s-agent --no-pager -l || true
         journalctl -u k3s-agent -n 80 --no-pager || true


### PR DESCRIPTION
v3/`staging` mirror of #2220 (which targets `master` for #2215).

> **Draft pending maintainer steer.** On #2215 I asked whether to land on `master`, mirror to `staging`/v3, or both. This is the v3 mirror, kept **draft** until you confirm scope. The v3 `agents.tf` still carries both halves of the bug, so neither is superseded by the v3 work.

## Why this is needed on v3 too

The v3 `agents.tf` restructured the agents' `depends_on` around the load-balancer services but **still does not** include `terraform_data.kustomization`, and the start provisioner **still** uses the silent `systemctl start … 2>/dev/null` + `systemctl status … >/dev/null` pattern — for both the `k3s-agent` and `rke2-agent` paths. So fresh single-applies hit the same exit-124 race and the same undebuggable failure.

## Changes

1. **Dependency edge** — append `terraform_data.kustomization` to the agents' `depends_on` so agents start only after CCM is being deployed.
2. **Observable start** — rework the start provisioner (applied to **both** the `rke2-agent` and `k3s-agent` branches):
   - `systemctl reset-failed` first (clears start-limit state from a prior failed attempt),
   - non-blocking start + wait on `systemctl is-active --quiet`,
   - on timeout, dump `systemctl status -l` + `journalctl -u <unit> -n 80` and `exit 1` — loud and diagnosable instead of a bare 124,
   - 600s wait (was 120s) as a safety margin for CCM rollout on a cold cluster.

   Diagnostics fire only on the failure path (not every wait iteration), to avoid flooding output during normal startup.

## No dependency cycle

In v3, `terraform_data.kustomization` (`init.tf`) depends only on `control_planes`, the load balancer, `rancher_bootstrap`, `longhorn_volume`, and `kube_system_secrets` — none of which depend on `terraform_data.agents`. Confirmed empirically: `tofu plan` builds the full v3 graph with **no cycle** (it fails only later on the missing Hetzner token, as expected for the module planned standalone).

## Testing

- ✅ `tofu fmt -check` — clean
- ✅ `tofu validate` (OpenTofu 1.10.6) — `Success! The configuration is valid.`
- ✅ `tofu plan` graph construction — no cycle
- ⚠️ **Integration gap (not run here):** the agent-start runtime behavior is only fully provable on a **live fresh apply** against Hetzner with a real snapshot — and ideally exercised for **both** the k3s and rke2 distributions on v3. A maintainer fresh-apply confirmation would close the loop.