### PR TITLE
fix(kustomize): don't mask a failed kubectl apply -k in user kustomization deploy

### DIFF
--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -61,13 +61,27 @@ resource "terraform_data" "kustomization_user_deploy" {
   }
 
   # Remove templates after rendering, and apply changes.
+  # `kubectl apply -k` runs in its own provisioner so that a non-zero exit fails this
+  # step directly. Previously it shared one remote-exec script with
+  # extra_kustomize_deployment_commands; since remote-exec has no `set -e` and the exit
+  # code is that of the LAST command, a failed apply was masked whenever a trailing
+  # command succeeded — tofu then reported success while nothing reconciled.
   provisioner "remote-exec" {
     # Debugging: "sh -c 'for file in $(find /var/user_kustomize -type f -name \"*.yaml\" | sort -n); do echo \"\n### Template $${file}.tpl after rendering:\" && cat $${file}; done'",
-    inline = compact([
+    inline = [
       "rm -f /var/user_kustomize/**/*.yaml.tpl",
       "echo 'Applying user kustomization...'",
       "kubectl apply -k /var/user_kustomize/ --wait=true",
-      var.extra_kustomize_deployment_commands
+    ]
+  }
+
+  # User-supplied post-apply commands run only after a successful apply. The leading
+  # "true" keeps inline non-empty when the variable is unset (compact() would otherwise
+  # produce an empty list).
+  provisioner "remote-exec" {
+    inline = compact([
+      "true",
+      var.extra_kustomize_deployment_commands,
     ])
   }
 


### PR DESCRIPTION
## Problem

`terraform_data.kustomization_user_deploy` runs `kubectl apply -k` and the user-provided
`extra_kustomize_deployment_commands` in a **single** `remote-exec`. `remote-exec` joins the
`inline` list into one script with no `set -e`, so the script's exit status is that of the
**last** command. If `apply -k` fails but any trailing command exits 0, the non-zero apply is
swallowed — tofu/terraform reports the apply as **successful while nothing reconciled**.

Symptom: the plan shows the `manifest_sha1` change + replacement, the apply prints
"Creation complete", but the cluster is never updated. A broken extra-manifest change fails
silently.

## Fix

Split into two provisioners:

- `kubectl apply -k` runs alone, so a non-zero exit fails the step and you get a real error
  instead of a silent success.
- `extra_kustomize_deployment_commands` run in a second provisioner, only after a successful apply.

No behavioral change on success.

## Notes

- The leading `"true"` keeps the second provisioner's `inline` non-empty when the variable is
  unset (`compact()` would otherwise yield an empty list, which `remote-exec` rejects).
- Post-apply commands no longer run if the apply failed — the intended, safer behavior.
