### PR TITLE
fix(agents): guard post-install readiness replace_triggered_by for zero-agent clusters

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -991,7 +991,7 @@ resource "terraform_data" "kustomization" {
 # directly there errors on OpenTofu when agent_nodepools is empty (zero
 # instances). See https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/2236.
 resource "terraform_data" "agents_replacement_trigger" {
-  input = { for k, v in terraform_data.agents : k => v.id }
+  triggers_replace = { for k, v in terraform_data.agents : k => v.id }
 }
 
 resource "terraform_data" "post_install_readiness" {
@@ -1000,7 +1000,7 @@ resource "terraform_data" "post_install_readiness" {
   lifecycle {
     replace_triggered_by = [
       terraform_data.kustomization,
-      terraform_data.agents_replacement_trigger.output,
+      terraform_data.agents_replacement_trigger,
     ]
   }
 
@@ -1502,7 +1502,7 @@ resource "terraform_data" "rke2_post_install_readiness" {
   lifecycle {
     replace_triggered_by = [
       terraform_data.rke2_kustomization,
-      terraform_data.agents_replacement_trigger.output,
+      terraform_data.agents_replacement_trigger,
     ]
   }
 

--- a/init.tf
+++ b/init.tf
@@ -985,13 +985,22 @@ resource "terraform_data" "kustomization" {
   ]
 }
 
+# Aggregates the replacement state of all agent nodes into a single instance so
+# the post-install readiness resources can react to agent changes via
+# replace_triggered_by. Referencing terraform_data.agents (a for_each resource)
+# directly there errors on OpenTofu when agent_nodepools is empty (zero
+# instances). See https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/2236.
+resource "terraform_data" "agents_replacement_trigger" {
+  input = { for k, v in terraform_data.agents : k => v.id }
+}
+
 resource "terraform_data" "post_install_readiness" {
   count = local.kubernetes_distribution == "k3s" ? 1 : 0
 
   lifecycle {
     replace_triggered_by = [
       terraform_data.kustomization,
-      terraform_data.agents,
+      terraform_data.agents_replacement_trigger.output,
     ]
   }
 
@@ -1493,7 +1502,7 @@ resource "terraform_data" "rke2_post_install_readiness" {
   lifecycle {
     replace_triggered_by = [
       terraform_data.rke2_kustomization,
-      terraform_data.agents,
+      terraform_data.agents_replacement_trigger.output,
     ]
   }
 


### PR DESCRIPTION
Closes #2236.

### Problem

On a zero-agent cluster (`agent_nodepools = []`), v3.0.0 applies successfully but **every subsequent `tofu plan` fails**:

```
Error: no change found for terraform_data.agents in module.kube_hetzner
```

### Cause

`terraform_data.post_install_readiness` (and `terraform_data.rke2_post_install_readiness`) list `terraform_data.agents` in `replace_triggered_by`. `terraform_data.agents` is `for_each = local.agent_nodes`, so it has **zero instances** when there are no agent nodepools. OpenTofu errors when `replace_triggered_by` references a `for_each` resource with no instances once the referencing resource is already in state — hence the first apply works but every later plan fails. `terraform_data.kustomization` in the same list is fine because it uses `count` (single instance).

### Fix

Add a single-instance `terraform_data.agents_replacement_trigger` whose `input` is a map of each agent's `id`, and reference its `output` in `replace_triggered_by` instead of the `for_each` resource directly. This:

- **preserves the behavior** — the map changes when an agent node is added, removed, or replaced, so post-install readiness still re-runs on agent changes;
- is **valid for zero-agent clusters** — the aggregator always has exactly one instance (`input = {}` when there are no agents);
- leaves `depends_on = [..., terraform_data.agents]` unchanged, since `depends_on` tolerates zero instances and still orders readiness after the agents.

Applied to both the k3s and rke2 post-install readiness resources.

### Testing

- `terraform fmt` and `terraform validate` pass. Uses `terraform_data` (not `null_resource`), so the "forbid null_resource" check is unaffected.
- I don't have a spare zero-agent Hetzner cluster to run the full apply→plan→plan loop; the change is static HCL and the reporter (@... in #2236) offered to verify on their setup. Happy to adjust if a maintainer prefers a different idiom for the trigger.

<sub>Developed with AI assistance (Claude Code); I directed the change and verified fmt/validate locally.</sub>
