### PR TITLE
fix(ci): install hcloud CLI for trusted smoke

### DIFF
--- a/.github/workflows/trusted_hcloud_smoke.yaml
+++ b/.github/workflows/trusted_hcloud_smoke.yaml
@@ -54,6 +54,12 @@ jobs:
           terraform_version: 1.15.0
           terraform_wrapper: false
 
+      - name: Install HCloud CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes hcloud-cli
+          hcloud version
+
       - name: Run token-backed negative contract tests
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN || secrets.TF_VAR_HCLOUD_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ OpenTofu is officially supported. Pull requests are validated in CI with both Te
 (
   set -eu
   umask 077
-  kh_commit="585af1ddfef01d1f9966783b000991800078484b"
-  kh_archive_sha256="957f57baa6905c5a6322bfce4bc71514c56e31bd8fa266fad395eaaccc6f9c1b"
-  kh_manifest_sha256="673a97425d26d25802e699281d800f2a44a4feb744dd11c88bca0a44175726a4"
+  kh_commit="__KH_SOURCE_COMMIT__"
+  kh_archive_sha256="__KH_SOURCE_ARCHIVE_SHA256__"
+  kh_manifest_sha256="__KH_PACKER_BUNDLE_MANIFEST_SHA256__"
 
   printf '%s\n' "$kh_commit" | grep -Eq '^[0-9a-f]{40}$' || {
     echo "The release bootstrap is missing its immutable source commit." >&2

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ OpenTofu is officially supported. Pull requests are validated in CI with both Te
 (
   set -eu
   umask 077
-  kh_commit="__KH_SOURCE_COMMIT__"
-  kh_archive_sha256="__KH_SOURCE_ARCHIVE_SHA256__"
-  kh_manifest_sha256="__KH_PACKER_BUNDLE_MANIFEST_SHA256__"
+  kh_commit="7c0839ca2a55376ab59cf90f6c7bfd0a6b4ed4de"
+  kh_archive_sha256="d76c4c7b2eac018a3275ce47c657e00b5106b6929fe7c7d670e8f1d7fbfd760b"
+  kh_manifest_sha256="673a97425d26d25802e699281d800f2a44a4feb744dd11c88bca0a44175726a4"
 
   printf '%s\n' "$kh_commit" | grep -Eq '^[0-9a-f]{40}$' || {
     echo "The release bootstrap is missing its immutable source commit." >&2

--- a/scripts/tests/test_trusted_hcloud_smoke_contract.sh
+++ b/scripts/tests/test_trusted_hcloud_smoke_contract.sh
@@ -45,9 +45,12 @@ grep -Fq "$default_branch_guard" "$workflow" \
   || fail "workflow must reject dispatches whose selected ref is not the default branch"
 
 verify_line="$(grep -nF 'name: Verify and checkout merged candidate' "$workflow" | cut -d: -f1)"
+hcloud_cli_line="$(grep -nF 'sudo apt-get install --yes hcloud-cli' "$workflow" | cut -d: -f1 || true)"
 secret_line="$(grep -nF "$secret_expression" "$workflow" | head -n 1 | cut -d: -f1)"
 [[ -n "$verify_line" && -n "$secret_line" && "$verify_line" -lt "$secret_line" ]] \
   || fail "candidate ancestry verification must precede every secret-bearing step"
+[[ -n "$hcloud_cli_line" && "$hcloud_cli_line" -lt "$secret_line" ]] \
+  || fail "the HCloud CLI required by the plan matrix must be installed before secret-bearing steps"
 
 if grep -Eq '^[[:space:]]+(pull_request|pull_request_target):' "$workflow"; then
   fail "trusted HCloud smoke must remain manually dispatched"


### PR DESCRIPTION
## Summary

Fix the v3.1.0 trusted HCloud smoke runner after run 31253475600 proved the token-backed negative contracts but failed before the positive plan matrix because `hcloud` was absent.

- install Ubuntu-signed `hcloud-cli` before any secret-bearing step
- verify the installed CLI immediately
- add a workflow contract requiring the dependency before secrets are exposed
- preserve strict release A/B topology with a functional commit and pin-only README child

## Release topology

- functional A: `7c0839ca2a55376ab59cf90f6c7bfd0a6b4ed4de`
- pin-only B: `c80638e0f4d7937575292f3dec89a795eceaca38`
- Codeload SHA-256: `d76c4c7b2eac018a3275ce47c657e00b5106b6929fe7c7d670e8f1d7fbfd760b`
- Packer manifest SHA-256: `673a97425d26d25802e699281d800f2a44a4feb744dd11c88bca0a44175726a4`

## Verification

- [x] regression contract failed before the workflow fix
- [x] trusted HCloud smoke contract
- [x] Actionlint
- [x] ShellCheck
- [x] release workflow and GitHub control contracts
- [x] strict A/B topology
- [x] real pinned Codeload bootstrap
- [ ] protected PR CI
- [ ] trusted HCloud smoke rerun from merged `master`

The module, Packer images, installers, Terraform, and live-tested cluster runtime are unchanged.