### PR TITLE
feat: dual-stack node-ip for control-plane and agent nodes

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -143,7 +143,7 @@ locals {
       # Kubelet arg precedence (last wins): local.kubelet_arg < global_kubelet_args < agent_kubelet_args < v.kubelet_args
       kubelet-arg   = local.agent_effective_kubelet_args_by_node[k]
       flannel-iface = local.flannel_iface
-      node-ip       = local.multinetwork_overlay_enabled ? join(",", compact([local.multinetwork_transport_ipv4_enabled ? module.agents[k].ipv4_address : null, local.multinetwork_transport_ipv6_enabled ? module.agents[k].ipv6_address : null])) : module.agents[k].private_ipv4_address
+      node-ip       = local.multinetwork_overlay_enabled ? join(",", compact([local.multinetwork_transport_ipv4_enabled ? module.agents[k].ipv4_address : null, local.multinetwork_transport_ipv6_enabled ? module.agents[k].ipv6_address : null])) : local.agent_node_ip_by_node[k]
       node-label    = v.labels
       node-taint    = v.taints
     },
@@ -169,7 +169,7 @@ locals {
       token     = local.cluster_token
       # Kubelet arg precedence (last wins): local.kubelet_arg < global_kubelet_args < agent_kubelet_args < v.kubelet_args
       kubelet-arg = local.agent_effective_kubelet_args_by_node[k]
-      node-ip     = local.multinetwork_overlay_enabled ? join(",", compact([local.multinetwork_transport_ipv4_enabled ? module.agents[k].ipv4_address : null, local.multinetwork_transport_ipv6_enabled ? module.agents[k].ipv6_address : null])) : module.agents[k].private_ipv4_address
+      node-ip     = local.multinetwork_overlay_enabled ? join(",", compact([local.multinetwork_transport_ipv4_enabled ? module.agents[k].ipv4_address : null, local.multinetwork_transport_ipv6_enabled ? module.agents[k].ipv6_address : null])) : local.agent_node_ip_by_node[k]
       node-label  = v.labels
       node-taint  = v.taints
     },

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -379,7 +379,7 @@ locals {
       kubelet-arg                 = local.control_plane_effective_kubelet_args_by_node[k]
       kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.enable_secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
       kube-controller-manager-arg = local.kube_controller_manager_arg
-      node-ip                     = module.control_planes[k].private_ipv4_address
+      node-ip                     = local.control_plane_node_ip_by_node[k]
       advertise-address           = module.control_planes[k].private_ipv4_address
       node-label                  = v.labels
       node-taint                  = v.taints
@@ -438,7 +438,7 @@ locals {
       kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.enable_secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
       kube-controller-manager-arg = local.kube_controller_manager_arg
       flannel-iface               = local.flannel_iface
-      node-ip                     = module.control_planes[k].private_ipv4_address
+      node-ip                     = local.control_plane_node_ip_by_node[k]
       advertise-address           = module.control_planes[k].private_ipv4_address
       node-label                  = v.labels
       node-taint                  = v.taints

--- a/init.tf
+++ b/init.tf
@@ -109,7 +109,7 @@ resource "terraform_data" "first_control_plane" {
           kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.enable_secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
           kube-controller-manager-arg = local.kube_controller_manager_arg
           flannel-iface               = local.flannel_iface
-          node-ip                     = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
+          node-ip                     = local.control_plane_node_ip_by_node[keys(module.control_planes)[0]]
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels
@@ -278,7 +278,7 @@ resource "terraform_data" "control_plane_setup_rke2" {
           kubelet-arg                 = concat(local.kubelet_arg, var.global_kubelet_args, var.control_plane_kubelet_args, local.control_plane_nodes[keys(module.control_planes)[0]].kubelet_args)
           kube-apiserver-arg          = concat(local.kube_apiserver_arg, var.enable_secrets_encryption ? ["encryption-provider-config=${local.secrets_encryption_config_file}"] : [])
           kube-controller-manager-arg = local.kube_controller_manager_arg
-          node-ip                     = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
+          node-ip                     = local.control_plane_node_ip_by_node[keys(module.control_planes)[0]]
           advertise-address           = module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
           node-taint                  = local.control_plane_nodes[keys(module.control_planes)[0]].taints
           node-label                  = local.control_plane_nodes[keys(module.control_planes)[0]].labels

--- a/locals.tf
+++ b/locals.tf
@@ -1786,6 +1786,22 @@ EOT
   cluster_has_ipv4            = local.cluster_ipv4_cidr_effective != null
   cluster_has_ipv6            = local.cluster_ipv6_cidr_effective != null
 
+  # k3s/RKE2 reject a dual-stack cluster-cidr/service-cidr when node-ip advertises
+  # only one family:
+  #   "cluster-cidr: [...] and node-ip: [...], must share the same IP version"
+  # Hetzner Cloud Networks are IPv4-only, so the IPv6 half of node-ip is necessarily
+  # the node's public IPv6 address. compact() keeps this a no-op when a node has no
+  # public IPv6 (enable_public_ipv6 = false), which the validation contract rejects
+  # up front for dual-stack clusters.
+  control_plane_node_ip_by_node = {
+    for k, v in module.control_planes :
+    k => local.cluster_has_ipv6 ? join(",", compact([v.private_ipv4_address, v.ipv6_address])) : v.private_ipv4_address
+  }
+  agent_node_ip_by_node = {
+    for k, v in module.agents :
+    k => local.cluster_has_ipv6 ? join(",", compact([v.private_ipv4_address, v.ipv6_address])) : v.private_ipv4_address
+  }
+
   cluster_cidrs = compact([
     local.cluster_ipv4_cidr_effective,
     local.cluster_ipv6_cidr_effective,

--- a/validation-contract.tf
+++ b/validation-contract.tf
@@ -187,6 +187,36 @@ resource "terraform_data" "validation_contract" {
       error_message = "multinetwork_mode=\"cilium_public_overlay\" with IPv6 or dual-stack transport requires public IPv6 enabled on all control-plane and agent nodes, plus autoscaler nodes when autoscaler_nodepools are configured."
     }
 
+    # Dual-stack pod/service CIDRs require every node to advertise an IPv6 node-ip.
+    # Hetzner Cloud Networks are IPv4-only, so that address is the node's public
+    # IPv6. Without it, node-ip stays IPv4-only and k3s/RKE2 refuse to start with
+    # "cluster-cidr: [...] and node-ip: [...], must share the same IP version",
+    # which is hard to trace back to this setting.
+    precondition {
+      condition = (
+        try(trimspace(var.cluster_ipv6_cidr), "") == "" ||
+        (
+          alltrue([
+            for control_plane_nodepool in var.control_plane_nodepools :
+            control_plane_nodepool.enable_public_ipv6 &&
+            alltrue([
+              for _, control_plane_node in coalesce(control_plane_nodepool.nodes, {}) :
+              coalesce(control_plane_node.enable_public_ipv6, control_plane_nodepool.enable_public_ipv6)
+            ])
+          ]) &&
+          alltrue([
+            for agent_nodepool in var.agent_nodepools :
+            agent_nodepool.enable_public_ipv6 &&
+            alltrue([
+              for _, agent_node in coalesce(agent_nodepool.nodes, {}) :
+              coalesce(agent_node.enable_public_ipv6, agent_nodepool.enable_public_ipv6)
+            ])
+          ])
+        )
+      )
+      error_message = "cluster_ipv6_cidr/service_ipv6_cidr require public IPv6 enabled on all control-plane and agent nodes, because Hetzner Cloud Networks are IPv4-only and the IPv6 half of node-ip must be the node's public address."
+    }
+
     # Moved from variable "node_transport_mode" validation near variables.tf:453.
     precondition {
       condition = (


### PR DESCRIPTION
## Summary

Makes `cluster_ipv6_cidr` / `service_ipv6_cidr` actually usable on the standard
`hetzner_private` topology by advertising a dual-stack `node-ip`.

Fixes #2244.

Today those variables render dual-stack `cluster-cidr` and `service-cidr` while
`node-ip` stays IPv4-only, so k3s/RKE2 refuse to start:

```
cluster-cidr: [10.42.0.0/16 fd00:42::/56] and node-ip: [10.255.0.101],
must share the same IP version (IPv4, IPv6 or dual-stack)
```

## What changed

- New `control_plane_node_ip_by_node` / `agent_node_ip_by_node` locals that append
  the node's public IPv6 when `local.cluster_has_ipv6` is set, and pass through
  `private_ipv4_address` otherwise.
- Used at all six `node-ip` sites: `control_planes.tf:382,441`, `init.tf:112,281`,
  `agents.tf:146,172`. The agent `multinetwork_overlay_enabled` branch is untouched.
- A validation precondition requiring public IPv6 on all control-plane and agent
  nodes when the IPv6 CIDRs are set, so a missing address fails with a clear
  message instead of the opaque k3s error above.

Hetzner Cloud Networks are IPv4-only, so the public address is the only IPv6
available for `node-ip`. `advertise-address` is deliberately left as the private
IPv4 — it is single-valued and the apiserver advertisement stays on the private
network.

Diff: 5 files, +52/-6.

## Relationship to #2170

This is the `node-ip` portion of #2170, rebased onto the v3 locals
(`cluster_has_ipv6` rather than that PR's `enable_dualstack`), and **without the
subnet rewrite** that was the stated reason #2170 was not merged. It also drops
that PR's cloud-init runtime IP-detection, because the addresses are already known
to Terraform for control planes and static agents. Credit to @mgazza for the
original work in #2170.

Scope is intentionally narrow: no autoscaler changes, no subnet changes, no Cilium
or CCM changes (those already landed via #2185).

## Default behavior

Unchanged. `cluster_has_ipv6` is false unless `cluster_ipv6_cidr` is set, so every
existing cluster renders exactly the same `node-ip` as before. The new validation
only triggers when the IPv6 CIDRs are set.

## Testing

- `terraform fmt -check -recursive` — clean
- `terraform init -backend=false && terraform validate` — passes
- Single-stack path unchanged: with `cluster_ipv6_cidr` unset the locals return
  `private_ipv4_address` exactly as before.

### Live-tested on a real cluster

Applied to a production v3.0.1 cluster (k3s v1.33.13+k3s1, Cilium tunnel mode, 3
control planes, single Hetzner Network, MicroOS). Before the patch the same config
aborted with the fatal error; with it, all three control planes restarted k3s
cleanly and rendered:

```
"cluster-cidr": "10.42.0.0/16,fd00:42::/56"
"service-cidr": "10.43.0.0/16,fd00:43::/112"
"node-ip":      "10.255.0.101,2a01:4ff:1f0:dbe3::1"
```

Nodes returned Ready, etcd healthy, Cilium picked up `enable-ipv6=true`, and pods
received dual-stack addresses (e.g. `10.42.x.y` + `fd00:42::…`). Cross-node
IPv4/IPv6 pod networking and service DNS verified working.

### Migration caveat for existing clusters (documented, not a code issue)

`node.spec.podCIDRs` is assigned at node registration and is immutable
(`spec.podCIDRs: Forbidden: node updates may not change podCIDR except from "" to
valid`). A **new** cluster registers nodes against the dual-stack `cluster-cidr`
and gets both pod CIDRs. An **existing** cluster additionally needs its nodes
re-registered so the controller-manager reallocates `podCIDRs`; until then Cilium
waits on `required IPv6 PodCIDR not available`. This is inherent to enabling
dual-stack on a live cluster, not something this patch can or should solve — it
just needs a note in the docs (happy to add one).

## Open questions

1. `advertise-address` left as private IPv4 — correct, or should it follow?
2. Autoscaler nodepools are out of scope here; they need runtime detection since
   addresses aren't known at plan time (#2170 used a cloud-init hook). Same PR or
   separate?
3. Requiring public IPv6 on all nodes — acceptable, or should there be an escape
   hatch for per-nodepool `enable_public_ipv6 = false`?
