### PR TITLE
fix(packer): expose server type/location overrides for snapshot builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Bug Fixes
 
 - **Traefik Gateway API CRDs** - Install the Kubernetes Gateway API standard CRDs before Traefik when `traefik_provider_kubernetes_gateway_enabled` is enabled, preventing Helm install failures for `GatewayClass` and `Gateway` resources (#2211).
+- **Agent Startup Race on Fresh Deploys** - Agent nodes now start only after the kustomization that deploys the Hetzner CCM, fixing consistent `exit 124` timeouts on fresh single-apply deployments. The agent start is also observable now: on failure it dumps `systemctl status` and journal output instead of failing silently (#2215, #2220).
+- **User Kustomization Failures No Longer Masked** - A failed `kubectl apply -k` in the user kustomization deploy now fails the apply loudly instead of being masked by trailing `extra_kustomize_deployment_commands` (#2225).
+- **Packer Snapshot Build Overrides** - The MicroOS snapshot template now exposes `x86_server_type`, `x86_location`, `arm_server_type`, and `arm_location` packer variables, so builds can be pointed at available server types/locations with `-var` instead of editing the template when Hetzner capacity shifts (#2214).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,18 @@ packer init hcloud-microos-snapshots.pkr.hcl
 packer build hcloud-microos-snapshots.pkr.hcl
 hcloud context create <project-name>
 ```
+
+> **Server availability**: the snapshot build uses small default server types (`cx23` for x86, `cax11` for ARM). Hetzner availability varies by location and over time — if the build fails with `unsupported location for server type` or `resource_unavailable`, override the build servers without editing the template:
+>
+> ```sh
+> packer build -var x86_server_type=cpx31 -var x86_location=fsn1 hcloud-microos-snapshots.pkr.hcl
+> ```
+>
+> And if one architecture has no capacity at all (or you don't need it), build just the other one:
+>
+> ```sh
+> packer build -only=hcloud.microos-x86-snapshot hcloud-microos-snapshots.pkr.hcl
+> ```
 </details>
 
 <table>

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -16,6 +16,32 @@ variable "hcloud_token" {
   sensitive = true
 }
 
+# Server type and location used to build each snapshot. Override these when the defaults are
+# unavailable in your project (Hetzner availability varies by location and over time), e.g.:
+#   packer build -var x86_server_type=cpx31 -var x86_location=fsn1 hcloud-microos-snapshots.pkr.hcl
+# To build only one architecture (e.g. no ARM capacity available), use -only:
+#   packer build -only=hcloud.microos-x86-snapshot hcloud-microos-snapshots.pkr.hcl
+# Any server type works as long as its disk is >= 40GiB (needed to install the MicroOS image).
+variable "x86_server_type" {
+  type    = string
+  default = "cx23"
+}
+
+variable "x86_location" {
+  type    = string
+  default = "nbg1"
+}
+
+variable "arm_server_type" {
+  type    = string
+  default = "cax11"
+}
+
+variable "arm_location" {
+  type    = string
+  default = "fsn1"
+}
+
 # We download the OpenSUSE MicroOS x86 image from an automatically selected mirror.
 variable "opensuse_microos_x86_mirror_link" {
   type    = string
@@ -123,8 +149,8 @@ locals {
 source "hcloud" "microos-x86-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cx23" # disk size of >= 40GiB is needed to install the MicroOS image
+  location    = var.x86_location
+  server_type = var.x86_server_type # disk size of >= 40GiB is needed to install the MicroOS image
   snapshot_labels = {
     microos-snapshot = "yes"
     creator          = "kube-hetzner"
@@ -138,8 +164,8 @@ source "hcloud" "microos-x86-snapshot" {
 source "hcloud" "microos-arm-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cax11" # disk size of >= 40GiB is needed to install the MicroOS image
+  location    = var.arm_location
+  server_type = var.arm_server_type # disk size of >= 40GiB is needed to install the MicroOS image
   snapshot_labels = {
     microos-snapshot = "yes"
     creator          = "kube-hetzner"


### PR DESCRIPTION
Fixes #2214

## Problem
The MicroOS snapshot template hardcodes `cx23`/`nbg1` (x86) and `cax11`/`nbg1` (ARM). When Hetzner capacity shifts (as currently: no ARM capacity, cx23 unavailable in some DCs), `packer build` fails hard and users must hand-edit the template.

## Fix
- New packer variables: `x86_server_type`, `x86_location`, `arm_server_type`, `arm_location` (defaults preserve current behavior, except ARM default location moves to `fsn1` which has the broadest CAX capacity).
- README documents `-var` overrides and single-arch builds via `-only=hcloud.microos-x86-snapshot`.
- Changelog: adds entries for this fix and for the already-merged #2220/#2225 (release prep for v2.20.1).

## Testing
- `packer validate` passes (syntax + full validate with token).
- Zero terraform state impact — packer template + docs only.

## Backward compatibility
Defaults keep existing behavior; existing snapshots unaffected.