### PR TITLE
fix(packer): expose server type/location overrides for snapshot builds (v3)

### DIFF
--- a/packer-template/hcloud-leapmicro-snapshots.pkr.hcl
+++ b/packer-template/hcloud-leapmicro-snapshots.pkr.hcl
@@ -16,6 +16,32 @@ variable "hcloud_token" {
   sensitive = true
 }
 
+# Server type and location used to build each snapshot. Override these when the defaults are
+# unavailable in your project (Hetzner availability varies by location and over time), e.g.:
+#   packer build -var x86_server_type=cpx31 -var x86_location=fsn1 <template>.pkr.hcl
+# To build only one architecture (e.g. no ARM capacity available), use -only with the
+# corresponding source name. Any server type works as long as its disk is >= 40GiB.
+variable "x86_server_type" {
+  type    = string
+  default = "cx23"
+}
+
+variable "x86_location" {
+  type    = string
+  default = "nbg1"
+}
+
+variable "arm_server_type" {
+  type    = string
+  default = "cax11"
+}
+
+variable "arm_location" {
+  type    = string
+  default = "fsn1"
+}
+
+
 variable "leap_micro_version" {
   type        = string
   default     = "6.2"
@@ -253,8 +279,8 @@ EOF
 source "hcloud" "leapmicro-x86-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cx23" # disk size of >= 40GiB is needed to install the Leap Micro image
+  location    = var.x86_location
+  server_type = var.x86_server_type # disk size of >= 40GiB is needed to install the Leap Micro image
   snapshot_labels = {
     leapmicro-snapshot        = "yes"
     creator                   = "kube-hetzner"
@@ -271,8 +297,8 @@ source "hcloud" "leapmicro-x86-snapshot" {
 source "hcloud" "leapmicro-arm-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cax11" # disk size of >= 40GiB is needed to install the Leap Micro image
+  location    = var.arm_location
+  server_type = var.arm_server_type # disk size of >= 40GiB is needed to install the Leap Micro image
   snapshot_labels = {
     leapmicro-snapshot        = "yes"
     creator                   = "kube-hetzner"

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -16,6 +16,32 @@ variable "hcloud_token" {
   sensitive = true
 }
 
+# Server type and location used to build each snapshot. Override these when the defaults are
+# unavailable in your project (Hetzner availability varies by location and over time), e.g.:
+#   packer build -var x86_server_type=cpx31 -var x86_location=fsn1 <template>.pkr.hcl
+# To build only one architecture (e.g. no ARM capacity available), use -only with the
+# corresponding source name. Any server type works as long as its disk is >= 40GiB.
+variable "x86_server_type" {
+  type    = string
+  default = "cx23"
+}
+
+variable "x86_location" {
+  type    = string
+  default = "nbg1"
+}
+
+variable "arm_server_type" {
+  type    = string
+  default = "cax11"
+}
+
+variable "arm_location" {
+  type    = string
+  default = "fsn1"
+}
+
+
 # We download the OpenSUSE MicroOS x86 image from an automatically selected mirror.
 variable "opensuse_microos_x86_mirror_link" {
   type    = string
@@ -123,8 +149,8 @@ locals {
 source "hcloud" "microos-x86-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cx23" # disk size of >= 40GiB is needed to install the MicroOS image
+  location    = var.x86_location
+  server_type = var.x86_server_type # disk size of >= 40GiB is needed to install the MicroOS image
   snapshot_labels = {
     microos-snapshot = "yes"
     creator          = "kube-hetzner"
@@ -138,8 +164,8 @@ source "hcloud" "microos-x86-snapshot" {
 source "hcloud" "microos-arm-snapshot" {
   image       = "ubuntu-24.04"
   rescue      = "linux64"
-  location    = "nbg1"
-  server_type = "cax11" # disk size of >= 40GiB is needed to install the MicroOS image
+  location    = var.arm_location
+  server_type = var.arm_server_type # disk size of >= 40GiB is needed to install the MicroOS image
   snapshot_labels = {
     microos-snapshot = "yes"
     creator          = "kube-hetzner"


### PR DESCRIPTION
Ports #2228 (merged to master for v2.20.1) to `staging`, covering **both** the MicroOS and Leap Micro templates.

Refs #2214.

- New packer variables in each template: `x86_server_type` (cx23), `x86_location` (nbg1), `arm_server_type` (cax11), `arm_location` (fsn1).
- `packer validate` passes for both templates.
- Packer-only; zero terraform impact.