### PR TITLE
fix(selinux): allow container liveness probes on kernel-labeled tcp sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent Startup Race on Fresh Deploys** - Agent nodes now start only after the kustomization that deploys the Hetzner CCM, fixing consistent `exit 124` timeouts on fresh single-apply deployments. The agent start is also observable now: on failure it dumps `systemctl status` and journal output instead of failing silently (#2215, #2220).
 - **User Kustomization Failures No Longer Masked** - A failed `kubectl apply -k` in the user kustomization deploy now fails the apply loudly instead of being masked by trailing `extra_kustomize_deployment_commands` (#2225).
 - **Packer Snapshot Build Overrides** - The MicroOS snapshot template now exposes `x86_server_type`, `x86_location`, `arm_server_type`, and `arm_location` packer variables, so builds can be pointed at available server types/locations with `-var` instead of editing the template when Hetzner capacity shifts (#2214).
+- **SELinux: CSI Liveness Probes** - Added `allow container_t kernel_t:tcp_socket { read write }` to the kube-hetzner SELinux policy, fixing hcloud-csi-driver (and similar CSI) crash-loops caused by liveness-probe denials under enforcing SELinux. Applies to newly provisioned/replaced nodes; on existing nodes either replace nodes or apply the module manually as described in #2203.
 
 ---
 

--- a/templates/kube-hetzner-selinux.te
+++ b/templates/kube-hetzner-selinux.te
@@ -18,7 +18,7 @@ require {
     class bpf map_create;
     class io_uring sqpoll;
     class anon_inode { create map read write };
-    class tcp_socket name_connect;
+    class tcp_socket { name_connect read write };
     class chr_file { open read write };
     class blk_file getattr;
 }
@@ -67,6 +67,11 @@ allow container_t container_share_t:file { read write create unlink };
 allow container_t container_runtime_exec_t:file { read execute execute_no_trans open };
 allow container_t container_runtime_t:unix_stream_socket { connectto read write };
 allow container_t kernel_t:system module_request;
+# Needed by liveness/readiness probes of CSI drivers (e.g. hcloud-csi) whose probe
+# sockets are kernel-labeled; without it the probes fail with connection reset and
+# the pods crash-loop under enforcing SELinux. Matches the rule already shipped in
+# the v3 Leap Micro policy (k8s-custom-policies.te).
+allow container_t kernel_t:tcp_socket { read write };
 allow container_t var_log_t:dir { add_name write remove_name watch read };
 allow container_t var_log_t:file { create lock open read setattr write unlink getattr };
 allow container_t var_lib_t:dir { add_name remove_name write read create };


### PR DESCRIPTION
Fixes #2203

## Problem
Under enforcing SELinux, hcloud-csi-driver (node + controller) crash-loops: the liveness probe fails with connection reset. AVC-wise this is `container_t` denied `{ read write }` on a `kernel_t`-labeled `tcp_socket` — confirmed by the reporter's working workaround module.

## Fix
Backports to the v2 `templates/kube-hetzner-selinux.te`:
- require: `class tcp_socket { name_connect read write };`
- rule: `allow container_t kernel_t:tcp_socket { read write };`

This is **exactly the rule v3 already ships** in `templates/k8s-custom-policies.te` (staging), so v2/v3 are now consistent on this point.

## Scope / rollout semantics
- `user_data` is under `ignore_changes` in the host module → **zero node recreation** on upgrade.
- New and replaced nodes (incl. autoscaler nodes — shared cloud-init locals) get the policy automatically.
- Existing nodes: apply the module manually (commands in #2203) or replace nodes.
- Cloud-init `runcmd` is fail-open: a policy compile failure logs and continues, same as today.

## Security note
The rule permits all containers read/write on kernel-labeled tcp sockets. That breadth was already accepted for v3 (the Leap Micro policy is broader still); the alternative (per-workload policy) isn't expressible for probe sockets created by the kubelet.

## Testing
- Syntax mirrors the production-proven v3 policy file (same class/require/allow pattern).
- `terraform fmt`/`validate` unaffected (template file + changelog only).
- Runtime compile verified indirectly: identical grammar to rules already compiling on every v3 Leap Micro node.