### PR TITLE
fix(agents): pin explicit private_ipv4 for primary-network agents

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -82,7 +82,16 @@ module "agents" {
   network_id                    = local.agent_primary_network_id_by_node[each.key]
   primary_network_key           = each.value.network_id
   extra_network_ids             = local.agent_effective_extra_network_ids_by_node[each.key]
-  private_ipv4                  = null
+  # Pin an explicit private IPv4 for primary-network agents. The hcloud API
+  # attaches a server to a Network with an optional IP, not to a subnet; with
+  # no IP it lands in the last-created subnet (the control-plane range),
+  # ignoring the nodepool's subnet_ip_range (issue #2239). Mirror the
+  # ipv4_subnet_id selection above and offset by node index, matching v2.
+  # External-network nodepools (network_id != 0) keep API auto-assignment.
+  private_ipv4 = each.value.network_id == 0 ? cidrhost(
+    hcloud_network_subnet.agent[local.use_per_nodepool_subnets ? [for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0] : 0].ip_range,
+    each.value.index + (local.network_size >= 16 ? 101 : floor(pow(local.subnet_size, 2) * 0.4))
+  ) : null
 
   labels = merge(local.labels, local.labels_agent_node, each.value.hcloud_labels, { "kube-hetzner/os" = each.value.os })
 


### PR DESCRIPTION
## Problem

`v3.0.0` sets `private_ipv4 = null` for agent nodes (`agents.tf`). The hcloud API attaches a server to a **Network** with an *optional* IP; it cannot attach to a specific subnet (hcloud provider limitation, [hetznercloud/terraform-provider-hcloud#265](https://github.com/hetznercloud/terraform-provider-hcloud/issues/265)). With no explicit IP, the server is assigned an address from the **last-created subnet** (ordered by `ip_range`) — which in `per_nodepool` mode is the control-plane subnet. Agent nodes therefore ignore their nodepool's `subnet_ip_range` and all land in the control-plane range.

Fixes #2239.

## Fix

Restore the v2 behavior: derive an explicit `private_ipv4` from the nodepool's agent subnet — reusing the exact subnet selection already present one line above in `ipv4_subnet_id` — offset by the node index (same `local.network_size` / `local.subnet_size` formula as v2). Guarded to primary-network nodes (`network_id == 0`); external-network nodepools keep API auto-assignment.

```hcl
private_ipv4 = each.value.network_id == 0 ? cidrhost(
  hcloud_network_subnet.agent[local.use_per_nodepool_subnets ? [for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0] : 0].ip_range,
  each.value.index + (local.network_size >= 16 ? 101 : floor(pow(local.subnet_size, 2) * 0.4))
) : null
```

## Notes

- Control-plane nodes carry the same `private_ipv4 = null` (`control_planes.tf`) but currently resolve to the correct range because the control-plane subnet sorts last. Left unchanged here to keep the fix minimal and scoped to #2239 — happy to add symmetric control-plane pinning if you'd prefer it in the same PR.
- `terraform fmt` clean; `terraform validate` passes on the module.
- The plan-matrix smoke test reads live provider data sources (needs a real Hetzner token), so I couldn't run it locally; CI should exercise it.
