### PR TITLE
feat: add enable_kured and enable_system_upgrade_controller deploy toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,23 @@ automatically_upgrade_os = false
 automatically_upgrade_k3s = false
 ```
 
+> **Note:** these two flags only stop the upgrade *activity* — they do **not** undeploy the tooling.
+> `automatically_upgrade_os` toggles the host `transactional-update` timer (kured stays deployed), and
+> `automatically_upgrade_k3s` only controls the `k3s_upgrade` node label (the system-upgrade-controller stays deployed).
+
+### Skip Deploying the Upgrade Tooling
+
+To not deploy the components at all (for example when managing them externally via GitOps/ArgoCD), use the
+dedicated deploy toggles. Both default to `true`, so existing clusters are unaffected.
+
+```tf
+# Do not deploy kured (the reboot daemon)
+enable_kured = false
+
+# Do not deploy the system-upgrade-controller (with its CRDs and plans)
+enable_system_upgrade_controller = false
+```
+
 <details>
 <summary><strong>Manual upgrade commands</strong></summary>
 

--- a/init.tf
+++ b/init.tf
@@ -456,7 +456,7 @@ resource "terraform_data" "kustomization" {
 
   # Upload the system upgrade controller plans config
   provisioner "file" {
-    content = templatefile(
+    content = var.enable_system_upgrade_controller ? templatefile(
       "${path.module}/templates/plans.yaml.tpl",
       {
         channel          = var.initial_k3s_channel
@@ -464,7 +464,7 @@ resource "terraform_data" "kustomization" {
         disable_eviction = !var.system_upgrade_enable_eviction
         drain            = var.system_upgrade_use_drain
         upgrade_window   = var.system_upgrade_schedule_window
-    })
+    }) : ""
     destination = "/var/post_install/plans.yaml"
   }
 
@@ -534,17 +534,17 @@ resource "terraform_data" "kustomization" {
   # Upload release-asset manifests as local files because kustomize >= 5
   # treats GitHub releases/download URLs as git repository sources.
   provisioner "file" {
-    content     = data.http.kured_manifest.response_body
+    content     = var.enable_kured ? data.http.kured_manifest.response_body : ""
     destination = "/var/post_install/kured-base.yaml"
   }
 
   provisioner "file" {
-    content     = data.http.system_upgrade_controller_manifest.response_body
+    content     = var.enable_system_upgrade_controller ? data.http.system_upgrade_controller_manifest.response_body : ""
     destination = "/var/post_install/system-upgrade-controller.yaml"
   }
 
   provisioner "file" {
-    content     = data.http.system_upgrade_controller_crd_manifest.response_body
+    content     = var.enable_system_upgrade_controller ? data.http.system_upgrade_controller_crd_manifest.response_body : ""
     destination = "/var/post_install/system-upgrade-controller-crd.yaml"
   }
 
@@ -554,12 +554,12 @@ resource "terraform_data" "kustomization" {
   }
 
   provisioner "file" {
-    content = templatefile(
+    content = var.enable_kured ? templatefile(
       "${path.module}/templates/kured.yaml.tpl",
       {
         options = local.kured_options
       }
-    )
+    ) : ""
     destination = "/var/post_install/kured.yaml"
   }
 
@@ -601,12 +601,16 @@ resource "terraform_data" "kustomization" {
       [
         # Ready, set, go for the kustomization
         "kubectl apply -k /var/post_install",
+      ],
+      var.enable_system_upgrade_controller ? [
         "echo 'Waiting for the system-upgrade-controller deployment to become available...'",
         "kubectl -n system-upgrade wait --for=condition=available --timeout=900s deployment/system-upgrade-controller",
         "sleep 7", # important as the system upgrade controller CRDs sometimes don't get ready right away, especially with Cilium.
         "kubectl -n system-upgrade apply -f /var/post_install/plans.yaml",
+      ] : [],
+      [
         # Wait for system namespace deployments to become available
-        "for ns in kube-system ${var.enable_cert_manager ? "cert-manager" : ""} ${var.enable_longhorn ? var.longhorn_namespace : ""} ${local.ingress_controller_namespace} system-upgrade; do [ -n \"$ns\" ] && kubectl get ns $ns &>/dev/null && kubectl -n $ns wait deployment --all --for=condition=Available --timeout=300s || true; done",
+        "for ns in kube-system ${var.enable_cert_manager ? "cert-manager" : ""} ${var.enable_longhorn ? var.longhorn_namespace : ""} ${local.ingress_controller_namespace} ${var.enable_system_upgrade_controller ? "system-upgrade" : ""}; do [ -n \"$ns\" ] && kubectl get ns $ns &>/dev/null && kubectl -n $ns wait deployment --all --for=condition=Available --timeout=300s || true; done",
         # Wait for helm install jobs to complete (only in namespaces that have jobs)
         "for ns in kube-system ${var.enable_longhorn ? var.longhorn_namespace : ""}; do [ -n \"$ns\" ] && kubectl get ns $ns &>/dev/null && kubectl -n $ns get job -o name 2>/dev/null | grep -q . && kubectl -n $ns wait job --all --for=condition=Complete --timeout=300s || true; done"
       ],

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -707,6 +707,11 @@ module "kube-hetzner" {
   # The default is "true" (in HA setup i.e. at least 3 control plane nodes & 2 agents, just keep it enabled since it works flawlessly).
   # automatically_upgrade_k3s = false
 
+  # Note: automatically_upgrade_k3s only controls the k3s_upgrade node label and the upgrade activity; the
+  # system-upgrade-controller (with its CRDs and plans) is still deployed. To skip deploying it entirely
+  # (e.g. when managing it externally via GitOps/ArgoCD), set the flag below to false. The default is "true".
+  # enable_system_upgrade_controller = false
+
   # By default nodes are drained before k3s upgrade, which will delete and transfer all pods to other nodes.
   # Set this to false to cordon nodes instead, which just prevents scheduling new pods on the node during upgrade
   # and keeps all pods running. This may be useful if you have pods which are known to be slow to start e.g.
@@ -723,6 +728,11 @@ module "kube-hetzner" {
   # The default is "true" (in HA setup it works wonderfully well, with automatic roll-back to the previous snapshot in case of an issue).
   # IMPORTANT! For non-HA clusters i.e. when the number of control-plane nodes is < 3, you have to turn it off.
   # automatically_upgrade_os = false
+
+  # Note: automatically_upgrade_os only toggles the host transactional-update timer; the kured DaemonSet is still
+  # deployed. To skip deploying kured entirely (e.g. when managing reboots externally via GitOps/ArgoCD), set the
+  # flag below to false. The default is "true".
+  # enable_kured = false
 
   # If you need more control over kured and the reboot behaviour, you can pass additional options to kured.
   # For example limiting reboots to certain timeframes. For all options see: https://kured.dev/docs/configuration/

--- a/locals.tf
+++ b/locals.tf
@@ -202,11 +202,11 @@ locals {
     apiVersion = "kustomize.config.k8s.io/v1beta1"
     kind       = "Kustomization"
     resources = concat(
-      [
-        "kured-base.yaml",
+      var.enable_kured ? ["kured-base.yaml"] : [],
+      var.enable_system_upgrade_controller ? [
         "system-upgrade-controller.yaml",
         "system-upgrade-controller-crd.yaml"
-      ],
+      ] : [],
       var.hetzner_ccm_use_helm ? ["hcloud-ccm-helm.yaml"] : ["ccm-networks.yaml"],
       var.disable_hetzner_csi ? [] : ["hcloud-csi.yaml"],
       lookup(local.ingress_controller_install_resources, var.ingress_controller, []),
@@ -218,21 +218,20 @@ locals {
       var.enable_rancher ? ["rancher.yaml"] : [],
       var.rancher_registration_manifest_url != "" ? [var.rancher_registration_manifest_url] : []
     ),
-    patches = concat([
-      {
-        target = {
-          group     = "apps"
-          version   = "v1"
-          kind      = "Deployment"
-          name      = "system-upgrade-controller"
-          namespace = "system-upgrade"
+    patches = concat(
+      var.enable_system_upgrade_controller ? [
+        {
+          target = {
+            group     = "apps"
+            version   = "v1"
+            kind      = "Deployment"
+            name      = "system-upgrade-controller"
+            namespace = "system-upgrade"
+          }
+          patch = file("${path.module}/kustomize/system-upgrade-controller.yaml")
         }
-        patch = file("${path.module}/kustomize/system-upgrade-controller.yaml")
-      },
-      {
-        path = "kured.yaml"
-      }
-      ],
+      ] : [],
+      var.enable_kured ? [{ path = "kured.yaml" }] : [],
       var.hetzner_ccm_use_helm ? [] : [{ path = "ccm.yaml" }]
     )
   })

--- a/variables.tf
+++ b/variables.tf
@@ -839,12 +839,14 @@ variable "automatically_upgrade_k3s" {
 variable "enable_system_upgrade_controller" {
   type        = bool
   default     = true
+  nullable    = false
   description = "Whether to deploy the system-upgrade-controller (with its CRDs and upgrade plans) used for automated k3s upgrades. Set to false to skip deploying it entirely, for example when it is managed externally (GitOps/ArgoCD). Note that automatically_upgrade_k3s only controls the k3s_upgrade node label and the upgrade activity, not whether the controller is deployed."
 }
 
 variable "enable_kured" {
   type        = bool
   default     = true
+  nullable    = false
   description = "Whether to deploy kured (the Kubernetes Reboot Daemon) used to perform safe, HA-aware node reboots after OS updates. Set to false to skip deploying it entirely, for example when it is managed externally (GitOps/ArgoCD). Note that automatically_upgrade_os only toggles the host transactional-update timer, not whether kured is deployed."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -836,6 +836,18 @@ variable "automatically_upgrade_k3s" {
   description = "Whether to automatically upgrade k3s based on the selected channel."
 }
 
+variable "enable_system_upgrade_controller" {
+  type        = bool
+  default     = true
+  description = "Whether to deploy the system-upgrade-controller (with its CRDs and upgrade plans) used for automated k3s upgrades. Set to false to skip deploying it entirely, for example when it is managed externally (GitOps/ArgoCD). Note that automatically_upgrade_k3s only controls the k3s_upgrade node label and the upgrade activity, not whether the controller is deployed."
+}
+
+variable "enable_kured" {
+  type        = bool
+  default     = true
+  description = "Whether to deploy kured (the Kubernetes Reboot Daemon) used to perform safe, HA-aware node reboots after OS updates. Set to false to skip deploying it entirely, for example when it is managed externally (GitOps/ArgoCD). Note that automatically_upgrade_os only toggles the host transactional-update timer, not whether kured is deployed."
+}
+
 variable "system_upgrade_schedule_window" {
   type = object({
     days      = optional(list(string), [])


### PR DESCRIPTION
## What

Adds two new variables, both defaulting to `true` (no change for existing clusters):

- `enable_kured` — when `false`, kured (the Kubernetes Reboot Daemon) is not deployed.
- `enable_system_upgrade_controller` — when `false`, the system-upgrade-controller, its CRDs, and the upgrade plans are not deployed.

## Why

Today kured and the system-upgrade-controller are **always deployed**, with no way to skip them. The existing flags only stop the upgrade *activity*, not the deployment:

| Existing flag | What it actually controls | Still deployed? |
|---|---|---|
| `automatically_upgrade_os = false` | Disables the host transactional-update timer | ✅ kured still deployed |
| `automatically_upgrade_k3s = false` | Removes the `k3s_upgrade` node label | ✅ controller + CRDs + plans still deployed |

This is a problem for users who manage these optional, non-core components externally (e.g. GitOps/ArgoCD) and want the module to stay out of the way. There's no clean way to do that without the controller fighting an external one, or kured running twice.

## Precedent

This follows the existing convention in the module for toggling component deployment:

- **Explicit toggles:** `enable_cert_manager`, `enable_csi_driver_smb`, `enable_metrics_server`, `enable_longhorn`, `enable_rancher`, `disable_hetzner_csi`
- **Implicit toggles:** empty `autoscaler_nodepools` (no autoscaler), `ingress_controller = "none"`

kured and the system-upgrade-controller were the notable optional components with no deploy toggle at all.

## Changes

- `variables.tf` — two new `bool` variables (default `true`).
- `locals.tf` — the kustomization `resources`/`patches` entries for kured and the controller (incl. CRDs and the strategic-merge patch) are now conditional.
- `init.tf` — the relevant file-provisioner contents render empty, and the controller's wait/apply remote-exec steps + the `system-upgrade` namespace wait are skipped, when disabled.
- `kube.tf.example` / `README.md` — document both flags; README notes the `automatically_upgrade_*` flags only stop activity, not deployment.

Minimal-change design: the `data.http` manifest fetches are left ungated (harmless — they're just not referenced when disabled). `docs/terraform.md` is intentionally not touched here since the repo's `generate-docs` workflow regenerates it on merge.

## Backward compatibility

Both default to `true`, so the conditionals collapse to today's static behavior. `terraform validate`, `terraform fmt -check`, and `tfsec` all pass.
