### PR TITLE
fix(kustomize): don't hide deploy errors when the connection uses a sensitive value

### DIFF
--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -61,13 +61,27 @@ resource "terraform_data" "kustomization_user_deploy" {
   }
 
   # Remove templates after rendering, and apply changes.
+  # `kubectl apply -k` runs in its own provisioner so that a non-zero exit fails this
+  # step directly. Previously it shared one remote-exec script with
+  # extra_kustomize_deployment_commands; since remote-exec has no `set -e` and the exit
+  # code is that of the LAST command, a failed apply was masked whenever a trailing
+  # command succeeded — tofu then reported success while nothing reconciled.
   provisioner "remote-exec" {
     # Debugging: "sh -c 'for file in $(find /var/user_kustomize -type f -name \"*.yaml\" | sort -n); do echo \"\n### Template $${file}.tpl after rendering:\" && cat $${file}; done'",
-    inline = compact([
+    inline = [
       "rm -f /var/user_kustomize/**/*.yaml.tpl",
       "echo 'Applying user kustomization...'",
       "kubectl apply -k /var/user_kustomize/ --wait=true",
-      var.extra_kustomize_deployment_commands
+    ]
+  }
+
+  # User-supplied post-apply commands run only after a successful apply. The leading
+  # "true" keeps inline non-empty when the variable is unset (compact() would otherwise
+  # produce an empty list).
+  provisioner "remote-exec" {
+    inline = compact([
+      "true",
+      var.extra_kustomize_deployment_commands,
     ])
   }
 

--- a/kustomization_user.tf
+++ b/kustomization_user.tf
@@ -1,5 +1,19 @@
 locals {
   user_kustomization_templates = try(fileset(var.extra_kustomize_folder, "**/*.yaml.tpl"), toset([]))
+
+  # tofu hides a remote-exec provisioner's output whenever anything in its config or
+  # connection is sensitive. When ssh_private_key is sensitive (e.g. sourced from a
+  # secrets manager), the deploy connection suppresses the `kubectl apply -k` output and
+  # errors entirely, so a failed reconcile is opaque. The keys are only used to open the
+  # SSH session — never echoed to stdout, and provisioner connections are not written to
+  # state — so stripping the sensitive mark here reveals the apply output without leaking
+  # anything (sensitive marks control display only, not what is stored in state).
+  # `try(nonsensitive(x), x)` strips the mark whether or not x is currently sensitive and
+  # never errors. Secrets in extra_kustomize_deployment_commands stay suppressed via their
+  # own provisioner.
+  kustomize_deploy_conn_private_key         = try(nonsensitive(var.ssh_private_key), var.ssh_private_key)
+  kustomize_deploy_conn_agent_identity      = try(nonsensitive(local.ssh_agent_identity), local.ssh_agent_identity)
+  kustomize_deploy_conn_bastion_private_key = try(nonsensitive(local.ssh_bastion.bastion_private_key), local.ssh_bastion.bastion_private_key)
 }
 
 resource "terraform_data" "kustomization_user" {
@@ -48,15 +62,15 @@ resource "terraform_data" "kustomization_user_deploy" {
 
   connection {
     user           = "root"
-    private_key    = var.ssh_private_key
-    agent_identity = local.ssh_agent_identity
+    private_key    = local.kustomize_deploy_conn_private_key
+    agent_identity = local.kustomize_deploy_conn_agent_identity
     host           = local.first_control_plane_ip
     port           = var.ssh_port
 
     bastion_host        = local.ssh_bastion.bastion_host
     bastion_port        = local.ssh_bastion.bastion_port
     bastion_user        = local.ssh_bastion.bastion_user
-    bastion_private_key = local.ssh_bastion.bastion_private_key
+    bastion_private_key = local.kustomize_deploy_conn_bastion_private_key
 
   }
 


### PR DESCRIPTION
> **Stacked on #2225** (the fail-loud fix). Please review/merge that first;
> this PR's net change is only the connection un-masking (locals + the deploy `connection`).

## Problem

tofu/terraform hides **all** output of a `remote-exec` provisioner when anything in its config or
`connection` is a sensitive value. In `kustomization_user_deploy` the `connection` uses
`var.ssh_private_key`. If that value is sensitive, every line of the deploy — including
`kubectl apply -k` errors — prints only as:

```
(output suppressed due to sensitive value in config)
```

So even with the fail-loud fix you get a hard failure but no idea what went wrong. (If your key
isn't sensitive, nothing changes — your output was never hidden.)

## Fix

Strip the sensitive mark from the deploy connection's SSH-key fields with `try(nonsensitive(x), x)`.
Why it's safe:

- these fields are only used to open the SSH session — they are never printed to stdout (the
  connection log shows `Private key: true`, not the key itself);
- provisioner `connection` config is not written to state (a `terraform_data` persists only
  `id/input/output/triggers_replace`; no `connection` blocks appear in state);
- sensitive marks change what is *displayed*, not what is *stored* — so this affects log output only;
- real secrets in `extra_kustomize_deployment_commands` stay hidden — they run in their own
  provisioner (from the fail-loud PR).

## Why I ran into this

I pass a sensitive variable into the module and it flows into the deploy `connection`. That turns
the whole `remote-exec` sensitive, so when `kubectl apply -k` failed I got nothing but
`(output suppressed…)` and couldn't tell what was wrong. Un-masking the connection was the only way
to read the actual error.

## Tradeoff — open to alternatives

This un-masks the connection unconditionally. I couldn't find a clean per-flag toggle because of how
marks propagate: a conditional `cond ? a : b` taints the result if *either* branch is sensitive, and
`try()` strips marks entirely — so a `debug ? nonsensitive(x) : x` gate ends up always sensitive.
Happy to gate it behind a variable or scope it differently if you'd prefer.
