### PR TITLE
fix: registries_config type error on plan when non-empty

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -196,7 +196,10 @@ locals {
   # Check if the user has set custom DNS servers.
   has_dns_servers = length(var.dns_servers) > 0
 
-  registries_config_user = trimspace(var.registries_config) == "" ? {} : yamldecode(var.registries_config)
+  # The conditional lives inside yamldecode() so both branches are strings:
+  # `cond ? {} : yamldecode(...)` fails type unification (object({}) vs the
+  # decoded object type) for any non-empty registries_config.
+  registries_config_user = yamldecode(trimspace(var.registries_config) == "" ? "{}" : var.registries_config)
   embedded_registry_mirror_registries = var.embedded_registry_mirror.enabled ? [
     for registry in var.embedded_registry_mirror.registries : registry
   ] : []


### PR DESCRIPTION
Fixes #2241

## Problem

Since v3.0.0, any non-empty `registries_config` fails `plan`/`apply` on both Terraform and OpenTofu:

```
Error: Inconsistent conditional result types

The true and false result expressions must have consistent types. The 'false'
value includes object attribute "configs", which is absent in the 'true' value.
```

`locals.tf`'s `cond ? {} : yamldecode(var.registries_config)` requires both conditional branches to unify to one type, and `object({})` cannot unify with the concrete object type produced by `yamldecode()` of the user's YAML. This is defined HCL/cty behavior, identical in both tools, and blocks the v2 → v3 in-place migration for anyone carrying a `k3s_registries` → `registries_config` value. (v2 never decoded the string, which is why it only surfaces in v3.)

## Fix

Move the conditional inside `yamldecode()` so both branches are strings, which unify trivially:

```hcl
registries_config_user = yamldecode(trimspace(var.registries_config) == "" ? "{}" : var.registries_config)
```

Semantics are unchanged: empty/whitespace input still yields `{}` (`yamldecode("{}")` is an empty object), non-empty input decodes exactly as before, and the downstream `try(local.registries_config_user.mirrors, null)` / `length(keys(...))` usages are unaffected. Malformed YAML still errors loudly (unlike a `try(yamldecode(...), {})` variant, which would silently swallow it).

## Verification

- Standalone repro of the expression (in #2241): fails before, plans cleanly after, for both empty and non-empty inputs, on OpenTofu 1.12.1 and Terraform.
- Used as a local patch to complete a real v2.21.0 → v3.0.1 in-place migration of a live 3-node MicroOS cluster with a non-empty registries mirror config: the standard upgrade path then applied with the documented no-destroy plan gate passing and the re-encoded `registries.yaml` rolling out cleanly (semantic no-op, k3s service restarts as documented).
- `tofu fmt -check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)