### PR TITLE
docs: fix stale staging branch reference in contributing steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1834,7 +1834,7 @@ tmp_script=$(mktemp) && curl -sSL -o "${tmp_script}" https://raw.githubuserconte
 5. Update `kube.tf.example` if needed
 6. Commit: `git commit -m 'Add AmazingFeature'`
 7. Push: `git push origin AmazingFeature`
-8. Open PR targeting `staging` branch
+8. Open PR targeting `master` branch
 
 ### Support This Project
 


### PR DESCRIPTION
## Summary

The contributing workflow in the README tells new contributors to open PRs against a `staging` branch:

> 8. Open PR targeting `staging` branch

That branch no longer exists on origin. `origin/HEAD` points to `master`, and all current development and recently merged PRs (e.g. #2240, #2237, #2235) target `master`. A new contributor following this step verbatim has no valid branch to target.

## Change

One line: `staging` → `master` in the Development Workflow steps.

No code changes.