### PR TITLE
fix: allow null public control-plane host on private-only clusters

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -107,16 +107,16 @@ locals {
 
   control_plane_endpoint_host = var.control_plane_endpoint != null ? one(compact(regexall("^(?:https?://)?(?:.*@)?(?:\\[([a-fA-F0-9:]+)\\]|([^:/?#]+))", var.control_plane_endpoint)[0])) : null
   control_plane_private_host  = var.enable_control_plane_load_balancer ? hcloud_load_balancer_network.control_plane.*.ip[0] : module.control_planes[keys(module.control_planes)[0]].private_ipv4_address
-  control_plane_public_host = coalesce(
+  control_plane_public_host = try(coalesce(
     local.control_plane_endpoint_host,
     var.enable_control_plane_load_balancer && var.control_plane_load_balancer_enable_public_network && local.public_endpoint_ipv4_candidate ? hcloud_load_balancer.control_plane.*.ipv4[0] : null,
     var.enable_control_plane_load_balancer && var.control_plane_load_balancer_enable_public_network && local.public_endpoint_ipv6_candidate ? hcloud_load_balancer.control_plane.*.ipv6[0] : null,
     local.public_endpoint_ipv4_candidate ? module.control_planes[keys(module.control_planes)[0]].ipv4_address : null,
     local.public_endpoint_ipv6_candidate ? module.control_planes[keys(module.control_planes)[0]].ipv6_address : null,
-  )
+  ), null)
   control_plane_public_host_formatted = local.control_plane_public_host != null && provider::assert::ipv6(local.control_plane_public_host) ? "[${local.control_plane_public_host}]" : local.control_plane_public_host
   control_plane_private_endpoint      = "https://${local.control_plane_private_host}:${var.kubernetes_api_port}"
-  control_plane_public_endpoint       = var.control_plane_endpoint != null ? var.control_plane_endpoint : "https://${local.control_plane_public_host_formatted}:${var.kubernetes_api_port}"
+  control_plane_public_endpoint       = var.control_plane_endpoint != null ? var.control_plane_endpoint : (local.control_plane_public_host_formatted == null ? null : "https://${local.control_plane_public_host_formatted}:${var.kubernetes_api_port}")
   tailscale_first_control_plane_host  = local.node_transport_tailscale_enabled ? "${module.control_planes[keys(module.control_planes)[0]].name}.${local.tailscale_magicdns_domain}" : null
   tailscale_control_plane_join_host   = local.node_transport_tailscale_enabled ? module.control_planes[keys(module.control_planes)[0]].private_ipv4_address : null
   tailscale_k3s_join_endpoint         = local.node_transport_tailscale_enabled ? "https://${local.tailscale_control_plane_join_host}:${var.kubernetes_api_port}" : null
@@ -126,7 +126,7 @@ locals {
   k3s_endpoint = local.node_transport_tailscale_enabled ? local.tailscale_k3s_join_endpoint : (local.multinetwork_overlay_enabled ? local.control_plane_public_endpoint : local.control_plane_private_endpoint)
 
   rke2_private_join_endpoint = "https://${local.control_plane_private_host}:9345"
-  rke2_public_join_endpoint  = "https://${local.control_plane_public_host_formatted}:9345"
+  rke2_public_join_endpoint  = local.control_plane_public_host_formatted == null ? null : "https://${local.control_plane_public_host_formatted}:9345"
   rke2_join_endpoint         = local.node_transport_tailscale_enabled ? local.tailscale_rke2_join_endpoint : (local.multinetwork_overlay_enabled ? local.rke2_public_join_endpoint : local.rke2_private_join_endpoint)
 
   # Reviewed on 2026-07-05 from upstream release metadata and Helm chart indexes.


### PR DESCRIPTION
## Summary

Fixes #2248.

`local.control_plane_public_host` is built with `coalesce()`, which errors when every
argument is null or an empty string. That is precisely the private-only cluster shape:

- `control_plane_endpoint` unset
- `control_plane_load_balancer_enable_public_network = false`
- control-plane nodepools with `enable_public_ipv4 = false` and `enable_public_ipv6 = false`,
  for which the provider reports `""` as the node address

`plan` then fails with:

```
Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

There is no public endpoint by design, so absence should be `null`, not a hard error.

## Change

`locals.tf`, 4 lines:

1. `control_plane_public_host` wraps the unchanged `coalesce()` in `try(..., null)`.
2. `control_plane_public_endpoint` returns `null` instead of interpolating a null host.
3. `rke2_public_join_endpoint` does the same.

No arguments, ordering, or precedence inside `coalesce()` were touched, so clusters that do
have a public endpoint resolve exactly as before.

## Why null is safe here

- `control_plane_public_host_formatted` on the following line already null-guards its input,
  so `null` was the intended representation for this case; only the producer was missing the
  guard.
- `validation-contract.tf` already requires `control_plane_endpoint`, a public control-plane
  load balancer, or public node IPs for every consumer of a public endpoint
  (`join_endpoint_type = "public"` on control-plane, agent and autoscaler nodepools, and
  `multinetwork_mode = "cilium_public_overlay"`). A null public host is therefore only
  reachable in configurations where nothing consumes it.
- `k3s_endpoint` and the per-node join endpoints keep using the private endpoint for the
  default `join_endpoint_type = "private"`, which is unchanged.

## Why not simply set `control_plane_endpoint`

That workaround is not behavior-neutral. `k3s_control_plane_join_endpoint_by_node` uses
`var.control_plane_endpoint` as the join endpoint whenever it is set, even for
`join_endpoint_type = "private"`, so it rewrites `server:` in the control-plane
`config.yaml` of secondary nodes. Operators upgrading a working private-only cluster
should not have to change their node join topology to get past a plan-time error.

## Verification

- `terraform fmt -check -recursive` passes.
- `terraform validate` passes.
- Standalone repro of the expression with the private-only values: fails before the change,
  evaluates to `null` after it, and the derived endpoint expression yields `null` rather
  than an invalid URL.
- Found while upgrading a real private-only cluster (NAT router, private-only control-plane
  load balancer, control planes without public IPs) from v2.20.0 to v3.0.1. This is the
  second blocker on that path; the first is #2241 / #2242. With both applied the plan
  completes and shows no destroy or replace action on any `hcloud_server`, `hcloud_network`,
  `hcloud_network_subnet`, `hcloud_load_balancer`, `hcloud_volume`, `hcloud_primary_ip`,
  `hcloud_placement_group` or `hcloud_firewall`, so the protected-infrastructure gate from
  `MIGRATION.md` passes.

## Notes

This PR is independent of #2242 and touches a different expression; they can be merged in
any order, but both are needed for a private-only v2 to v3 upgrade that uses
`registries_config`.
